### PR TITLE
Fix easy bikeshed warnings for index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -2624,7 +2624,7 @@ var r = new Request("https://example.com/endpoint", init);
               passing in <var>origin</var>, <var>types</var> and <var>options</var>. 
          <li> If <var>result</var> is not <code>null</code>, resolve <var>promise</var> with <var>result</var>, and terminate this
               algorithm. 
-         <li> If <var>options</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credentialrequestoptions-unmediated" id="ref-for-dom-credentialrequestoptions-unmediated-3">unmediated</a></code> is <code>true</code>, resolve <var>promise</var> with <var>undefined</var>, and terminate this algorithm. 
+         <li> If <var>options</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credentialrequestoptions-unmediated" id="ref-for-dom-credentialrequestoptions-unmediated-3">unmediated</a></code> is <code>true</code>, resolve <var>promise</var> with <code>undefined</code>, and terminate this algorithm. 
          <li> Resolve <var>promise</var> with the result of executing <a href="#request-siteboundcredential-with-mediation">§4.2.3 Request a SiteBoundCredential with user mediation</a>,
               passing in <var>origin</var>, <var>types</var>, and <var>options</var>. 
         </ol>

--- a/index.src.html
+++ b/index.src.html
@@ -1276,8 +1276,8 @@ spec: URL; urlPrefix: https://url.spec.whatwg.org/
       32. If |request|'s <a for="request">method</a> is `GET` or `HEAD`, then
           throw a `TypeError` if any of the following are true:
 
-          *   |init|'s `body` member is present and non-null
-          *   |inputBody| is non-null
+          *   <var ignore>init</var>'s `body` member is present and non-null
+          *   <var ignore>inputBody</var> is non-null
           *   |request|'s <a for="request">attached credential</a> is non-null
 
   7.  The <a>HTTP-network-or-cache fetch</a> algorithm is updated with the
@@ -1496,7 +1496,7 @@ spec: URL; urlPrefix: https://url.spec.whatwg.org/
             <li>
               If <var>options</var>'s {{CredentialRequestOptions/unmediated}}
               is <code>true</code>, resolve <var>promise</var> with
-              <var>undefined</var>, and terminate this algorithm.
+              <code>undefined</code>, and terminate this algorithm.
             </li>
             <li>
               Resolve <var>promise</var> with the result of executing
@@ -1617,7 +1617,7 @@ spec: URL; urlPrefix: https://url.spec.whatwg.org/
         <li>
           Let <var>cloned value</var> be the result of invoking the <a>internal
           structured cloning algorithm</a> with <var>source value</var> as the
-          "<code>input</code>" argument, and <var>memory</var> as the
+          "<code>input</code>" argument, and <var ignore>memory</var> as the
           "<code>memory</code>" argument.
         </li>
         <li>
@@ -1632,7 +1632,7 @@ spec: URL; urlPrefix: https://url.spec.whatwg.org/
       </ol>
     </li>
     <li>
-      Set <var>deep clone</var> to <code>own</code>.
+      Set <var ignore>deep clone</var> to <code>own</code>.
     </li>
   </ol>
 

--- a/index.src.html
+++ b/index.src.html
@@ -1294,7 +1294,7 @@ spec: URL; urlPrefix: https://url.spec.whatwg.org/
           3.  If |type| is the empty string, return a <a>network error</a>.
 
           4.  Let |httpRequest|'s <a for="request">body</a> be |body|,
-              |Content-Type| be |type|, and <a for="request">redirect
+              <var ignore>Content-Type</var> be |type|, and <a for="request">redirect
               mode</a> be "`manual`".
 
   ISSUE(whatwg/fetch#237): These patches are combined into an outstanding


### PR DESCRIPTION
Bikeshed complains that the variables inputBody, Content-Type, memory, undefined, init and
deep clone are only used once. The reasons are:
 * undefined should actualy be a `<code>` not a `<var>` element, because it
   expresses a JavaSCript constant, not a variable
 * all the rest references external algorithms, which define them

Content-Type actually has multiple occurrences, but bikeshed apparently understands scopes
so that it picked the one where Content-Type only had one occurrence (which was a reference
to an external algorithm).

This patch marks all of those `<var>`s with the "ignore" attribute to silence the
warning. This is one step towards fixing https://github.com/w3c/webappsec-credential-management/issues/39.

Note that there is one more warning for the unique mention: for `|possible
types|`. That looks in fact as a malformed algorithm. It will be dealt with separately.