### PR TITLE
Clarify the "Request a Credential" algorithm

### DIFF
--- a/index.html
+++ b/index.html
@@ -1431,7 +1431,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Credential Management Level 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-12-23">23 December 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-12-27">27 December 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2582,9 +2582,9 @@ var r = new Request("https://example.com/endpoint", init);
     <h2 class="heading settled" data-level="4" id="algorithms"><span class="secno">4. </span><span class="content">Algorithms</span><a class="self-link" href="#algorithms"></a></h2>
     <h3 class="heading settled" data-level="4.1" id="processing"><span class="secno">4.1. </span><span class="content"> Processing <code>Credential</code>s </span><a class="self-link" href="#processing"></a></h3>
     <h4 class="heading settled" data-level="4.1.1" id="request-credential"><span class="secno">4.1.1. </span><span class="content"> Request a <code>Credential</code> </span><a class="self-link" href="#request-credential"></a></h4>
-    <p>Given a <code>sequence&lt;DOMString></code> (<var>types</var>) and a <code class="idl"><a data-link-type="idl" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions-6">CredentialRequestOptions</a></code> object (<var>options</var>), this
-  algorithm returns a <code>Promise</code> which resolves with either a
-  single <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-18">Credential</a></code> object if one can be obtained, or <code>undefined</code> if not.</p>
+    <p>Given a <code class="idl"><a data-link-type="idl" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions-6">CredentialRequestOptions</a></code> object (<var>options</var>), this
+  algorithm returns a <code>Promise</code> which resolves with either a single <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-18">Credential</a></code> object if one can be obtained, or <code>undefined</code> if
+  not.</p>
     <p>If called from an environment which is not a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure context</a>, or
   from somewhere other than a <a data-link-type="dfn" href="http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context">top-level browsing context</a>, the <code>Promise</code> will be rejected with a <code>NotSupportedError</code>.</p>
     <ol>
@@ -2601,8 +2601,7 @@ var r = new Request("https://example.com/endpoint", init);
      <li>
        For each <var>key</var> in <var>options</var>: 
       <ol>
-       <li> Let <var>interface</var> be the interface whose name is <var>key</var>, or <code>null</code> if no interface’s name
-          matches. 
+       <li> Let <var>interface</var> be the interface such that <code class="idl"><a data-link-type="idl" href="#dom-credential-type-slot" id="ref-for-dom-credential-type-slot-11">[[type]]</a></code> across all objects implementing that interface is <var>key</var>, or <code>null</code> if no interface’s name matches. 
        <li> If <var>interface</var> is not <code>null</code>, insert <var>interface</var> into <var>types</var>. 
       </ol>
      <li>
@@ -3032,20 +3031,20 @@ var r = new Request("https://example.com/endpoint", init);
      <a class="self-link" href="#example-488fdc05"></a> If we wished to add a new credential type, how would we spell it out? 
      <ol>
       <li>
-        Define a new <code>ExampleCredential</code> that inherits from <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-41">Credential</a></code>, and define the value of its <code class="idl"><a data-link-type="idl" href="#dom-credential-type-slot" id="ref-for-dom-credential-type-slot-11">[[type]]</a></code> slot: 
+        Define a new <code>ExampleCredential</code> that inherits from <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-41">Credential</a></code>, and define the value of its <code class="idl"><a data-link-type="idl" href="#dom-credential-type-slot" id="ref-for-dom-credential-type-slot-12">[[type]]</a></code> slot: 
 <pre>interface ExampleCredential : Credential {
   // Definition goes here.
 };
 
 ...
 
-All <code>ExampleCredential</code> objects have their <a data-link-type="idl" href="#dom-credential-type-slot" id="ref-for-dom-credential-type-slot-12">[[type]]</a> slot’s
+All <code>ExampleCredential</code> objects have their <a data-link-type="idl" href="#dom-credential-type-slot" id="ref-for-dom-credential-type-slot-13">[[type]]</a> slot’s
 value set to the string "example".
 </pre>
       <li>
         Define the options that the new credential type requires, and add them
         to the <code class="idl"><a data-link-type="idl" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions-10">CredentialRequestOptions</a></code> dictionary with a property name that
-        matches the <code class="idl"><a data-link-type="idl" href="#dom-credential-type-slot" id="ref-for-dom-credential-type-slot-13">[[type]]</a></code> slot’s value. 
+        matches the <code class="idl"><a data-link-type="idl" href="#dom-credential-type-slot" id="ref-for-dom-credential-type-slot-14">[[type]]</a></code> slot’s value. 
 <pre>dictionary ExampleCredentialRequestOptions {
   // Definition goes here.
 };
@@ -3650,7 +3649,9 @@ partial dictionary CredentialRequestOptions {
     <li><a href="#ref-for-dom-credential-type-slot-8">3.1.3.2. 
     PasswordCredential(PasswordCredentialData data) Constructor </a>
     <li><a href="#ref-for-dom-credential-type-slot-9">3.1.4. FederatedCredential</a> <a href="#ref-for-dom-credential-type-slot-10">(2)</a>
-    <li><a href="#ref-for-dom-credential-type-slot-11">8.2. Extension Points</a> <a href="#ref-for-dom-credential-type-slot-12">(2)</a> <a href="#ref-for-dom-credential-type-slot-13">(3)</a>
+    <li><a href="#ref-for-dom-credential-type-slot-11">4.1.1. 
+    Request a Credential </a>
+    <li><a href="#ref-for-dom-credential-type-slot-12">8.2. Extension Points</a> <a href="#ref-for-dom-credential-type-slot-13">(2)</a> <a href="#ref-for-dom-credential-type-slot-14">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dictdef-siteboundcredentialdata">

--- a/index.src.html
+++ b/index.src.html
@@ -1403,11 +1403,10 @@ spec: URL; urlPrefix: https://url.spec.whatwg.org/
     Request a <code>Credential</code>
   </h4>
 
-  Given a <code>sequence&lt;DOMString&gt;</code> (<var>types</var>) and a
-  {{CredentialRequestOptions}} object (<var>options</var>), this
-  algorithm returns a <code>Promise</code> which resolves with either a
-  single {{Credential}} object if one can be obtained, or <code>undefined</code>
-  if not.
+  Given a {{CredentialRequestOptions}} object (<var>options</var>), this
+  algorithm returns a <code>Promise</code> which resolves with either a single
+  {{Credential}} object if one can be obtained, or <code>undefined</code> if
+  not.
 
   If called from an environment which is not a <a>secure context</a>, or
   from somewhere other than a <a>top-level browsing context</a>, the
@@ -1445,9 +1444,9 @@ spec: URL; urlPrefix: https://url.spec.whatwg.org/
 
       <ol>
         <li>
-          Let <var>interface</var> be the interface whose name is
-          <var>key</var>, or <code>null</code> if no interface's name
-          matches.
+          Let <var>interface</var> be the interface such that {{[[type]]}}
+          across all objects implementing that interface is <var>key</var>, or
+          <code>null</code> if no interface's name matches.
         </li>
         <li>
           If <var>interface</var> is not <code>null</code>, insert


### PR DESCRIPTION
This CL drops the input |types| from the "Request a Credential" algorithm,
because it is not used (instead, |types| is a local variable, value of which is
computed by the algorithm).

The CL also replaces "name" of an interface with a [[type]] shared by instances
implementing this interface. For PasswordCredential, for instance, "name" is
PasswordCredential, whereas [[type]] is "password". The latter corresponds to a
possible key in CredentialRequestOptions, which is what the algorithm expects.

This should fix issue #41.