### PR TITLE
Fix for issue 15: Some example code does not work

### DIFF
--- a/index.html
+++ b/index.html
@@ -1771,15 +1771,15 @@ store user credentials for future use.</p>
      <h4 class="heading settled" data-level="1.2.3" id="examples-post-signin"><span class="secno">1.2.3. </span><span class="content">Post-sign-in Confirmation</span><a class="self-link" href="#examples-post-signin"></a></h4>
      <p>To ensure that credentials are persisted correctly, it may be useful for a
     website to tell the credential manager that sign-in succeeded.</p>
-     <div class="example" id="example-621d835b">
-      <a class="self-link" href="#example-621d835b"></a> If a user is signed in by calling <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-global-fetch">fetch()</a></code> on a <code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential-1">PasswordCredential</a></code> object, submitting that data to a sign-in endpoint, then we can check the
+     <div class="example" id="example-21124b1e">
+      <a class="self-link" href="#example-21124b1e"></a> If a user is signed in by calling <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-global-fetch">fetch()</a></code> on a <code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential-1">PasswordCredential</a></code> object, submitting that data to a sign-in endpoint, then we can check the
       response to determine whether the user was signed in successfully, and
       notify the user agent accordingly. Given a sign-in form like the following: 
 <pre>&lt;form action="https://example.com/login" method="POST" id="theForm">
   &lt;label for="username">Username&lt;/label>
-  &lt;input type="text" name="username" <a data-link-type="element-attr" href="http://www.w3.org/TR/html5/forms.html#attr-fe-autocomplete">autocomplete</a>="<a data-link-type="attr-value" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-username">username</a>">
+  &lt;input type="text" id="username" name="username" <a data-link-type="element-attr" href="http://www.w3.org/TR/html5/forms.html#attr-fe-autocomplete">autocomplete</a>="<a data-link-type="attr-value" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-username">username</a>">
   &lt;label for="password">Password&lt;/label>
-  &lt;input type="text" name="password" <a data-link-type="element-attr" href="http://www.w3.org/TR/html5/forms.html#attr-fe-autocomplete">autocomplete</a>="<a data-link-type="attr-value" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-current-password">current-password</a>">
+  &lt;input type="text" id="password" name="password" <a data-link-type="element-attr" href="http://www.w3.org/TR/html5/forms.html#attr-fe-autocomplete">autocomplete</a>="<a data-link-type="attr-value" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-current-password">current-password</a>">
   &lt;input type="submit">
 &lt;/form>
 </pre>
@@ -1824,15 +1824,15 @@ store user credentials for future use.</p>
     modifications: if the user changes her credentials, the website can notify
     the user agent that she’s successfully signed in with new credentials. The
     user agent can then update the credentials it stores:</p>
-     <div class="example" id="example-e0ac32e2">
-      <a class="self-link" href="#example-e0ac32e2"></a> MegaCorp Inc. allows users to change their passwords by POSTing data to
+     <div class="example" id="example-86eac981">
+      <a class="self-link" href="#example-86eac981"></a> MegaCorp Inc. allows users to change their passwords by POSTing data to
       a backend server asynchronously. After doing so successfully, they can
       update the user’s credentials by calling <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-store" id="ref-for-dom-credentialscontainer-store-3">store()</a></code> with the new information. 
       <p>Given a password change form like the following:</p>
 <pre>&lt;form action="https://example.com/changePassword" method="POST" id="theForm">
   &lt;input type="hidden" name="username" <a data-link-type="element-attr" href="http://www.w3.org/TR/html5/forms.html#attr-fe-autocomplete">autocomplete</a>="<a data-link-type="attr-value" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-username">username</a>" value="user">
   &lt;label for="password">New Password&lt;/label>
-  &lt;input type="text" name="password" <a data-link-type="element-attr" href="http://www.w3.org/TR/html5/forms.html#attr-fe-autocomplete">autocomplete</a>="<a data-link-type="attr-value" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-new-password">new-password</a>">
+  &lt;input type="text" id="password" name="password" <a data-link-type="element-attr" href="http://www.w3.org/TR/html5/forms.html#attr-fe-autocomplete">autocomplete</a>="<a data-link-type="attr-value" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-new-password">new-password</a>">
   &lt;input type="submit">
 &lt;/form>
 </pre>

