### PR TITLE
Rename requireUserMediation to preventSilentAccess

### DIFF
--- a/index.html
+++ b/index.html
@@ -1512,7 +1512,7 @@ store user credentials for future use.</p>
         <li><a href="#algorithm-collect-known"><span class="secno">2.5.2</span> <span class="content">Collect <code>Credential</code>s from the credential store</span></a>
         <li><a href="#algorithm-store"><span class="secno">2.5.3</span> <span class="content">Store a <code>Credential</code></span></a>
         <li><a href="#algorithm-create"><span class="secno">2.5.4</span> <span class="content">Create a <code>Credential</code></span></a>
-        <li><a href="#algorithm-require-mediation"><span class="secno">2.5.5</span> <span class="content">Prevent Silent Access</span></a>
+        <li><a href="#algorithm-prevent-silent-access"><span class="secno">2.5.5</span> <span class="content">Prevent Silent Access</span></a>
        </ol>
      </ol>
     <li>
@@ -1925,7 +1925,7 @@ store user credentials for future use.</p>
   object</a>.</p>
        <p class="note" role="note"><span>Note:</span> The intent here is a signal from the origin that the user has signed out. That
   is, after a click on a "Sign out" button, the site updates the user’s session info, and
-  calls <code>navigator.credentials.preventSilentAccess()</code>. This toggles the <a data-link-type="dfn" href="#origin-prevent-silent-access-flag" id="ref-for-origin-prevent-silent-access-flag-1"><code>prevent silent access</code> flag</a>, meaning that credentials will not be automagically handed back to the
+  calls <code>navigator.credentials.preventSilentAccess()</code>. This sets the <a data-link-type="dfn" href="#origin-prevent-silent-access-flag" id="ref-for-origin-prevent-silent-access-flag-1"><code>prevent silent access</code> flag</a>, meaning that credentials will not be automagically handed back to the
   page next time the user visits.</p>
        <p class="note" role="note"><span>Note:</span> This function was previously called <code>requireUserMediation()</code> which should be considered
   deprecated.</p>
@@ -2280,7 +2280,7 @@ store user credentials for future use.</p>
      <li data-md="">
       <p>Return <var>p</var>.</p>
     </ol>
-    <h4 class="heading settled algorithm" data-algorithm="Prevent Silent Access" data-level="2.5.5" id="algorithm-require-mediation"><span class="secno">2.5.5. </span><span class="content">Prevent Silent Access</span><a class="self-link" href="#algorithm-require-mediation"></a></h4>
+    <h4 class="heading settled algorithm" data-algorithm="Prevent Silent Access" data-level="2.5.5" id="algorithm-prevent-silent-access"><span class="secno">2.5.5. </span><span class="content">Prevent Silent Access</span><a class="self-link" href="#algorithm-prevent-silent-access"></a></h4>
     <p>The <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export="" id="abstract-opdef-prevent-silent-access">Prevent Silent Access</dfn> algorithm accepts an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings
   object</a> (<var>settings</var>), and returns a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-promise">Promise</a></code> which resolves once the <code>prevent silent access</code> flag is persisted to the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store-11">credential store</a>.</p>
     <ol class="algorithm">
@@ -2903,10 +2903,9 @@ store user credentials for future use.</p>
   user’s direct interaction with a <a data-link-type="dfn" href="#credential-chooser" id="ref-for-credential-chooser-9">credential chooser</a> interface, for example. In general, <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated-9">user
   mediated</a> actions will involve presenting the user some sort of UI, and asking them to make a
   decision.</p>
-    <p>An action is <dfn data-dfn-type="dfn" data-export="" id="unmediated">unmediated<a class="self-link" href="#unmediated"></a></dfn> or <dfn data-dfn-type="dfn" data-export="" id="silent">silent<a class="self-link" href="#silent"></a></dfn> if it takes place without
-  explicit user consent. For example, if a user configures their browser to grant persistent
-  credential access to a particular origin, credentials may be provided without presenting the user
-  with a UI requesting a decision.</p>
+    <p>An action is unmediated if it takes place silently, without explicit user consent. For example,
+  if a user configures their browser to grant persistent credential access to a particular origin,
+  credentials may be provided without presenting the user with a UI requesting a decision.</p>
     <p>Here we’ll spell out a few requirements that hold for all credential types, but note that there’s
   a good deal of latitude left up to the user agent (which is in a priviliged position to assist
   the user). Moreover, specific credential types may have distinct requirements that exceed the
