### PR TITLE
Fix typo (s/chosent/chosen/)

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -2185,7 +2185,7 @@ spec: URL; urlPrefix: https://url.spec.whatwg.org/
 
   <h3 id="privacy-signout">Signing-Out</h3>
 
-  If a user has chosent to automatically sign-in to websites, as discussed
+  If a user has chosen to automatically sign-in to websites, as discussed
   in [[#user-mediation-requirements]], then the user agent will provide
   credentials to an origin whenever it asks for them. The website can instruct
   the user agent to suppress this behavior by calling {{CredentialsContainer}}'s


### PR DESCRIPTION
@mikewest this valuable gem contains a fix to a typo (it's actually just a first CL to get me started).

Please review. Thanks.