--- a/index.html
+++ b/index.html
@@ -1431,7 +1431,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Credential Management Level 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-12-20">20 December 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-12-22">22 December 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1771,15 +1771,15 @@ store user credentials for future use.</p>
      <h4 class="heading settled" data-level="1.2.3" id="examples-post-signin"><span class="secno">1.2.3. </span><span class="content">Post-sign-in Confirmation</span><a class="self-link" href="#examples-post-signin"></a></h4>
      <p>To ensure that credentials are persisted correctly, it may be useful for a
     website to tell the credential manager that sign-in succeeded.</p>
-     <div class="example" id="example-29573e10">
-      <a class="self-link" href="#example-29573e10"></a> If a user is signed in by calling <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-global-fetch">fetch()</a></code> on a <code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential-1">PasswordCredential</a></code> object, submitting that data to a sign-in endpoint, then we can check the
+     <div class="example" id="example-621d835b">
+      <a class="self-link" href="#example-621d835b"></a> If a user is signed in by calling <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-global-fetch">fetch()</a></code> on a <code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential-1">PasswordCredential</a></code> object, submitting that data to a sign-in endpoint, then we can check the
       response to determine whether the user was signed in successfully, and
       notify the user agent accordingly. Given a sign-in form like the following: 
 <pre>&lt;form action="https://example.com/login" method="POST" id="theForm">
   &lt;label for="username">Username&lt;/label>
-  &lt;input type="text" id="username" <a data-link-type="element-attr" href="http://www.w3.org/TR/html5/forms.html#attr-fe-autocomplete">autocomplete</a>="<a data-link-type="attr-value" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-username">username</a>">
+  &lt;input type="text" name="username" <a data-link-type="element-attr" href="http://www.w3.org/TR/html5/forms.html#attr-fe-autocomplete">autocomplete</a>="<a data-link-type="attr-value" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-username">username</a>">
   &lt;label for="password">Password&lt;/label>
-  &lt;input type="text" id="password" <a data-link-type="element-attr" href="http://www.w3.org/TR/html5/forms.html#attr-fe-autocomplete">autocomplete</a>="<a data-link-type="attr-value" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-current-password">current-password</a>">
+  &lt;input type="text" name="password" <a data-link-type="element-attr" href="http://www.w3.org/TR/html5/forms.html#attr-fe-autocomplete">autocomplete</a>="<a data-link-type="attr-value" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-current-password">current-password</a>">
   &lt;input type="submit">
 &lt;/form>
 </pre>
@@ -1824,15 +1824,15 @@ store user credentials for future use.</p>
     modifications: if the user changes her credentials, the website can notify
     the user agent that she’s successfully signed in with new credentials. The
     user agent can then update the credentials it stores:</p>
-     <div class="example" id="example-ac45f873">
-      <a class="self-link" href="#example-ac45f873"></a> MegaCorp Inc. allows users to change their passwords by POSTing data to
+     <div class="example" id="example-e0ac32e2">
+      <a class="self-link" href="#example-e0ac32e2"></a> MegaCorp Inc. allows users to change their passwords by POSTing data to
       a backend server asynchronously. After doing so successfully, they can
       update the user’s credentials by calling <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-store" id="ref-for-dom-credentialscontainer-store-3">store()</a></code> with the new information. 
       <p>Given a password change form like the following:</p>
 <pre>&lt;form action="https://example.com/changePassword" method="POST" id="theForm">
-  &lt;input type="hidden" id="username" <a data-link-type="element-attr" href="http://www.w3.org/TR/html5/forms.html#attr-fe-autocomplete">autocomplete</a>="<a data-link-type="attr-value" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-username">username</a>" value="user">
+  &lt;input type="hidden" name="username" <a data-link-type="element-attr" href="http://www.w3.org/TR/html5/forms.html#attr-fe-autocomplete">autocomplete</a>="<a data-link-type="attr-value" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-username">username</a>" value="user">
   &lt;label for="password">New Password&lt;/label>
-  &lt;input type="text" id="password" <a data-link-type="element-attr" href="http://www.w3.org/TR/html5/forms.html#attr-fe-autocomplete">autocomplete</a>="<a data-link-type="attr-value" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-new-password">new-password</a>">
+  &lt;input type="text" name="password" <a data-link-type="element-attr" href="http://www.w3.org/TR/html5/forms.html#attr-fe-autocomplete">autocomplete</a>="<a data-link-type="attr-value" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-new-password">new-password</a>">
   &lt;input type="submit">
 &lt;/form>
 </pre>
@@ -2978,7 +2978,7 @@ var r = new Request("https://example.com/endpoint", init);
   abusive for a page to request credentials more than a few times in a short
   period.</p>
     <h3 class="heading settled" data-level="7.2" id="privacy-signout"><span class="secno">7.2. </span><span class="content">Signing-Out</span><a class="self-link" href="#privacy-signout"></a></h3>
