### PR TITLE
[[Store]] can fail.

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -792,7 +792,9 @@ spec:url; type:dfn; text:urlencoded byte serializer
         1.  Let |r| be the result of executing |credential|'s [=interface object=]'s
             {{Credential/[[Store]](credential)}} internal method on |credential|.
 
-        2.  [=Resolve=] |p| with |r|.
+        2.  If |r| is an [=exception=], [=reject=] |p| with |r|.
+
+            Otherwise, [=resolve=] |p| with |r|.
 
     6.  Return |p|.
   </ol>


### PR DESCRIPTION
Addresses https://github.com/w3c/webappsec-credential-management/issues/107.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webappsec-credential-management/store-fail.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webappsec-credential-management/6e831a6...761f041.html)