### PR TITLE
formData -> params in step 9.3 of 3.1.3.1

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -855,7 +855,7 @@ spec: URL; urlPrefix: https://url.spec.whatwg.org/
               |entry|'s <a for="entry">name</a> and <a for="entry">value</a>.
 
       3.  Set |c|'s {{PasswordCredential/additionalData}} attribute
-          to |formData|.
+          to |params|.
 
   10. Return |c|.
 


### PR DESCRIPTION
As pointed out in https://github.com/w3c/webappsec-credential-management/issues/26, there is a typo in step 9.3 of 3.1.3.1.
This patch fixes it as suggested.