-    <p>If a user has chosent to automatically sign-in to websites, as discussed
+    <p>If a user has chosen to automatically sign-in to websites, as discussed
   in <a href="#user-mediation-requirements">§5.2 Requiring User Mediation</a>, then the user agent will provide
   credentials to an origin whenever it asks for them. The website can instruct
   the user agent to suppress this behavior by calling <code class="idl"><a data-link-type="idl" href="#credentialscontainer" id="ref-for-credentialscontainer-2">CredentialsContainer</a></code>'s <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-requireusermediation" id="ref-for-dom-credentialscontainer-requireusermediation-3">requireUserMediation()</a></code> method, which will turn off

--- a/index.src.html
+++ b/index.src.html
@@ -394,9 +394,9 @@ spec: URL; urlPrefix: https://url.spec.whatwg.org/
       <pre>
         &lt;form action="https://example.com/login" method="POST" id="theForm"&gt;
           &lt;label for="username"&gt;Username&lt;/label&gt;
-          &lt;input type="text" name="username" <a element-attr for="input">autocomplete</a>="<a attr-value>username</a>"&gt;
+          &lt;input type="text" id="username" name="username" <a element-attr for="input">autocomplete</a>="<a attr-value>username</a>"&gt;
           &lt;label for="password"&gt;Password&lt;/label&gt;
-          &lt;input type="text" name="password" <a element-attr for="input">autocomplete</a>="<a attr-value>current-password</a>"&gt;
+          &lt;input type="text" id="password" name="password" <a element-attr for="input">autocomplete</a>="<a attr-value>current-password</a>"&gt;
           &lt;input type="submit"&gt;
         &lt;/form&gt;
       </pre>
@@ -462,7 +462,7 @@ spec: URL; urlPrefix: https://url.spec.whatwg.org/
         &lt;form action="https://example.com/changePassword" method="POST" id="theForm"&gt;
           &lt;input type="hidden" name="username" <a element-attr for="input">autocomplete</a>="<a attr-value>username</a>" value="user"&gt;
           &lt;label for="password"&gt;New Password&lt;/label&gt;
-          &lt;input type="text" name="password" <a element-attr for="input">autocomplete</a>="<a attr-value>new-password</a>"&gt;
+          &lt;input type="text" id="password" name="password" <a element-attr for="input">autocomplete</a>="<a attr-value>new-password</a>"&gt;
           &lt;input type="submit"&gt;
         &lt;/form&gt;
       </pre>

--- a/index.src.html
+++ b/index.src.html
@@ -394,9 +394,9 @@ spec: URL; urlPrefix: https://url.spec.whatwg.org/
       <pre>
         &lt;form action="https://example.com/login" method="POST" id="theForm"&gt;
           &lt;label for="username"&gt;Username&lt;/label&gt;
-          &lt;input type="text" id="username" <a element-attr for="input">autocomplete</a>="<a attr-value>username</a>"&gt;
+          &lt;input type="text" name="username" <a element-attr for="input">autocomplete</a>="<a attr-value>username</a>"&gt;
           &lt;label for="password"&gt;Password&lt;/label&gt;
-          &lt;input type="text" id="password" <a element-attr for="input">autocomplete</a>="<a attr-value>current-password</a>"&gt;
+          &lt;input type="text" name="password" <a element-attr for="input">autocomplete</a>="<a attr-value>current-password</a>"&gt;
           &lt;input type="submit"&gt;
         &lt;/form&gt;
       </pre>
@@ -460,9 +460,9 @@ spec: URL; urlPrefix: https://url.spec.whatwg.org/
 
       <pre>
         &lt;form action="https://example.com/changePassword" method="POST" id="theForm"&gt;
-          &lt;input type="hidden" id="username" <a element-attr for="input">autocomplete</a>="<a attr-value>username</a>" value="user"&gt;
+          &lt;input type="hidden" name="username" <a element-attr for="input">autocomplete</a>="<a attr-value>username</a>" value="user"&gt;
           &lt;label for="password"&gt;New Password&lt;/label&gt;
-          &lt;input type="text" id="password" <a element-attr for="input">autocomplete</a>="<a attr-value>new-password</a>"&gt;
+          &lt;input type="text" name="password" <a element-attr for="input">autocomplete</a>="<a attr-value>new-password</a>"&gt;
           &lt;input type="submit"&gt;
         &lt;/form&gt;
       </pre>


### PR DESCRIPTION
The PasswordCredential(form) constructor requires name attributes for the username/password fields. Fixes #15.