@@ -3377,12 +3376,7 @@ partial dictionary CredentialCreationOptions {
    <li><a href="#dom-credentialmediationrequirement-required">required</a><span>, in §2.3.2</span>
    <li><a href="#origin-requires-user-mediation">requires user mediation</a><span>, in §2.1</span>
    <li><a href="#abstract-opdef-credential-store-retrieve-a-list-of-credentials">Retrieve a list of credentials</a><span>, in §2.1</span>
-   <li>
-    silent
-    <ul>
-     <li><a href="#dom-credentialmediationrequirement-silent">enum-value for CredentialMediationRequirement</a><span>, in §2.3.2</span>
-     <li><a href="#silent">definition of</a><span>, in §5</span>
-    </ul>
+   <li><a href="#dom-credentialmediationrequirement-silent">silent</a><span>, in §2.3.2</span>
    <li><a href="#dom-credentialscontainer-store">store()</a><span>, in §2.3</span>
    <li><a href="#abstract-opdef-credential-store-store-a-credential">Store a credential</a><span>, in §2.1</span>
    <li><a href="#abstract-opdef-store-a-credential">Store a Credential</a><span>, in §2.5.3</span>
@@ -3396,7 +3390,6 @@ partial dictionary CredentialCreationOptions {
     </ul>
    <li><a href="#dom-credential-type">type</a><span>, in §2.2</span>
    <li><a href="#dom-credential-type-slot">[[type]]</a><span>, in §2.2</span>
-   <li><a href="#unmediated">unmediated</a><span>, in §5</span>
    <li><a href="#user-mediated">user mediated</a><span>, in §5</span>
    <li><a href="#user-mediated">user mediation</a><span>, in §5</span>
   </ul>

--- a/index.html
+++ b/index.html
@@ -1423,7 +1423,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Credential Management Level 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-05-22">22 May 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-05-24">24 May 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1711,7 +1711,7 @@ store user credentials for future use.</p>
      <li data-md="">
       <p><dfn data-dfn-for="credential store" data-dfn-type="abstract-op" data-export="" id="abstract-opdef-credential-store-modify-a-credential">Modify a credential<a class="self-link" href="#abstract-opdef-credential-store-modify-a-credential"></a></dfn>. This accepts a <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential-11">credential</a>, and overwrites the state of an existing <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential-12">credential</a> in the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store-2">credential store</a>.</p>
     </ol>
-    <p>Additionally, the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store-3">credential store</a> should maintain a <dfn class="dfn-paneled" data-dfn-for="origin" data-dfn-type="dfn" data-noexport="" id="origin-requires-user-mediation-flag"><code>requires user mediation</code> flag</dfn> for <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">origins</a> (which is set to <code>true</code> unless otherwise specified).
+    <p>Additionally, the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store-3">credential store</a> should maintain a <dfn class="dfn-paneled" data-dfn-for="origin" data-dfn-type="dfn" data-noexport="" id="origin-prevent-silent-access-flag"><code>prevent silent access</code> flag</dfn> for <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">origins</a> (which is set to <code>true</code> unless otherwise specified).
   An origin <dfn class="dfn-paneled" data-dfn-for="origin" data-dfn-type="dfn" data-noexport="" id="origin-requires-user-mediation">requires user mediation</dfn> if its flag is set to <code>true</code>.</p>
     <p class="note" role="note"><span>Note:</span> The importance of user mediation is discussed in more detail in <a href="#user-mediation">§5 User Mediation</a>.</p>
     <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store-4">credential store</a> is an internal implementation detail of a user agent’s
@@ -1925,7 +1925,7 @@ store user credentials for future use.</p>
   object</a>.</p>
        <p class="note" role="note"><span>Note:</span> The intent here is a signal from the origin that the user has signed out. That
   is, after a click on a "Sign out" button, the site updates the user’s session info, and
-  calls <code>navigator.credentials.preventSilentAccess()</code>. This toggles the <a data-link-type="dfn" href="#origin-requires-user-mediation-flag" id="ref-for-origin-requires-user-mediation-flag-1"><code>requires user mediation</code> flag</a>, meaning that credentials will not be automagically handed back to the
+  calls <code>navigator.credentials.preventSilentAccess()</code>. This toggles the <a data-link-type="dfn" href="#origin-prevent-silent-access-flag" id="ref-for-origin-prevent-silent-access-flag-1"><code>prevent silent access</code> flag</a>, meaning that credentials will not be automagically handed back to the
   page next time the user visits.</p>
        <p class="note" role="note"><span>Note:</span> This function used to be called <code>requireUserMediation()</code> which should be considered
   deprecated.</p>
@@ -2033,9 +2033,9 @@ store user credentials for future use.</p>
   see a <a data-link-type="dfn" href="#credential-chooser" id="ref-for-credential-chooser-4">credential chooser</a> if necessary.</p>
      <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="CredentialMediationRequirement" data-dfn-type="enum-value" data-export="" id="dom-credentialmediationrequirement-required">required</dfn>
      <dd data-md="">
-      <p>The user agent will not hand over credentials without <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated-4">user mediation</a>, even if the <a data-link-type="dfn" href="#origin-requires-user-mediation" id="ref-for-origin-requires-user-mediation-2">requires user mediation</a> flag is unset for an origin.</p>
+      <p>The user agent will not hand over credentials without <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated-4">user mediation</a>, even if the <a data-link-type="dfn" href="#origin-prevent-silent-access-flag" id="ref-for-origin-prevent-silent-access-flag-2">prevent silent access flag</a> is unset for an origin.</p>
       <p class="note" role="note"><span>Note:</span> This requirement is intended to support <a href="#example-mediation-require">reauthentication</a> or <a href="#example-mediation-switch">user-switching</a> scenarios. Further, the requirement is tied
-  to a specific operation, and does not affect the <a data-link-type="dfn" href="#origin-requires-user-mediation" id="ref-for-origin-requires-user-mediation-3">requires user mediation</a> flag for the
+  to a specific operation, and does not affect the <a data-link-type="dfn" href="#origin-prevent-silent-access-flag" id="ref-for-origin-prevent-silent-access-flag-3">prevent silent access flag</a> for the
   origin. To set that flag, developers should call <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-preventsilentaccess" id="ref-for-dom-credentialscontainer-preventsilentaccess-3">preventSilentAccess()</a></code>.</p>
     </dl>
     <h5 class="heading settled" data-level="2.3.2.1" id="mediation-examples"><span class="secno">2.3.2.1. </span><span class="content">Examples</span><a class="self-link" href="#mediation-examples"></a></h5>
@@ -2154,7 +2154,7 @@ store user credentials for future use.</p>
          <li data-md="">
           <p><var>credentials</var>’ <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-size">size</a> is 1</p>
          <li data-md="">
-          <p><var>settings</var>’ <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> does not <a data-link-type="dfn" href="#origin-requires-user-mediation" id="ref-for-origin-requires-user-mediation-4">require user mediation</a></p>
+          <p><var>settings</var>’ <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> does not <a data-link-type="dfn" href="#origin-requires-user-mediation" id="ref-for-origin-requires-user-mediation-2">require user mediation</a></p>
          <li data-md="">
           <p><var>options</var> is <a data-link-type="dfn" href="#credentialrequestoptions-matchable-a-priori" id="ref-for-credentialrequestoptions-matchable-a-priori-2">matchable <i lang="la">a priori</i></a>.</p>
          <li data-md="">
@@ -2282,7 +2282,7 @@ store user credentials for future use.</p>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Prevent Silent Access" data-level="2.5.5" id="algorithm-require-mediation"><span class="secno">2.5.5. </span><span class="content">Prevent Silent Access</span><a class="self-link" href="#algorithm-require-mediation"></a></h4>
     <p>The <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export="" id="abstract-opdef-prevent-silent-access">Prevent Silent Access</dfn> algorithm accepts an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings
-  object</a> (<var>settings</var>), and returns a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-promise">Promise</a></code> which resolves once the <code>requires user mediation</code> flag is persisted to the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store-11">credential store</a>.</p>
+  object</a> (<var>settings</var>), and returns a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-promise">Promise</a></code> which resolves once the <code>prevent silent access</code> flag is persisted to the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store-11">credential store</a>.</p>
     <ol class="algorithm">
      <li data-md="">
       <p>Let <var>origin</var> be <var>settings</var>’ <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>.</p>
@@ -2292,7 +2292,7 @@ store user credentials for future use.</p>
       <p>Run the following seps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
       <ol>
        <li data-md="">
-        <p>Set <var>origin</var>’s <a data-link-type="dfn" href="#origin-requires-user-mediation-flag" id="ref-for-origin-requires-user-mediation-flag-2"><code>requires user mediation</code> flag</a> in the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store-12">credential store</a>.</p>
+        <p>Set <var>origin</var>’s <a data-link-type="dfn" href="#origin-prevent-silent-access-flag" id="ref-for-origin-prevent-silent-access-flag-4"><code>prevent silent access</code> flag</a> in the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store-12">credential store</a>.</p>
        <li data-md="">
         <p><a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#resolve-promise">Resolve</a> <var>p</var> with <code>undefined</code>.</p>
       </ol>
@@ -2903,9 +2903,10 @@ store user credentials for future use.</p>
   user’s direct interaction with a <a data-link-type="dfn" href="#credential-chooser" id="ref-for-credential-chooser-9">credential chooser</a> interface, for example. In general, <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated-9">user
   mediated</a> actions will involve presenting the user some sort of UI, and asking them to make a
   decision.</p>
-    <p>An action is <dfn data-dfn-type="dfn" data-export="" id="unmediated">unmediated<a class="self-link" href="#unmediated"></a></dfn> if it takes place without explicit user consent. For
-  example, if a user configures their browser to grant persistent credential access to a particular
-  origin, credentials may be provided without presenting the user with a UI requesting a decision.</p>
+    <p>An action is <dfn data-dfn-type="dfn" data-export="" id="unmediated">unmediated<a class="self-link" href="#unmediated"></a></dfn> or <dfn data-dfn-type="dfn" data-export="" id="silent">silent<a class="self-link" href="#silent"></a></dfn> if it takes place without
+  explicit user consent. For example, if a user configures their browser to grant persistent
+  credential access to a particular origin, credentials may be provided without presenting the user
+  with a UI requesting a decision.</p>
     <p>Here we’ll spell out a few requirements that hold for all credential types, but note that there’s
   a good deal of latitude left up to the user agent (which is in a priviliged position to assist
   the user). Moreover, specific credential types may have distinct requirements that exceed the
@@ -2931,10 +2932,10 @@ store user credentials for future use.</p>
   be implemented as a settings page, or via interaction with a notification as described above.</p>
     </ol>
     <h3 class="heading settled" data-level="5.2" id="user-mediation-requirement"><span class="secno">5.2. </span><span class="content">Requiring User Mediation</span><a class="self-link" href="#user-mediation-requirement"></a></h3>
-    <p>By default, <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated-11">user mediation</a> is required for all <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">origins</a>, as the relevant <a data-link-type="dfn" href="#origin-requires-user-mediation-flag" id="ref-for-origin-requires-user-mediation-flag-3">requires user
-  mediation flag</a> in the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store-24">credential store</a> is set to <code>true</code>. Users MAY choose to grant an
+    <p>By default, <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated-11">user mediation</a> is required for all <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">origins</a>, as the relevant <a data-link-type="dfn" href="#origin-prevent-silent-access-flag" id="ref-for-origin-prevent-silent-access-flag-5">prevent silent
+  access flag</a> in the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store-24">credential store</a> is set to <code>true</code>. Users MAY choose to grant an
   origin persistent access to credentials (perhaps in the form of a "Stay signed into this site."
-  option), which would set this flag to <code>true</code>. In this case, the user would always be signed into
+  option), which would set this flag to <code>false</code>. In this case, the user would always be signed into
   that site, which is desirable from the perspective of usability and convinience, but which
   might nevertheless have surprising implications (consider a user agent which syncs this flag’s
   state across devices, for instance).</p>
@@ -2943,10 +2944,10 @@ store user credentials for future use.</p>
      <li data-md="">
       <p>User agents MUST allow users to require <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated-12">user mediation</a> for a given origin or for all
   origins. This functionality might be implemented as a global toggle that overrides each
-  origin’s <a data-link-type="dfn" href="#origin-requires-user-mediation-flag" id="ref-for-origin-requires-user-mediation-flag-4"><code>requires user mediation</code> flag</a> to return <code>false</code>, or via more granular
+  origin’s <a data-link-type="dfn" href="#origin-prevent-silent-access-flag" id="ref-for-origin-prevent-silent-access-flag-6"><code>prevent silent access</code> flag</a> to return <code>false</code>, or via more granular
   settings for specific origins (or specific credentials on specific origins).</p>
      <li data-md="">
-      <p>User agents MUST NOT set an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">origin</a>'s <a data-link-type="dfn" href="#origin-requires-user-mediation-flag" id="ref-for-origin-requires-user-mediation-flag-5"><code>requires user mediation</code> flag</a> to <code>false</code> without <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated-13">user mediation</a>. For example, the <a data-link-type="dfn" href="#credential-chooser" id="ref-for-credential-chooser-10">credential chooser</a> described in <a href="#user-mediated-selection">§5.3 Credential Selection</a> could have a checkbox which the user could toggle to mark a
+      <p>User agents MUST NOT set an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">origin</a>'s <a data-link-type="dfn" href="#origin-prevent-silent-access-flag" id="ref-for-origin-prevent-silent-access-flag-7"><code>prevent silent access</code> flag</a> to <code>false</code> without <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated-13">user mediation</a>. For example, the <a data-link-type="dfn" href="#credential-chooser" id="ref-for-credential-chooser-10">credential chooser</a> described in <a href="#user-mediated-selection">§5.3 Credential Selection</a> could have a checkbox which the user could toggle to mark a
   credential as available without mediation for the origin, or the user agent could have an
   onboarding process for its credential manager which asked a user for a default setting.</p>
      <li data-md="">
@@ -2954,7 +2955,7 @@ store user credentials for future use.</p>
   form of an icon in the address bar, or some similar location.</p>
      <li data-md="">
       <p>If a user clears her browsing data for an origin (cookies, localStorage, and so on), the user
-  agent MUST set the <a data-link-type="dfn" href="#origin-requires-user-mediation-flag" id="ref-for-origin-requires-user-mediation-flag-6"><code>requires user mediation</code> flag</a> to <code>false</code> for that origin.</p>
+  agent MUST set the <a data-link-type="dfn" href="#origin-prevent-silent-access-flag" id="ref-for-origin-prevent-silent-access-flag-8"><code>prevent silent access</code> flag</a> to <code>true</code> for that origin.</p>
     </ol>
     <h3 class="heading settled" data-level="5.3" id="user-mediated-selection"><span class="secno">5.3. </span><span class="content">Credential Selection</span><a class="self-link" href="#user-mediated-selection"></a></h3>
     <p>When responding to a call to <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get-20">get()</a></code> on an origin which requires <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated-14">user mediation</a>, user agents MUST ask the user for permission to share credential information.
@@ -3072,7 +3073,7 @@ store user credentials for future use.</p>
   doesn’t clear user credentials when they click "Sign-out", as the user agent becomes complicit in
   the authentication.</p>
     <p>The user MUST have some control over this behavior. As noted in <a href="#user-mediation-requirement">§5.2 Requiring User Mediation</a>,
-  clearing cookies for an origin will also reset that origin’s <a data-link-type="dfn" href="#origin-requires-user-mediation-flag" id="ref-for-origin-requires-user-mediation-flag-7"><code>requires user mediation</code> flag</a> the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store-26">credential store</a> to <code>true</code>. Additionally, the user agent SHOULD provide some UI affordance
+  clearing cookies for an origin will also reset that origin’s <a data-link-type="dfn" href="#origin-prevent-silent-access-flag" id="ref-for-origin-prevent-silent-access-flag-9"><code>prevent silent access</code> flag</a> the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store-26">credential store</a> to <code>true</code>. Additionally, the user agent SHOULD provide some UI affordance
   for disabling automatic sign-in for a particular origin. This could be tied to the notification
   that credentials have been provided to an origin, for example.</p>
     <h3 class="heading settled" data-level="6.7" id="security-chooser-leakage"><span class="secno">6.7. </span><span class="content">Chooser Leakage</span><a class="self-link" href="#security-chooser-leakage"></a></h3>
@@ -3355,6 +3356,7 @@ partial dictionary CredentialCreationOptions {
    <li><a href="#typedefdef-passwordcredentialinit">PasswordCredentialInit</a><span>, in §3.2</span>
    <li><a href="#dom-credentialscontainer-preventsilentaccess">preventSilentAccess()</a><span>, in §2.3</span>
    <li><a href="#abstract-opdef-prevent-silent-access">Prevent Silent Access</a><span>, in §2.5.5</span>
+   <li><a href="#origin-prevent-silent-access-flag">prevent silent access flag</a><span>, in §2.1</span>
    <li>
     protocol
     <ul>
@@ -3374,9 +3376,13 @@ partial dictionary CredentialCreationOptions {
    <li><a href="#abstract-opdef-request-a-credential">Request a Credential</a><span>, in §2.5.1</span>
    <li><a href="#dom-credentialmediationrequirement-required">required</a><span>, in §2.3.2</span>
    <li><a href="#origin-requires-user-mediation">requires user mediation</a><span>, in §2.1</span>
-   <li><a href="#origin-requires-user-mediation-flag">requires user mediation flag</a><span>, in §2.1</span>
    <li><a href="#abstract-opdef-credential-store-retrieve-a-list-of-credentials">Retrieve a list of credentials</a><span>, in §2.1</span>
-   <li><a href="#dom-credentialmediationrequirement-silent">silent</a><span>, in §2.3.2</span>
+   <li>
+    silent
+    <ul>
+     <li><a href="#dom-credentialmediationrequirement-silent">enum-value for CredentialMediationRequirement</a><span>, in §2.3.2</span>
+     <li><a href="#silent">definition of</a><span>, in §5</span>
+    </ul>
    <li><a href="#dom-credentialscontainer-store">store()</a><span>, in §2.3</span>
    <li><a href="#abstract-opdef-credential-store-store-a-credential">Store a credential</a><span>, in §2.1</span>
    <li><a href="#abstract-opdef-store-a-credential">Store a Credential</a><span>, in §2.5.3</span>
@@ -3742,20 +3748,21 @@ partial dictionary CredentialCreationOptions {
     FederatedCredential's [[CollectFromCredentialStore]](options) </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="origin-requires-user-mediation-flag">
-   <b><a href="#origin-requires-user-mediation-flag">#origin-requires-user-mediation-flag</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="origin-prevent-silent-access-flag">
+   <b><a href="#origin-prevent-silent-access-flag">#origin-prevent-silent-access-flag</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-origin-requires-user-mediation-flag-1">2.3. navigator.credentials</a>
-    <li><a href="#ref-for-origin-requires-user-mediation-flag-2">2.5.5. Prevent Silent Access</a>
-    <li><a href="#ref-for-origin-requires-user-mediation-flag-3">5.2. Requiring User Mediation</a> <a href="#ref-for-origin-requires-user-mediation-flag-4">(2)</a> <a href="#ref-for-origin-requires-user-mediation-flag-5">(3)</a> <a href="#ref-for-origin-requires-user-mediation-flag-6">(4)</a>
-    <li><a href="#ref-for-origin-requires-user-mediation-flag-7">6.6. Signing-Out</a>
+    <li><a href="#ref-for-origin-prevent-silent-access-flag-1">2.3. navigator.credentials</a>
+    <li><a href="#ref-for-origin-prevent-silent-access-flag-2">2.3.2. Mediation Requirements</a> <a href="#ref-for-origin-prevent-silent-access-flag-3">(2)</a>
+    <li><a href="#ref-for-origin-prevent-silent-access-flag-4">2.5.5. Prevent Silent Access</a>
+    <li><a href="#ref-for-origin-prevent-silent-access-flag-5">5.2. Requiring User Mediation</a> <a href="#ref-for-origin-prevent-silent-access-flag-6">(2)</a> <a href="#ref-for-origin-prevent-silent-access-flag-7">(3)</a> <a href="#ref-for-origin-prevent-silent-access-flag-8">(4)</a>
+    <li><a href="#ref-for-origin-prevent-silent-access-flag-9">6.6. Signing-Out</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="origin-requires-user-mediation">
    <b><a href="#origin-requires-user-mediation">#origin-requires-user-mediation</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-origin-requires-user-mediation-1">2.3.2. Mediation Requirements</a> <a href="#ref-for-origin-requires-user-mediation-2">(2)</a> <a href="#ref-for-origin-requires-user-mediation-3">(3)</a>
-    <li><a href="#ref-for-origin-requires-user-mediation-4">2.5.1. Request a Credential</a>
+    <li><a href="#ref-for-origin-requires-user-mediation-1">2.3.2. Mediation Requirements</a>
+    <li><a href="#ref-for-origin-requires-user-mediation-2">2.5.1. Request a Credential</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="credential">

--- a/index.html
+++ b/index.html
@@ -1927,7 +1927,7 @@ store user credentials for future use.</p>
   is, after a click on a "Sign out" button, the site updates the user’s session info, and
   calls <code>navigator.credentials.preventSilentAccess()</code>. This toggles the <a data-link-type="dfn" href="#origin-prevent-silent-access-flag" id="ref-for-origin-prevent-silent-access-flag-1"><code>prevent silent access</code> flag</a>, meaning that credentials will not be automagically handed back to the
   page next time the user visits.</p>
-       <p class="note" role="note"><span>Note:</span> This function used to be called <code>requireUserMediation()</code> which should be considered
+       <p class="note" role="note"><span>Note:</span> This function was previously called <code>requireUserMediation()</code> which should be considered
   deprecated.</p>
      </dl>
     </dl>

--- a/index.html
+++ b/index.html
@@ -1423,7 +1423,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Credential Management Level 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-05-09">9 May 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-05-11">11 May 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1512,7 +1512,7 @@ store user credentials for future use.</p>
         <li><a href="#algorithm-collect-known"><span class="secno">2.5.2</span> <span class="content">Collect <code>Credential</code>s from the credential store</span></a>
         <li><a href="#algorithm-store"><span class="secno">2.5.3</span> <span class="content">Store a <code>Credential</code></span></a>
         <li><a href="#algorithm-create"><span class="secno">2.5.4</span> <span class="content">Create a <code>Credential</code></span></a>
-        <li><a href="#algorithm-require-mediation"><span class="secno">2.5.5</span> <span class="content">Require User Mediation</span></a>
+        <li><a href="#algorithm-require-mediation"><span class="secno">2.5.5</span> <span class="content">Prevent Silent Access</span></a>
        </ol>
      </ol>
     <li>
@@ -1840,7 +1840,7 @@ store user credentials for future use.</p>
   <span class="kt">Promise</span>&lt;<a class="n" data-link-type="idl-name" href="#credential" id="ref-for-credential-21">Credential</a>?> <a class="nv idl-code" data-link-type="method" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get-1">get</a>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions-3">CredentialRequestOptions</a> <a class="nv idl-code" data-link-type="argument" href="#dom-credentialscontainer-get-options-options" id="ref-for-dom-credentialscontainer-get-options-options-1">options</a>);
   <span class="kt">Promise</span>&lt;<a class="n" data-link-type="idl-name" href="#credential" id="ref-for-credential-22">Credential</a>> <a class="nv idl-code" data-link-type="method" href="#dom-credentialscontainer-store" id="ref-for-dom-credentialscontainer-store-2">store</a>(<a class="n" data-link-type="idl-name" href="#credential" id="ref-for-credential-23">Credential</a> <a class="nv idl-code" data-link-type="argument" href="#dom-credentialscontainer-store-credential-credential" id="ref-for-dom-credentialscontainer-store-credential-credential-1">credential</a>);
   <span class="kt">Promise</span>&lt;<a class="n" data-link-type="idl-name" href="#credential" id="ref-for-credential-24">Credential</a>?> <a class="nv idl-code" data-link-type="method" href="#dom-credentialscontainer-create" id="ref-for-dom-credentialscontainer-create-1">create</a>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-credentialcreationoptions" id="ref-for-dictdef-credentialcreationoptions-2">CredentialCreationOptions</a> <a class="nv idl-code" data-link-type="argument" href="#dom-credentialscontainer-create-options-options" id="ref-for-dom-credentialscontainer-create-options-options-1">options</a>);
-  <span class="kt">Promise</span>&lt;<span class="kt">void</span>> <a class="nv idl-code" data-link-type="method" href="#dom-credentialscontainer-requireusermediation" id="ref-for-dom-credentialscontainer-requireusermediation-1">requireUserMediation</a>();
+  <span class="kt">Promise</span>&lt;<span class="kt">void</span>> <a class="nv idl-code" data-link-type="method" href="#dom-credentialscontainer-preventsilentaccess" id="ref-for-dom-credentialscontainer-preventsilentaccess-1">preventSilentAccess</a>();
 };
 
 <span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-credentialdata">CredentialData</dfn> {
@@ -1918,15 +1918,17 @@ store user credentials for future use.</p>
         <td>The options used to create a <code>Credential</code>. 
      </table>
      <dl>
-      <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="CredentialsContainer" data-dfn-type="method" data-export="" id="dom-credentialscontainer-requireusermediation">requireUserMediation()</dfn>
+      <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="CredentialsContainer" data-dfn-type="method" data-export="" id="dom-credentialscontainer-preventsilentaccess">preventSilentAccess()</dfn>
       <dd data-md="">
-       <p>When <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-requireusermediation" id="ref-for-dom-credentialscontainer-requireusermediation-2">requireUserMediation()</a></code> is called, the user agent MUST return
-  the result of executing <a data-link-type="abstract-op" href="#abstract-opdef-require-user-mediation" id="ref-for-abstract-opdef-require-user-mediation-1">Require user mediation</a> on the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">current settings
+       <p>When <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-preventsilentaccess" id="ref-for-dom-credentialscontainer-preventsilentaccess-2">preventSilentAccess()</a></code> is called, the user agent MUST return
+  the result of executing <a data-link-type="abstract-op" href="#abstract-opdef-prevent-silent-access" id="ref-for-abstract-opdef-prevent-silent-access-1">Prevent Silent Access</a> on the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">current settings
   object</a>.</p>
        <p class="note" role="note"><span>Note:</span> The intent here is a signal from the origin that the user has signed out. That
   is, after a click on a "Sign out" button, the site updates the user’s session info, and
-  calls <code>navigator.credentials.requireUserMediation()</code>. This toggles the <a data-link-type="dfn" href="#origin-requires-user-mediation-flag" id="ref-for-origin-requires-user-mediation-flag-1"><code>requires user mediation</code> flag</a>, meaning that credentials will not be automagically handed back to the
+  calls <code>navigator.credentials.preventSilentAccess()</code>. This toggles the <a data-link-type="dfn" href="#origin-requires-user-mediation-flag" id="ref-for-origin-requires-user-mediation-flag-1"><code>requires user mediation</code> flag</a>, meaning that credentials will not be automagically handed back to the
   page next time the user visits.</p>
+       <p class="note" role="note"><span>Note:</span> This function used to be called <code>requireUserNavigation()</code> which
+  should be considered deprecated.</p>
      </dl>
     </dl>
     <div class="algorithm" data-algorithm="create credentialscontainer"> When a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/webappapis.html#navigator">Navigator</a></code> object (<var>navigator</var>) is created, the user agent MUST create a
@@ -2034,7 +2036,7 @@ store user credentials for future use.</p>
       <p>The user agent will not hand over credentials without <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated-4">user mediation</a>, even if the <a data-link-type="dfn" href="#origin-requires-user-mediation" id="ref-for-origin-requires-user-mediation-2">requires user mediation</a> flag is unset for an origin.</p>
       <p class="note" role="note"><span>Note:</span> This requirement is intended to support <a href="#example-mediation-require">reauthentication</a> or <a href="#example-mediation-switch">user-switching</a> scenarios. Further, the requirement is tied
   to a specific operation, and does not affect the <a data-link-type="dfn" href="#origin-requires-user-mediation" id="ref-for-origin-requires-user-mediation-3">requires user mediation</a> flag for the
-  origin. To set that flag, developers should call <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-requireusermediation" id="ref-for-dom-credentialscontainer-requireusermediation-3">requireUserMediation()</a></code>.</p>
+  origin. To set that flag, developers should call <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-preventsilentaccess" id="ref-for-dom-credentialscontainer-preventsilentaccess-3">preventSilentAccess()</a></code>.</p>
     </dl>
     <h5 class="heading settled" data-level="2.3.2.1" id="mediation-examples"><span class="secno">2.3.2.1. </span><span class="content">Examples</span><a class="self-link" href="#mediation-examples"></a></h5>
     <div class="example" id="example-mediation-silent">
@@ -2278,8 +2280,8 @@ store user credentials for future use.</p>
      <li data-md="">
       <p>Return <var>p</var>.</p>
     </ol>
-    <h4 class="heading settled algorithm" data-algorithm="Require User Mediation" data-level="2.5.5" id="algorithm-require-mediation"><span class="secno">2.5.5. </span><span class="content">Require User Mediation</span><a class="self-link" href="#algorithm-require-mediation"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export="" id="abstract-opdef-require-user-mediation">Require user mediation</dfn> algorithm accepts an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings
+    <h4 class="heading settled algorithm" data-algorithm="Prevent Silent Access" data-level="2.5.5" id="algorithm-require-mediation"><span class="secno">2.5.5. </span><span class="content">Prevent Silent Access</span><a class="self-link" href="#algorithm-require-mediation"></a></h4>
+    <p>The <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export="" id="abstract-opdef-prevent-silent-access">Prevent Silent Access</dfn> algorithm accepts an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings
   object</a> (<var>settings</var>), and returns a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-promise">Promise</a></code> which resolves once the <code>requires user mediation</code> flag is persisted to the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store-11">credential store</a>.</p>
     <ol class="algorithm">
      <li data-md="">
@@ -3062,7 +3064,7 @@ store user credentials for future use.</p>
     <h3 class="heading settled" data-level="6.6" id="security-signout"><span class="secno">6.6. </span><span class="content">Signing-Out</span><a class="self-link" href="#security-signout"></a></h3>
     <p>If a user has chosen to automatically sign-in to websites, as discussed in <a href="#user-mediation-requirement">§5.2 Requiring User Mediation</a>, then the user agent will provide credentials to an origin
   whenever it asks for them. The website can instruct the user agent to suppress this behavior by
-  calling <code class="idl"><a data-link-type="idl" href="#credentialscontainer" id="ref-for-credentialscontainer-6">CredentialsContainer</a></code>'s <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-requireusermediation" id="ref-for-dom-credentialscontainer-requireusermediation-4">requireUserMediation()</a></code> method, which
+  calling <code class="idl"><a data-link-type="idl" href="#credentialscontainer" id="ref-for-credentialscontainer-6">CredentialsContainer</a></code>'s <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-preventsilentaccess" id="ref-for-dom-credentialscontainer-preventsilentaccess-4">preventSilentAccess()</a></code> method, which
   will turn off automatic sign-in for a given origin.</p>
     <p>The user agent relies on the website to do the right thing; an inattentive (or malicious) website
   could simply neglect to call this method, causing the user agent to continue providing credentials
@@ -3351,6 +3353,8 @@ partial dictionary CredentialCreationOptions {
    <li><a href="#dictdef-passwordcredentialdata">PasswordCredentialData</a><span>, in §3.2</span>
    <li><a href="#dom-passwordcredential-passwordcredential">PasswordCredential(form)</a><span>, in §3.2</span>
    <li><a href="#typedefdef-passwordcredentialinit">PasswordCredentialInit</a><span>, in §3.2</span>
+   <li><a href="#dom-credentialscontainer-preventsilentaccess">preventSilentAccess()</a><span>, in §2.3</span>
+   <li><a href="#abstract-opdef-prevent-silent-access">Prevent Silent Access</a><span>, in §2.5.5</span>
    <li>
     protocol
     <ul>
@@ -3371,8 +3375,6 @@ partial dictionary CredentialCreationOptions {
    <li><a href="#dom-credentialmediationrequirement-required">required</a><span>, in §2.3.2</span>
    <li><a href="#origin-requires-user-mediation">requires user mediation</a><span>, in §2.1</span>
    <li><a href="#origin-requires-user-mediation-flag">requires user mediation flag</a><span>, in §2.1</span>
-   <li><a href="#dom-credentialscontainer-requireusermediation">requireUserMediation()</a><span>, in §2.3</span>
-   <li><a href="#abstract-opdef-require-user-mediation">Require user mediation</a><span>, in §2.5.5</span>
    <li><a href="#abstract-opdef-credential-store-retrieve-a-list-of-credentials">Retrieve a list of credentials</a><span>, in §2.1</span>
    <li><a href="#dom-credentialmediationrequirement-silent">silent</a><span>, in §2.3.2</span>
    <li><a href="#dom-credentialscontainer-store">store()</a><span>, in §2.3</span>
@@ -3587,7 +3589,7 @@ partial dictionary CredentialCreationOptions {
   <span class="kt">Promise</span>&lt;<a class="n" data-link-type="idl-name" href="#credential">Credential</a>?> <a class="nv idl-code" data-link-type="method" href="#dom-credentialscontainer-get">get</a>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-credentialrequestoptions">CredentialRequestOptions</a> <a class="nv idl-code" data-link-type="argument" href="#dom-credentialscontainer-get-options-options">options</a>);
   <span class="kt">Promise</span>&lt;<a class="n" data-link-type="idl-name" href="#credential">Credential</a>> <a class="nv idl-code" data-link-type="method" href="#dom-credentialscontainer-store">store</a>(<a class="n" data-link-type="idl-name" href="#credential">Credential</a> <a class="nv idl-code" data-link-type="argument" href="#dom-credentialscontainer-store-credential-credential">credential</a>);
   <span class="kt">Promise</span>&lt;<a class="n" data-link-type="idl-name" href="#credential">Credential</a>?> <a class="nv idl-code" data-link-type="method" href="#dom-credentialscontainer-create">create</a>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-credentialcreationoptions">CredentialCreationOptions</a> <a class="nv idl-code" data-link-type="argument" href="#dom-credentialscontainer-create-options-options">options</a>);
-  <span class="kt">Promise</span>&lt;<span class="kt">void</span>> <a class="nv idl-code" data-link-type="method" href="#dom-credentialscontainer-requireusermediation">requireUserMediation</a>();
+  <span class="kt">Promise</span>&lt;<span class="kt">void</span>> <a class="nv idl-code" data-link-type="method" href="#dom-credentialscontainer-preventsilentaccess">preventSilentAccess</a>();
 };
 
 <span class="kt">dictionary</span> <a class="nv" href="#dictdef-credentialdata">CredentialData</a> {
@@ -3715,7 +3717,7 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-concept-credential-store-7">2.2.1. Credential Internal Methods</a> <a href="#ref-for-concept-credential-store-8">(2)</a>
     <li><a href="#ref-for-concept-credential-store-9">2.3. navigator.credentials</a>
     <li><a href="#ref-for-concept-credential-store-10">2.5.3. Store a Credential</a>
-    <li><a href="#ref-for-concept-credential-store-11">2.5.5. Require User Mediation</a> <a href="#ref-for-concept-credential-store-12">(2)</a>
+    <li><a href="#ref-for-concept-credential-store-11">2.5.5. Prevent Silent Access</a> <a href="#ref-for-concept-credential-store-12">(2)</a>
     <li><a href="#ref-for-concept-credential-store-13">3.1.1. Password-based Sign-in</a>
     <li><a href="#ref-for-concept-credential-store-14">3.3.1. 
     PasswordCredential's [[CollectFromCredentialStore]](options) </a> <a href="#ref-for-concept-credential-store-15">(2)</a>
@@ -3744,7 +3746,7 @@ partial dictionary CredentialCreationOptions {
    <b><a href="#origin-requires-user-mediation-flag">#origin-requires-user-mediation-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-origin-requires-user-mediation-flag-1">2.3. navigator.credentials</a>
-    <li><a href="#ref-for-origin-requires-user-mediation-flag-2">2.5.5. Require User Mediation</a>
+    <li><a href="#ref-for-origin-requires-user-mediation-flag-2">2.5.5. Prevent Silent Access</a>
     <li><a href="#ref-for-origin-requires-user-mediation-flag-3">5.2. Requiring User Mediation</a> <a href="#ref-for-origin-requires-user-mediation-flag-4">(2)</a> <a href="#ref-for-origin-requires-user-mediation-flag-5">(3)</a> <a href="#ref-for-origin-requires-user-mediation-flag-6">(4)</a>
     <li><a href="#ref-for-origin-requires-user-mediation-flag-7">6.6. Signing-Out</a>
    </ul>
@@ -4021,12 +4023,12 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-dom-credentialscontainer-create-options-options-1">2.3. navigator.credentials</a> <a href="#ref-for-dom-credentialscontainer-create-options-options-2">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-credentialscontainer-requireusermediation">
-   <b><a href="#dom-credentialscontainer-requireusermediation">#dom-credentialscontainer-requireusermediation</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="dom-credentialscontainer-preventsilentaccess">
+   <b><a href="#dom-credentialscontainer-preventsilentaccess">#dom-credentialscontainer-preventsilentaccess</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-credentialscontainer-requireusermediation-1">2.3. navigator.credentials</a> <a href="#ref-for-dom-credentialscontainer-requireusermediation-2">(2)</a>
-    <li><a href="#ref-for-dom-credentialscontainer-requireusermediation-3">2.3.2. Mediation Requirements</a>
-    <li><a href="#ref-for-dom-credentialscontainer-requireusermediation-4">6.6. Signing-Out</a>
+    <li><a href="#ref-for-dom-credentialscontainer-preventsilentaccess-1">2.3. navigator.credentials</a> <a href="#ref-for-dom-credentialscontainer-preventsilentaccess-2">(2)</a>
+    <li><a href="#ref-for-dom-credentialscontainer-preventsilentaccess-3">2.3.2. Mediation Requirements</a>
+    <li><a href="#ref-for-dom-credentialscontainer-preventsilentaccess-4">6.6. Signing-Out</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dictdef-credentialrequestoptions">
@@ -4143,10 +4145,10 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-abstract-opdef-create-a-credential-1">2.3. navigator.credentials</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abstract-opdef-require-user-mediation">
-   <b><a href="#abstract-opdef-require-user-mediation">#abstract-opdef-require-user-mediation</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="abstract-opdef-prevent-silent-access">
+   <b><a href="#abstract-opdef-prevent-silent-access">#abstract-opdef-prevent-silent-access</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-abstract-opdef-require-user-mediation-1">2.3. navigator.credentials</a>
+    <li><a href="#ref-for-abstract-opdef-prevent-silent-access-1">2.3. navigator.credentials</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="passwordcredential">

--- a/index.src.html
+++ b/index.src.html
@@ -217,8 +217,8 @@ spec:url; type:dfn; text:urlencoded byte serializer
       [=credential=], and overwrites the state of an existing [=credential=] in the
       [=credential store=].
 
-  Additionally, the [=credential store=] should maintain a <dfn for="origin">`requires user
-  mediation` flag</dfn> for [=origins=] (which is set to `true` unless otherwise specified).
+  Additionally, the [=credential store=] should maintain a <dfn for="origin">`prevent silent
+  access` flag</dfn> for [=origins=] (which is set to `true` unless otherwise specified).
   An origin <dfn for="origin">requires user mediation</dfn> if its flag is set to `true`.
 
   Note: The importance of user mediation is discussed in more detail in [[#user-mediation]].
@@ -421,8 +421,8 @@ spec:url; type:dfn; text:urlencoded byte serializer
   
         Note: The intent here is a signal from the origin that the user has signed out. That
         is, after a click on a "Sign out" button, the site updates the user's session info, and
-        calls `navigator.credentials.preventSilentAccess()`. This toggles the <a>`requires user
-        mediation` flag</a>, meaning that credentials will not be automagically handed back to the
+        calls `navigator.credentials.preventSilentAccess()`. This toggles the <a>`prevent silent
+        access` flag</a>, meaning that credentials will not be automagically handed back to the
         page next time the user visits.
 
         Note: This function used to be called `requireUserMediation()` which should be considered
@@ -553,11 +553,11 @@ spec:url; type:dfn; text:urlencoded byte serializer
 
     :   <dfn>required</dfn>
     ::  The user agent will not hand over credentials without [=user mediation=], even if the
-        [=requires user mediation=] flag is unset for an origin.
+        [=prevent silent access flag=] is unset for an origin.
 
         Note: This requirement is intended to support [reauthentication](#example-mediation-require)
         or [user-switching](#example-mediation-switch) scenarios. Further, the requirement is tied
-        to a specific operation, and does not affect the [=requires user mediation=] flag for the
+        to a specific operation, and does not affect the [=prevent silent access flag=] for the
         origin. To set that flag, developers should call {{preventSilentAccess()}}.
   </dl>
 
@@ -842,7 +842,7 @@ spec:url; type:dfn; text:urlencoded byte serializer
   <h4 id="algorithm-require-mediation" algorithm>Prevent Silent Access</h4>
 
   The <dfn abstract-op>Prevent Silent Access</dfn> algorithm accepts an [=environment settings
-  object=] (|settings|), and returns a {{Promise}} which resolves once the `requires user mediation`
+  object=] (|settings|), and returns a {{Promise}} which resolves once the `prevent silent access`
   flag is persisted to the [=credential store=].
 
   <ol class="algorithm">
@@ -852,7 +852,7 @@ spec:url; type:dfn; text:urlencoded byte serializer
 
     3.  Run the following seps [=in parallel=]:
 
-        1.  Set |origin|'s <a>`requires user mediation` flag</a> in the [=credential store=].
+        1.  Set |origin|'s <a>`prevent silent access` flag</a> in the [=credential store=].
 
         2.  [=Resolve=] |p| with `undefined`.
 
@@ -1594,9 +1594,10 @@ spec:url; type:dfn; text:urlencoded byte serializer
   mediated=] actions will involve presenting the user some sort of UI, and asking them to make a
   decision.
 
-  An action is <dfn export>unmediated</dfn> if it takes place without explicit user consent. For
-  example, if a user configures their browser to grant persistent credential access to a particular
-  origin, credentials may be provided without presenting the user with a UI requesting a decision.
+  An action is <dfn export>unmediated</dfn> or <dfn export>silent</dfn> if it takes place without
+  explicit user consent. For example, if a user configures their browser to grant persistent
+  credential access to a particular origin, credentials may be provided without presenting the user
+  with a UI requesting a decision.
 
   Here we'll spell out a few requirements that hold for all credential types, but note that there's
   a good deal of latitude left up to the user agent (which is in a priviliged position to assist
@@ -1626,10 +1627,10 @@ spec:url; type:dfn; text:urlencoded byte serializer
 
   ## Requiring User Mediation ## {#user-mediation-requirement}
 
-  By default, [=user mediation=] is required for all [=origins=], as the relevant [=requires user
-  mediation flag=] in the [=credential store=] is set to `true`. Users MAY choose to grant an
+  By default, [=user mediation=] is required for all [=origins=], as the relevant [=prevent silent
+  access flag=] in the [=credential store=] is set to `true`. Users MAY choose to grant an
   origin persistent access to credentials (perhaps in the form of a "Stay signed into this site."
-  option), which would set this flag to `true`. In this case, the user would always be signed into
+  option), which would set this flag to `false`. In this case, the user would always be signed into
   that site, which is desirable from the perspective of usability and convinience, but which
   might nevertheless have surprising implications (consider a user agent which syncs this flag's
   state across devices, for instance).
@@ -1638,10 +1639,10 @@ spec:url; type:dfn; text:urlencoded byte serializer
 
   1.  User agents MUST allow users to require [=user mediation=] for a given origin or for all
       origins. This functionality might be implemented as a global toggle that overrides each
-      origin's <a>`requires user mediation` flag</a> to return `false`, or via more granular
+      origin's <a>`prevent silent access` flag</a> to return `false`, or via more granular
       settings for specific origins (or specific credentials on specific origins).
 
-  2.  User agents MUST NOT set an [=origin=]'s <a>`requires user mediation` flag</a> to
+  2.  User agents MUST NOT set an [=origin=]'s <a>`prevent silent access` flag</a> to
       `false` without [=user mediation=]. For example, the [=credential chooser=] described in
       [[#user-mediated-selection]] could have a checkbox which the user could toggle to mark a
       credential as available without mediation for the origin, or the user agent could have an
@@ -1651,7 +1652,7 @@ spec:url; type:dfn; text:urlencoded byte serializer
       form of an icon in the address bar, or some similar location.
 
   4.  If a user clears her browsing data for an origin (cookies, localStorage, and so on), the user
-      agent MUST set the <a>`requires user mediation` flag</a> to `false` for that origin.
+      agent MUST set the <a>`prevent silent access` flag</a> to `true` for that origin.
 
   ## Credential Selection ## {#user-mediated-selection}
 
@@ -1819,7 +1820,7 @@ spec:url; type:dfn; text:urlencoded byte serializer
   the authentication.
 
   The user MUST have some control over this behavior. As noted in [[#user-mediation-requirement]],
-  clearing cookies for an origin will also reset that origin's <a>`requires user mediation` flag</a>
+  clearing cookies for an origin will also reset that origin's <a>`prevent silent access` flag</a>
   the [=credential store=] to `true`. Additionally, the user agent SHOULD provide some UI affordance
   for disabling automatic sign-in for a particular origin. This could be tied to the notification
   that credentials have been provided to an origin, for example.

--- a/index.src.html
+++ b/index.src.html
@@ -421,7 +421,7 @@ spec:url; type:dfn; text:urlencoded byte serializer
   
         Note: The intent here is a signal from the origin that the user has signed out. That
         is, after a click on a "Sign out" button, the site updates the user's session info, and
-        calls `navigator.credentials.preventSilentAccess()`. This toggles the <a>`prevent silent
+        calls `navigator.credentials.preventSilentAccess()`. This sets the <a>`prevent silent
         access` flag</a>, meaning that credentials will not be automagically handed back to the
         page next time the user visits.
 
@@ -839,7 +839,7 @@ spec:url; type:dfn; text:urlencoded byte serializer
     7.  Return |p|.
   </ol>
 
-  <h4 id="algorithm-require-mediation" algorithm>Prevent Silent Access</h4>
+  <h4 id="algorithm-prevent-silent-access" algorithm>Prevent Silent Access</h4>
 
   The <dfn abstract-op>Prevent Silent Access</dfn> algorithm accepts an [=environment settings
   object=] (|settings|), and returns a {{Promise}} which resolves once the `prevent silent access`
@@ -1594,10 +1594,9 @@ spec:url; type:dfn; text:urlencoded byte serializer
   mediated=] actions will involve presenting the user some sort of UI, and asking them to make a
   decision.
 
-  An action is <dfn export>unmediated</dfn> or <dfn export>silent</dfn> if it takes place without
-  explicit user consent. For example, if a user configures their browser to grant persistent
-  credential access to a particular origin, credentials may be provided without presenting the user
-  with a UI requesting a decision.
+  An action is unmediated if it takes place silently, without explicit user consent. For example,
+  if a user configures their browser to grant persistent credential access to a particular origin,
+  credentials may be provided without presenting the user with a UI requesting a decision.
 
   Here we'll spell out a few requirements that hold for all credential types, but note that there's
   a good deal of latitude left up to the user agent (which is in a priviliged position to assist

--- a/index.src.html
+++ b/index.src.html
@@ -425,7 +425,7 @@ spec:url; type:dfn; text:urlencoded byte serializer
         access` flag</a>, meaning that credentials will not be automagically handed back to the
         page next time the user visits.
 
-        Note: This function used to be called `requireUserMediation()` which should be considered
+        Note: This function was previously called `requireUserMediation()` which should be considered
         deprecated.
   </dl>
 

--- a/index.src.html
+++ b/index.src.html
@@ -378,7 +378,7 @@ spec:url; type:dfn; text:urlencoded byte serializer
       Promise&lt;Credential?&gt; get(optional CredentialRequestOptions options);
       Promise&lt;Credential&gt; store(Credential credential);
       Promise&lt;Credential?&gt; create(optional CredentialCreationOptions options);
-      Promise&lt;void&gt; requireUserMediation();
+      Promise&lt;void&gt; preventSilentAccess();
     };
 
     dictionary CredentialData {
@@ -414,16 +414,19 @@ spec:url; type:dfn; text:urlencoded byte serializer
           options: The options used to create a `Credential`.
         </pre>
     
-    :   <dfn method>requireUserMediation()</dfn>
-    ::  When {{CredentialsContainer/requireUserMediation()}} is called, the user agent MUST return
-        the result of executing <a abstract-op>Require user mediation</a> on the <a>current settings
+    :   <dfn method>preventSilentAccess()</dfn>
+    ::  When {{CredentialsContainer/preventSilentAccess()}} is called, the user agent MUST return
+        the result of executing <a abstract-op>Prevent Silent Access</a> on the <a>current settings
         object</a>.
   
         Note: The intent here is a signal from the origin that the user has signed out. That
         is, after a click on a "Sign out" button, the site updates the user's session info, and
-        calls `navigator.credentials.requireUserMediation()`. This toggles the <a>`requires user
+        calls `navigator.credentials.preventSilentAccess()`. This toggles the <a>`requires user
         mediation` flag</a>, meaning that credentials will not be automagically handed back to the
         page next time the user visits.
+
+        Note: This function used to be called `requireUserMediation()` which should be considered
+        deprecated.
   </dl>
 
   <div algorithm="create credentialscontainer">
@@ -555,7 +558,7 @@ spec:url; type:dfn; text:urlencoded byte serializer
         Note: This requirement is intended to support [reauthentication](#example-mediation-require)
         or [user-switching](#example-mediation-switch) scenarios. Further, the requirement is tied
         to a specific operation, and does not affect the [=requires user mediation=] flag for the
-        origin. To set that flag, developers should call {{requireUserMediation()}}.
+        origin. To set that flag, developers should call {{preventSilentAccess()}}.
   </dl>
 
   #### Examples #### {#mediation-examples}
@@ -836,9 +839,9 @@ spec:url; type:dfn; text:urlencoded byte serializer
     7.  Return |p|.
   </ol>
 
-  <h4 id="algorithm-require-mediation" algorithm>Require User Mediation</h4>
+  <h4 id="algorithm-require-mediation" algorithm>Prevent Silent Access</h4>
 
-  The <dfn abstract-op>Require user mediation</dfn> algorithm accepts an [=environment settings
+  The <dfn abstract-op>Prevent Silent Access</dfn> algorithm accepts an [=environment settings
   object=] (|settings|), and returns a {{Promise}} which resolves once the `requires user mediation`
   flag is persisted to the [=credential store=].
 
@@ -1806,7 +1809,7 @@ spec:url; type:dfn; text:urlencoded byte serializer
   If a user has chosen to automatically sign-in to websites, as discussed in
   [[#user-mediation-requirement]], then the user agent will provide credentials to an origin
   whenever it asks for them. The website can instruct the user agent to suppress this behavior by
-  calling {{CredentialsContainer}}'s {{CredentialsContainer/requireUserMediation()}} method, which
+  calling {{CredentialsContainer}}'s {{CredentialsContainer/preventSilentAccess()}} method, which
   will turn off automatic sign-in for a given origin.
 
   The user agent relies on the website to do the right thing; an inattentive (or malicious) website


### PR DESCRIPTION
I have created a pull request as discussed today.

Note that I have not renamed the require user mediation flag but the corresponding algorithm. I am a tiny big concerned that we are now using inconsistent naming (there are still a number of cases referring to mediation).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webappsec-credential-management/issue-74-rename-requireUserMediation.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webappsec-credential-management/cad004e...8561d88.html)