### PR TITLE
Handle the AbortSignal in get() and create() themselves.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+bikeshed/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-bikeshed/

--- a/index.html
+++ b/index.html
@@ -1178,7 +1178,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 4679d5ca787d737883d9c905dd138257fc2cec85" name="generator">
   <link href="http://www.w3.org/TR/credential-management-1/" rel="canonical">
-  <meta content="35220d6c86ebcb937a7121816ef9b06176485cb5" name="document-revision">
+  <meta content="a568516f39b8d5707ce16d4151f457eef1bbfe03" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1763,7 +1763,10 @@ store user credentials for future use.</p>
     <p>Some <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential⑤">Credential</a></code> objects are <dfn class="dfn-paneled" data-dfn-for="Credential" data-dfn-type="dfn" data-noexport="" id="credential-origin-bound">origin bound</dfn>: these contain an
   internal slot named <dfn class="dfn-paneled idl-code" data-dfn-for="Credential" data-dfn-type="attribute" data-export="" id="dom-credential-origin-slot"><code>[[origin]]</code></dfn>, which stores the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin②">origin</a> for which the <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential⑥">Credential</a></code> may be <a data-link-type="dfn" href="#credential-effective" id="ref-for-credential-effective①">effective</a>.</p>
     <h4 class="heading settled" data-level="2.2.1" id="credential-internal-methods"><span class="secno">2.2.1. </span><span class="content"><code>Credential</code> Internal Methods</span><a class="self-link" href="#credential-internal-methods"></a></h4>
-    <p>Each <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object④">interface object</a> created for interfaces which <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherit" id="ref-for-dfn-inherit①">inherit</a> from <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential⑦">Credential</a></code> defines several internal methods that allow retrieval and storage of <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential⑧">Credential</a></code> objects. The <code class="idl"><a data-link-type="idl" href="#dom-credential-create-slot" id="ref-for-dom-credential-create-slot">[[Create]](options)</a></code> method and <code class="idl"><a data-link-type="idl" href="#dom-credential-discoverfromexternalsource-slot" id="ref-for-dom-credential-discoverfromexternalsource-slot">[[DiscoverFromExternalSource]](options)</a></code> method can be aborted.</p>
+    <p>Each <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object④">interface object</a> created for interfaces which <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherit" id="ref-for-dfn-inherit①">inherit</a> from <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential⑦">Credential</a></code> defines several internal methods that allow retrieval and storage of <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential⑧">Credential</a></code> objects. The
+  methods taking an <code>options</code> argument receive an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#abortsignal" id="ref-for-abortsignal">AbortSignal</a></code>, with which they
+  can <a href="https://dom.spec.whatwg.org/#abortcontroller-api-integration">respond</a> to a caller attempting
+  to abort them.</p>
     <section class="algorithm" data-algorithm="&apos;collect credentials&apos; internal method">
       <dfn class="dfn-paneled idl-code" data-dfn-for="Credential" data-dfn-type="method" data-export="" id="dom-credential-collectfromcredentialstore-slot"><code>[[CollectFromCredentialStore]](options)</code></dfn> is called
     with a <code class="idl"><a data-link-type="idl" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions">CredentialRequestOptions</a></code>, and returns a set of <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential⑨">Credential</a></code> objects from the user
@@ -1934,7 +1937,7 @@ store user credentials for future use.</p>
   dictionary so they can be passed into the request. See <a href="#implementation-extension">§7.2 Extension Points</a>.</p>
 <pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-credentialrequestoptions"><code>CredentialRequestOptions</code></dfn> {
   <a class="n" data-link-type="idl-name" href="#enumdef-credentialmediationrequirement" id="ref-for-enumdef-credentialmediationrequirement">CredentialMediationRequirement</a> <a class="nv idl-code" data-default="&quot;optional&quot;" data-link-type="dict-member" data-type="CredentialMediationRequirement " href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation">mediation</a> = "optional";
-  <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#abortsignal" id="ref-for-abortsignal">AbortSignal</a> <a class="nv idl-code" data-link-type="dict-member" data-type="AbortSignal " href="#dom-credentialrequestoptions-signal" id="ref-for-dom-credentialrequestoptions-signal">signal</a>;
+  <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#abortsignal" id="ref-for-abortsignal①">AbortSignal</a> <a class="nv idl-code" data-link-type="dict-member" data-type="AbortSignal " href="#dom-credentialrequestoptions-signal" id="ref-for-dom-credentialrequestoptions-signal">signal</a>;
 };
 </pre>
     <div>
@@ -1944,10 +1947,11 @@ store user credentials for future use.</p>
        <p>This property specifies the mediation requirements for a given credential request. The
   meaning of each enum value is described below in <code class="idl"><a data-link-type="idl" href="#enumdef-credentialmediationrequirement" id="ref-for-enumdef-credentialmediationrequirement②">CredentialMediationRequirement</a></code>.
   Processing details are defined in <a href="#algorithm-request">§2.5.1 Request a Credential</a>.</p>
-      <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="CredentialRequestOptions" data-dfn-type="dict-member" data-export="" id="dom-credentialrequestoptions-signal"><code>signal</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#abortsignal" id="ref-for-abortsignal①">AbortSignal</a></span>
+      <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="CredentialRequestOptions" data-dfn-type="dict-member" data-export="" id="dom-credentialrequestoptions-signal"><code>signal</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#abortsignal" id="ref-for-abortsignal②">AbortSignal</a></span>
       <dd data-md="">
-       <p>This property lets the developer abort an ongoing <code class="idl"><a data-link-type="idl" href="#dom-credential-discoverfromexternalsource-slot" id="ref-for-dom-credential-discoverfromexternalsource-slot①">[[DiscoverFromExternalSource]](options)</a></code> operation and subsequently all related <a data-link-type="dfn">authenticatorGetAssertion</a> operations. Aborted promise would 
-  be rejected with an "AbortError" DOMException.</p>
+       <p>This property lets the developer abort an ongoing <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get④">get()</a></code> operation.
+  An aborted operation may complete normally (generally if the abort was received after the
+  operation finished) or reject with an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#aborterror" id="ref-for-aborterror">AbortError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException">DOMException</a></code>."</p>
      </dl>
     </div>
     <div class="note" role="note">
@@ -1995,14 +1999,14 @@ store user credentials for future use.</p>
       <li data-md="">
        <p>Return <code>true</code>.</p>
      </ol>
-     <p class="note" role="note"><span>Note:</span> When executing <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get④">get(options)</a></code>, we only return credentials without <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated">user mediation</a> if
+     <p class="note" role="note"><span>Note:</span> When executing <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get⑤">get(options)</a></code>, we only return credentials without <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated">user mediation</a> if
     the provided <code class="idl"><a data-link-type="idl" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions⑦">CredentialRequestOptions</a></code> is <a data-link-type="dfn" href="#credentialrequestoptions-matchable-a-priori" id="ref-for-credentialrequestoptions-matchable-a-priori">matchable <i lang="la">a priori</i></a>. If any
     credential types are requested that could require discovery from some external service (OAuth
     tokens, security key authenticators, etc.), then <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated①">user mediation</a> will be required in order
     to guide the discovery process (by choosing a federated identity provider, BTLE device, etc).</p>
     </div>
     <h4 class="heading settled" data-level="2.3.2" id="mediation-requirements"><span class="secno">2.3.2. </span><span class="content">Mediation Requirements</span><a class="self-link" href="#mediation-requirements"></a></h4>
-    <p>When making a request via <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get⑤">get(options)</a></code>, developers can set a case-by-case requirement for <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated②">user mediation</a> by choosing the appropriate <code class="idl"><a data-link-type="idl" href="#enumdef-credentialmediationrequirement" id="ref-for-enumdef-credentialmediationrequirement③">CredentialMediationRequirement</a></code> enum value.</p>
+    <p>When making a request via <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get⑥">get(options)</a></code>, developers can set a case-by-case requirement for <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated②">user mediation</a> by choosing the appropriate <code class="idl"><a data-link-type="idl" href="#enumdef-credentialmediationrequirement" id="ref-for-enumdef-credentialmediationrequirement③">CredentialMediationRequirement</a></code> enum value.</p>
     <p class="note" role="note"><span>Note:</span> The <a href="#user-mediation">§5 User Mediation</a> section gives more detail on the concept in general, and its
   implications on how the user agent deals with individual requests for a given origin).</p>
 <pre class="idl highlight def"><span class="kt">enum</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="enum" data-export="" id="enumdef-credentialmediationrequirement"><code>CredentialMediationRequirement</code></dfn> {
@@ -2027,7 +2031,7 @@ store user credentials for future use.</p>
        <p>If credentials can be handed over for a given operation without user mediation, they will
   be. If <a data-link-type="dfn" href="#origin-requires-user-mediation" id="ref-for-origin-requires-user-mediation">user mediation is required</a>, then the user agent will
   involve the user in the decision.</p>
-       <p class="note" role="note"><span>Note:</span> This is the default behavior for <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get⑥">get()</a></code>, and is intended to serve a case where a
+       <p class="note" role="note"><span>Note:</span> This is the default behavior for <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get⑦">get()</a></code>, and is intended to serve a case where a
   developer has reasonable confidence that a user expects to start a sign-in operation. If
   a user has just clicked "sign-in" for example, then they won’t be surprised or confused to
   see a <a data-link-type="dfn" href="#credential-chooser" id="ref-for-credential-chooser③">credential chooser</a> if necessary.</p>
@@ -2041,13 +2045,13 @@ store user credentials for future use.</p>
     </div>
     <h5 class="heading settled" data-level="2.3.2.1" id="mediation-examples"><span class="secno">2.3.2.1. </span><span class="content">Examples</span><a class="self-link" href="#mediation-examples"></a></h5>
     <div class="example" id="example-mediation-silent">
-     <a class="self-link" href="#example-mediation-silent"></a> MegaCorp, Inc. wishes to seamlessly sign in users when possible. They can do so by calling <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get⑦">get()</a></code> for all non-signed in users at some convinient point while a landing page is loading,
+     <a class="self-link" href="#example-mediation-silent"></a> MegaCorp, Inc. wishes to seamlessly sign in users when possible. They can do so by calling <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get⑧">get()</a></code> for all non-signed in users at some convinient point while a landing page is loading,
     passing in a <code class="idl"><a data-link-type="idl" href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation④">mediation</a></code> member set to
     "<code class="idl"><a data-link-type="idl" href="#dom-credentialmediationrequirement-silent" id="ref-for-dom-credentialmediationrequirement-silent②">silent</a></code>". This ensures that users who have opted-into
     dropping the requirements for user mediation (as described in <a href="#user-mediation-requirement">§5.2 Requiring User Mediation</a>)
     are signed in, and users who haven’t opted-into such behavior won’t be bothered with a confusing <a data-link-type="dfn" href="#credential-chooser" id="ref-for-credential-chooser④">credential chooser</a> popping up without context: 
 <pre>window.addEventListener('load', _ => {
-  var c = await navigatior.<a class="idl-code" data-link-type="attribute" href="#dom-navigator-credentials" id="ref-for-dom-navigator-credentials②">credentials</a>.<a class="idl-code" data-link-type="method" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get⑧">get</a>({
+  var c = await navigatior.<a class="idl-code" data-link-type="attribute" href="#dom-navigator-credentials" id="ref-for-dom-navigator-credentials②">credentials</a>.<a class="idl-code" data-link-type="method" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get⑨">get</a>({
     ...,
     <a class="idl-code" data-link-type="dict-member" href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation⑤">mediation</a>: '<a class="idl-code" data-link-type="enum-value" href="#dom-credentialmediationrequirement-silent" id="ref-for-dom-credentialmediationrequirement-silent③">silent</a>'
   });
@@ -2062,7 +2066,7 @@ store user credentials for future use.</p>
     experience. If they have <a href="#user-mediation-requirement">opted-into</a> signing in without <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated④">user mediation</a>, and the user agent can unambigiously choose a credential, great! If
     not, a <a data-link-type="dfn" href="#credential-chooser" id="ref-for-credential-chooser⑤">credential chooser</a> will be presented. 
 <pre>document.querySelector('#sign-in').addEventListener('click', e => {
-  var c = await navigatior.<a class="idl-code" data-link-type="attribute" href="#dom-navigator-credentials" id="ref-for-dom-navigator-credentials③">credentials</a>.<a class="idl-code" data-link-type="method" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get⑨">get</a>({
+  var c = await navigatior.<a class="idl-code" data-link-type="attribute" href="#dom-navigator-credentials" id="ref-for-dom-navigator-credentials③">credentials</a>.<a class="idl-code" data-link-type="method" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get①⓪">get</a>({
     ...,
     <a class="idl-code" data-link-type="dict-member" href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation⑥">mediation</a>: '<a class="idl-code" data-link-type="enum-value" href="#dom-credentialmediationrequirement-optional" id="ref-for-dom-credentialmediationrequirement-optional②">optional</a>'
   });
@@ -2077,13 +2081,13 @@ store user credentials for future use.</p>
      <a class="self-link" href="#example-mediation-require"></a> MegaCorp, Inc. wishes to protect a sensitive operation by requiring a user to reauthenticate
     before taking action. Even if a user has <a href="#user-mediation-requirement">opted-into</a> signing in
     without <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated⑤">user mediation</a>, MegaCorp, Inc. can ensure that the user agent requires mediation
-    by calling <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get①⓪">get()</a></code> with a <code class="idl"><a data-link-type="idl" href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation⑧">mediation</a></code> member set to
+    by calling <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get①①">get()</a></code> with a <code class="idl"><a data-link-type="idl" href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation⑧">mediation</a></code> member set to
     "<code class="idl"><a data-link-type="idl" href="#dom-credentialmediationrequirement-required" id="ref-for-dom-credentialmediationrequirement-required①">required</a></code>": 
      <p class="note" role="note"><span>Note:</span> Depending on the security model of the browser or the credential type, this may require
     the user to authenticate themselves in some way, perhaps by entering a master password, scanning
     a fingerprint, etc. before a credential is handed to the website.</p>
 <pre>document.querySelector('#important-form').addEventListener('submit', e => {
-  var c = await navigatior.<a class="idl-code" data-link-type="attribute" href="#dom-navigator-credentials" id="ref-for-dom-navigator-credentials④">credentials</a>.<a class="idl-code" data-link-type="method" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get①①">get</a>({
+  var c = await navigatior.<a class="idl-code" data-link-type="attribute" href="#dom-navigator-credentials" id="ref-for-dom-navigator-credentials④">credentials</a>.<a class="idl-code" data-link-type="method" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get①②">get</a>({
     ...,
     <a class="idl-code" data-link-type="dict-member" href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation⑨">mediation</a>: '<a class="idl-code" data-link-type="enum-value" href="#dom-credentialmediationrequirement-required" id="ref-for-dom-credentialmediationrequirement-required②">required</a>'
   });
@@ -2098,11 +2102,11 @@ store user credentials for future use.</p>
     </div>
     <div class="example" id="example-mediation-switch">
      <a class="self-link" href="#example-mediation-switch"></a> MegaCorp, Inc. wishes to support signing into multiple user accounts at once. In order to ensure
-    that the user gets a chance to select a different credential, MegaCorp, Inc. can call <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get①②">get()</a></code> with a <code class="idl"><a data-link-type="idl" href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation①⓪">mediation</a></code> member set to
+    that the user gets a chance to select a different credential, MegaCorp, Inc. can call <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get①③">get()</a></code> with a <code class="idl"><a data-link-type="idl" href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation①⓪">mediation</a></code> member set to
     "<code class="idl"><a data-link-type="idl" href="#dom-credentialmediationrequirement-required" id="ref-for-dom-credentialmediationrequirement-required③">required</a></code>" in order to ensure that that credentials aren’t
     returned automatically in response to clicking on an "Add account" button: 
 <pre>document.querySelector('#switch-button').addEventListener('click', e => {
-  var c = await navigatior.<a class="idl-code" data-link-type="attribute" href="#dom-navigator-credentials" id="ref-for-dom-navigator-credentials⑤">credentials</a>.<a class="idl-code" data-link-type="method" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get①③">get</a>({
+  var c = await navigatior.<a class="idl-code" data-link-type="attribute" href="#dom-navigator-credentials" id="ref-for-dom-navigator-credentials⑤">credentials</a>.<a class="idl-code" data-link-type="method" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get①④">get</a>({
     ...,
     <a class="idl-code" data-link-type="dict-member" href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation①①">mediation</a>: '<a class="idl-code" data-link-type="enum-value" href="#dom-credentialmediationrequirement-required" id="ref-for-dom-credentialmediationrequirement-required④">required</a>'
   });
@@ -2119,17 +2123,15 @@ store user credentials for future use.</p>
   credentials are introduced, they will add to the dictionary so they can be passed into the
   creation method. See <a href="#implementation-extension">§7.2 Extension Points</a>, and the extensions introduced in this document: <a href="#passwordcredential-interface">§3.2 The PasswordCredential Interface</a> and <a href="#federatedcredential-interface">§4.1 The FederatedCredential Interface</a>.</p>
 <pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-credentialcreationoptions"><code>CredentialCreationOptions</code></dfn> {
-  <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#abortsignal" id="ref-for-abortsignal②">AbortSignal</a> <a class="nv idl-code" data-link-type="dict-member" data-type="AbortSignal " href="#dom-credentialcreationoptions-signal" id="ref-for-dom-credentialcreationoptions-signal">signal</a>;
+  <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#abortsignal" id="ref-for-abortsignal③">AbortSignal</a> <a class="nv idl-code" data-link-type="dict-member" data-type="AbortSignal " href="#dom-credentialcreationoptions-signal" id="ref-for-dom-credentialcreationoptions-signal">signal</a>;
 };
 </pre>
     <div>
      <dl>
-      <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="CredentialCreationOptions" data-dfn-type="dict-member" data-export="" id="dom-credentialcreationoptions-signal"><code>signal</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#abortsignal" id="ref-for-abortsignal③">AbortSignal</a></span>
+      <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="CredentialCreationOptions" data-dfn-type="dict-member" data-export="" id="dom-credentialcreationoptions-signal"><code>signal</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#abortsignal" id="ref-for-abortsignal④">AbortSignal</a></span>
       <dd data-md="">
-       <p>This property lets the developer abort an ongoing <code class="idl"><a data-link-type="idl" href="#dom-credential-create-slot" id="ref-for-dom-credential-create-slot①">[[Create]](options)</a></code> operation
-  and susquently all related <a data-link-type="dfn">authenticatorMakeCredential</a> operations. An aborted operation 
-  may complete successfully (if the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#abortsignal-aborted-flag" id="ref-for-abortsignal-aborted-flag">aborted flag</a> was set after the operation completed) 
-  or be rejected with an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#aborterror" id="ref-for-aborterror">AbortError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException">DOMException</a></code>.</p>
+       <p>This property lets the developer abort an ongoing <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-create" id="ref-for-dom-credentialscontainer-create④">create()</a></code> operation. An aborted operation may complete normally (generally if the abort was received
+  after the operation finished) or reject with an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#aborterror" id="ref-for-aborterror①">AbortError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException①">DOMException</a></code>."</p>
      </dl>
     </div>
     <h3 class="heading settled" data-level="2.5" id="algorithms"><span class="secno">2.5. </span><span class="content">Algorithms</span><a class="self-link" href="#algorithms"></a></h3>
@@ -2150,6 +2152,8 @@ store user credentials for future use.</p>
        <li data-md="">
         <p><var>settings</var>’ <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document" id="ref-for-responsible-document①">responsible document</a> is not the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document">active document</a> in a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context" id="ref-for-top-level-browsing-context">top-level browsing context</a>.</p>
       </ol>
+     <li data-md="">
+      <p>If <code><var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-credentialrequestoptions-signal" id="ref-for-dom-credentialrequestoptions-signal①">signal</a></code></code>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#abortsignal-aborted-flag" id="ref-for-abortsignal-aborted-flag">aborted flag</a> is set, then return <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#a-promise-rejected-with" id="ref-for-a-promise-rejected-with①">a promise rejected with</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#aborterror" id="ref-for-aborterror②">AbortError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException②">DOMException</a></code>.</p>
      <li data-md="">
       <p>Let <var>p</var> be <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#a-new-promise" id="ref-for-a-new-promise">a new promise</a>.</p>
      <li data-md="">
@@ -2189,7 +2193,7 @@ store user credentials for future use.</p>
        <li data-md="">
         <p class="assertion">Assert: <var>choice</var> is an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object⑧">interface object</a>.</p>
        <li data-md="">
-        <p>Let <var>result</var> be the result of executing <var>choice</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credential-discoverfromexternalsource-slot" id="ref-for-dom-credential-discoverfromexternalsource-slot②">[[DiscoverFromExternalSource]](options)</a></code>, given <var>options</var>.</p>
+        <p>Let <var>result</var> be the result of executing <var>choice</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credential-discoverfromexternalsource-slot" id="ref-for-dom-credential-discoverfromexternalsource-slot">[[DiscoverFromExternalSource]](options)</a></code>, given <var>options</var>.</p>
        <li data-md="">
         <p>If <var>result</var> is a <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential②⑨">Credential</a></code> or <code>null</code>, resolve <var>p</var> with <var>result</var>.</p>
         <p>Otherwise, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#reject-promise" id="ref-for-reject-promise①">reject</a> <var>p</var> with <var>result</var>.</p>
@@ -2231,7 +2235,7 @@ store user credentials for future use.</p>
      <li data-md="">
       <p class="assertion">Assert: <var>settings</var> is a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-contexts" id="ref-for-secure-contexts②">secure context</a>.</p>
      <li data-md="">
-      <p>Return <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#a-promise-rejected-with" id="ref-for-a-promise-rejected-with①">a promise rejected with</a> <code>NotSupportedError</code> if any of the following statements
+      <p>Return <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#a-promise-rejected-with" id="ref-for-a-promise-rejected-with②">a promise rejected with</a> <code>NotSupportedError</code> if any of the following statements
   are true:</p>
       <ol>
        <li data-md="">
@@ -2264,7 +2268,7 @@ store user credentials for future use.</p>
      <li data-md="">
       <p>Let <var>interfaces</var> be the set of <var>options</var>’ <a data-link-type="dfn" href="#credentialrequestoptions-relevant-credential-interface-objects" id="ref-for-credentialrequestoptions-relevant-credential-interface-objects②">relevant credential interface objects</a>.</p>
      <li data-md="">
-      <p>Return <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#a-promise-rejected-with" id="ref-for-a-promise-rejected-with②">a promise rejected with</a> <code>NotSupportedError</code> if any of the following statements
+      <p>Return <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#a-promise-rejected-with" id="ref-for-a-promise-rejected-with③">a promise rejected with</a> <code>NotSupportedError</code> if any of the following statements
   are true:</p>
       <ol>
        <li data-md="">
@@ -2279,12 +2283,15 @@ store user credentials for future use.</p>
   on that by restricting the dictionary to a single entry.</p>
       </ol>
      <li data-md="">
+      <p>If <code><var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-credentialcreationoptions-signal" id="ref-for-dom-credentialcreationoptions-signal①">signal</a></code></code>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#abortsignal-aborted-flag" id="ref-for-abortsignal-aborted-flag①">aborted
+  flag</a> is set, then return <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#a-promise-rejected-with" id="ref-for-a-promise-rejected-with④">a promise rejected with</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#aborterror" id="ref-for-aborterror③">AbortError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException③">DOMException</a></code>.</p>
+     <li data-md="">
       <p>Let <var>p</var> be <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#a-new-promise" id="ref-for-a-new-promise②">a new promise</a>.</p>
      <li data-md="">
       <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel②">in parallel</a>:</p>
       <ol>
        <li data-md="">
-        <p>Let <var>r</var> be the result of executing <var>interfaces</var>[0] <code class="idl"><a data-link-type="idl" href="#dom-credential-create-slot" id="ref-for-dom-credential-create-slot②">[[Create]](options)</a></code> internal method on <var>options</var>.</p>
+        <p>Let <var>r</var> be the result of executing <var>interfaces</var>[0] <code class="idl"><a data-link-type="idl" href="#dom-credential-create-slot" id="ref-for-dom-credential-create-slot">[[Create]](options)</a></code> internal method on <var>options</var>.</p>
        <li data-md="">
         <p>If <var>r</var> is an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception" id="ref-for-dfn-exception②">exception</a>, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#reject-promise" id="ref-for-reject-promise②">reject</a> <var>p</var> with <var>r</var>.</p>
         <p>Otherwise, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#resolve-promise" id="ref-for-resolve-promise③">resolve</a> <var>p</var> with <var>r</var>.</p>
@@ -2321,10 +2328,10 @@ store user credentials for future use.</p>
     <h3 class="heading settled" data-level="3.1" id="password-examples"><span class="secno">3.1. </span><span class="content">Examples</span><a class="self-link" href="#password-examples"></a></h3>
     <h4 class="heading settled" data-level="3.1.1" id="examples-password-signin"><span class="secno">3.1.1. </span><span class="content">Password-based Sign-in</span><a class="self-link" href="#examples-password-signin"></a></h4>
     <div class="example" id="example-9d459b26">
-     <a class="self-link" href="#example-9d459b26"></a> MegaCorp, Inc. supports passwords, and can use <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get①④">navigator.credentials.get()</a></code> to obtain
+     <a class="self-link" href="#example-9d459b26"></a> MegaCorp, Inc. supports passwords, and can use <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get①⑤">navigator.credentials.get()</a></code> to obtain
     username/password pairs from a user’s <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store①②">credential store</a>: 
 <pre>navigator.<a class="idl-code" data-link-type="attribute" href="#dom-navigator-credentials" id="ref-for-dom-navigator-credentials⑥">credentials</a>
-  .<a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get①⑤">get</a>({ '<a class="idl-code" data-link-type="dict-member" href="#dom-credentialrequestoptions-password" id="ref-for-dom-credentialrequestoptions-password">password</a>': true })
+  .<a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get①⑥">get</a>({ '<a class="idl-code" data-link-type="dict-member" href="#dom-credentialrequestoptions-password" id="ref-for-dom-credentialrequestoptions-password">password</a>': true })
   .then(credential => {
     if (!credential) {
       // The user either doesn’t have credentials for this site, or
@@ -2358,7 +2365,7 @@ store user credentials for future use.</p>
 </pre>
      <p>Alternatively, the website could just copy the credential data into a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/forms.html#the-form-element" id="ref-for-the-form-element">form</a></code> and call <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/forms.html#dom-form-submit" id="ref-for-dom-form-submit">submit()</a></code> on the form:</p>
 <pre>navigator.<a class="idl-code" data-link-type="attribute" href="#dom-navigator-credentials" id="ref-for-dom-navigator-credentials⑧">credentials</a>
-  .<a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get①⑥">get</a>({ '<a class="idl-code" data-link-type="dict-member" href="#dom-credentialrequestoptions-password" id="ref-for-dom-credentialrequestoptions-password①">password</a>': true })
+  .<a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get①⑦">get</a>({ '<a class="idl-code" data-link-type="dict-member" href="#dom-credentialrequestoptions-password" id="ref-for-dom-credentialrequestoptions-password①">password</a>': true })
   .then(credential => {
     if (!credential) {
       return; // as above...
@@ -2382,7 +2389,7 @@ store user credentials for future use.</p>
   credentials from <code>https://m.example.com</code> when signing into <code>https://www.example.com</code> (as
   described in <a href="#security-credential-access">§6.1 Cross-domain credential access</a>), or it might allow a user to create a new
   credential on the fly. Developers can deal gracefully with this uncertainty by calling <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-store" id="ref-for-dom-credentialscontainer-store⑦">store()</a></code> every time credentials are successfully used, even right after
-  credentials have been retrieved from <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get①⑦">get()</a></code>: if the credentials aren’t
+  credentials have been retrieved from <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get①⑧">get()</a></code>: if the credentials aren’t
   yet stored for the origin, the user will be given the opportunity to do so. If they are stored,
   the user won’t be prompted.</p>
     <h4 class="heading settled" data-level="3.1.2" id="examples-post-signin"><span class="secno">3.1.2. </span><span class="content">Post-sign-in Confirmation</span><a class="self-link" href="#examples-post-signin"></a></h4>
@@ -2522,7 +2529,7 @@ store user credentials for future use.</p>
        </ol>
      </dl>
     </div>
-    <p><code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential⑦">PasswordCredential</a></code> objects can be created via <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-create" id="ref-for-dom-credentialscontainer-create④">navigator.credentials.create()</a></code> either explicitly by passing in a <code class="idl"><a data-link-type="idl" href="#dictdef-passwordcredentialdata" id="ref-for-dictdef-passwordcredentialdata②">PasswordCredentialData</a></code> dictionary, or based on the contents
+    <p><code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential⑦">PasswordCredential</a></code> objects can be created via <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-create" id="ref-for-dom-credentialscontainer-create⑤">navigator.credentials.create()</a></code> either explicitly by passing in a <code class="idl"><a data-link-type="idl" href="#dictdef-passwordcredentialdata" id="ref-for-dictdef-passwordcredentialdata②">PasswordCredentialData</a></code> dictionary, or based on the contents
   of an <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/forms.html#htmlformelement" id="ref-for-htmlformelement④">HTMLFormElement</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/forms.html#category-submit" id="ref-for-category-submit">submittable elements</a>.</p>
 <pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-passwordcredentialdata"><code>PasswordCredentialData</code></dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-credentialdata" id="ref-for-dictdef-credentialdata">CredentialData</a> {
   <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑨"><span class="kt">USVString</span></a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="PasswordCredentialData" data-dfn-type="dict-member" data-export="" data-type="USVString " id="dom-passwordcredentialdata-name"><code>name</code></dfn>;
@@ -2537,7 +2544,7 @@ store user credentials for future use.</p>
 };
 </pre>
     <p><code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential⑧">PasswordCredential</a></code> objects are <a data-link-type="dfn" href="#credential-origin-bound" id="ref-for-credential-origin-bound">origin bound</a>.</p>
-    <p><code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential⑨">PasswordCredential</a></code>'s <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object①③">interface object</a> inherits <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential③⑥">Credential</a></code>'s implementation of <code class="idl"><a data-link-type="idl" href="#dom-credential-discoverfromexternalsource-slot" id="ref-for-dom-credential-discoverfromexternalsource-slot③">[[DiscoverFromExternalSource]](options)</a></code>, and defines its own implementation of <code class="idl"><a data-link-type="idl" href="#dom-passwordcredential-collectfromcredentialstore-slot" id="ref-for-dom-passwordcredential-collectfromcredentialstore-slot">[[CollectFromCredentialStore]](options)</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-passwordcredential-create-slot" id="ref-for-dom-passwordcredential-create-slot">[[Create]](options)</a></code>, and <code class="idl"><a data-link-type="idl" href="#dom-passwordcredential-store-slot" id="ref-for-dom-passwordcredential-store-slot">[[Store]](credential)</a></code>.</p>
+    <p><code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential⑨">PasswordCredential</a></code>'s <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object①③">interface object</a> inherits <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential③⑥">Credential</a></code>'s implementation of <code class="idl"><a data-link-type="idl" href="#dom-credential-discoverfromexternalsource-slot" id="ref-for-dom-credential-discoverfromexternalsource-slot①">[[DiscoverFromExternalSource]](options)</a></code>, and defines its own implementation of <code class="idl"><a data-link-type="idl" href="#dom-passwordcredential-collectfromcredentialstore-slot" id="ref-for-dom-passwordcredential-collectfromcredentialstore-slot">[[CollectFromCredentialStore]](options)</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-passwordcredential-create-slot" id="ref-for-dom-passwordcredential-create-slot">[[Create]](options)</a></code>, and <code class="idl"><a data-link-type="idl" href="#dom-passwordcredential-store-slot" id="ref-for-dom-passwordcredential-store-slot">[[Store]](credential)</a></code>.</p>
     <h3 class="heading settled" data-level="3.3" id="passwordcredential-algorithms"><span class="secno">3.3. </span><span class="content">Algorithms</span><a class="self-link" href="#passwordcredential-algorithms"></a></h3>
     <h4 class="heading settled algorithm" data-algorithm="PasswordCredential&apos;s [[CollectFromCredentialStore]](options)" data-level="3.3.1" id="collectfromcredentialstore-passwordcredential"><span class="secno">3.3.1. </span><span class="content"> <code>PasswordCredential</code>'s <code>[[CollectFromCredentialStore]](options)</code> </span><a class="self-link" href="#collectfromcredentialstore-passwordcredential"></a></h4>
     <p><dfn class="dfn-paneled idl-code" data-dfn-for="PasswordCredential" data-dfn-type="method" data-export="" id="dom-passwordcredential-collectfromcredentialstore-slot"><code>[[CollectFromCredentialStore]](options)</code></dfn> is called
@@ -2727,7 +2734,7 @@ store user credentials for future use.</p>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="CredentialRequestOptions Matching for PasswordCredential" data-level="3.3.6" id="passwordcredential-matching"><span class="secno">3.3.6. </span><span class="content"> <code>CredentialRequestOptions</code> Matching for <code>PasswordCredential</code> </span><a class="self-link" href="#passwordcredential-matching"></a></h4>
     <p>Given a <code class="idl"><a data-link-type="idl" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions①②">CredentialRequestOptions</a></code> (<var>options</var>), the following algorithm returns "<code>Matches</code>" if
-  the <code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential①⑧">PasswordCredential</a></code> should be available as a response to a <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get①⑧">get()</a></code> request, and "<code>Does Not Match</code>" otherwise.</p>
+  the <code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential①⑧">PasswordCredential</a></code> should be available as a response to a <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get①⑨">get()</a></code> request, and "<code>Does Not Match</code>" otherwise.</p>
     <ol>
      <li data-md="">
       <p>If <var>options</var> has a <code class="idl"><a data-link-type="idl" href="#dom-credentialrequestoptions-password" id="ref-for-dom-credentialrequestoptions-password④">password</a></code> member whose value is <code>true</code>, then
@@ -2787,7 +2794,7 @@ store user credentials for future use.</p>
      </dl>
     </div>
     <p><code class="idl"><a data-link-type="idl" href="#federatedcredential" id="ref-for-federatedcredential④">FederatedCredential</a></code> objects can be created by passing a <code class="idl"><a data-link-type="idl" href="#dictdef-federatedcredentialinit" id="ref-for-dictdef-federatedcredentialinit②">FederatedCredentialInit</a></code> dictionary
-  into <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-create" id="ref-for-dom-credentialscontainer-create⑤">navigator.credentials.create()</a></code>.</p>
+  into <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-create" id="ref-for-dom-credentialscontainer-create⑥">navigator.credentials.create()</a></code>.</p>
 <pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-federatedcredentialinit"><code>FederatedCredentialInit</code></dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-credentialdata" id="ref-for-dictdef-credentialdata①">CredentialData</a> {
   <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①⑤"><span class="kt">USVString</span></a> <dfn class="nv idl-code" data-dfn-for="FederatedCredentialInit" data-dfn-type="dict-member" data-export="" data-type="USVString " id="dom-federatedcredentialinit-name"><code>name</code><a class="self-link" href="#dom-federatedcredentialinit-name"></a></dfn>;
   <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①⑥"><span class="kt">USVString</span></a> <dfn class="nv idl-code" data-dfn-for="FederatedCredentialInit" data-dfn-type="dict-member" data-export="" data-type="USVString " id="dom-federatedcredentialinit-iconurl"><code>iconURL</code><a class="self-link" href="#dom-federatedcredentialinit-iconurl"></a></dfn>;
@@ -2800,7 +2807,7 @@ store user credentials for future use.</p>
 };
 </pre>
     <p><code class="idl"><a data-link-type="idl" href="#federatedcredential" id="ref-for-federatedcredential⑤">FederatedCredential</a></code> objects are <a data-link-type="dfn" href="#credential-origin-bound" id="ref-for-credential-origin-bound①">origin bound</a>.</p>
-    <p><code class="idl"><a data-link-type="idl" href="#federatedcredential" id="ref-for-federatedcredential⑥">FederatedCredential</a></code>'s <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object①⑥">interface object</a> inherits <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential④⓪">Credential</a></code>'s implementation of <code class="idl"><a data-link-type="idl" href="#dom-credential-discoverfromexternalsource-slot" id="ref-for-dom-credential-discoverfromexternalsource-slot④">[[DiscoverFromExternalSource]](options)</a></code>, and defines its own implementation of <code class="idl"><a data-link-type="idl" href="#dom-federatedcredential-collectfromcredentialstore-slot" id="ref-for-dom-federatedcredential-collectfromcredentialstore-slot">[[CollectFromCredentialStore]](options)</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-federatedcredential-create-slot" id="ref-for-dom-federatedcredential-create-slot">[[Create]](options)</a></code>, and <code class="idl"><a data-link-type="idl" href="#dom-federatedcredential-store-slot" id="ref-for-dom-federatedcredential-store-slot">[[Store]](credential)</a></code>.</p>
+    <p><code class="idl"><a data-link-type="idl" href="#federatedcredential" id="ref-for-federatedcredential⑥">FederatedCredential</a></code>'s <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object①⑥">interface object</a> inherits <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential④⓪">Credential</a></code>'s implementation of <code class="idl"><a data-link-type="idl" href="#dom-credential-discoverfromexternalsource-slot" id="ref-for-dom-credential-discoverfromexternalsource-slot②">[[DiscoverFromExternalSource]](options)</a></code>, and defines its own implementation of <code class="idl"><a data-link-type="idl" href="#dom-federatedcredential-collectfromcredentialstore-slot" id="ref-for-dom-federatedcredential-collectfromcredentialstore-slot">[[CollectFromCredentialStore]](options)</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-federatedcredential-create-slot" id="ref-for-dom-federatedcredential-create-slot">[[Create]](options)</a></code>, and <code class="idl"><a data-link-type="idl" href="#dom-federatedcredential-store-slot" id="ref-for-dom-federatedcredential-store-slot">[[Store]](credential)</a></code>.</p>
     <p class="note" role="note"><span>Note:</span> If, in the future, we teach the user agent to obtain authentication tokens on a user’s
   behalf, we could do so by building an implementation of <code>[[DiscoverFromExternalSource]](options)</code>.</p>
     <h4 class="heading settled" data-level="4.1.1" id="provider-identification"><span class="secno">4.1.1. </span><span class="content">Identifying Providers</span><a class="self-link" href="#provider-identification"></a></h4>
@@ -2973,7 +2980,7 @@ store user credentials for future use.</p>
   agent MUST set the <a data-link-type="dfn" href="#origin-prevent-silent-access-flag" id="ref-for-origin-prevent-silent-access-flag⑦"><code>prevent silent access</code> flag</a> to <code>true</code> for that origin.</p>
     </ol>
     <h3 class="heading settled" data-level="5.3" id="user-mediated-selection"><span class="secno">5.3. </span><span class="content">Credential Selection</span><a class="self-link" href="#user-mediated-selection"></a></h3>
-    <p>When responding to a call to <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get①⑨">get()</a></code> on an origin which requires <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated①③">user mediation</a>, user agents MUST ask the user for permission to share credential information.
+    <p>When responding to a call to <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get②⓪">get()</a></code> on an origin which requires <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated①③">user mediation</a>, user agents MUST ask the user for permission to share credential information.
   This SHOULD take the form of a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="credential-chooser">credential chooser</dfn> which presents the user with a
   list of credentials that are available for use on a site, allowing them to select one which should
   be provided to the website, or to reject the request entirely.</p>
@@ -3031,9 +3038,9 @@ store user credentials for future use.</p>
      <li data-md="">
       <p>MAY use the Public Suffix List <a data-link-type="biblio" href="#biblio-psl">[PSL]</a> to determine the effective scope of a credential by
   comparing the <a data-link-type="dfn" href="https://publicsuffix.org/list/#">registerable domain</a> of the credential’s <code class="idl"><a data-link-type="idl" href="#dom-credential-origin-slot" id="ref-for-dom-credential-origin-slot①②">[[origin]]</a></code> with the
-  origin in which <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get②⓪">get()</a></code> is called. That is: credentials saved on <code>https://admin.example.com/</code> and <code>https://example.com/</code> MAY be offered to users when <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get②①">get()</a></code> is called from <code>https://www.example.com/</code>, and vice versa.</p>
+  origin in which <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get②①">get()</a></code> is called. That is: credentials saved on <code>https://admin.example.com/</code> and <code>https://example.com/</code> MAY be offered to users when <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get②②">get()</a></code> is called from <code>https://www.example.com/</code>, and vice versa.</p>
      <li data-md="">
-      <p>MUST NOT offer credentials to an origin in response to <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get②②">get()</a></code> without <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated①④">user mediation</a> if the credential’s origin is not an exact match for the calling origin.
+      <p>MUST NOT offer credentials to an origin in response to <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get②③">get()</a></code> without <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated①④">user mediation</a> if the credential’s origin is not an exact match for the calling origin.
   That is, <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential④⑧">Credential</a></code> objects for <code>https://example.com</code> would not be returned directly to <code>https://www.example.com</code>, but could be offered to the user via the chooser.</p>
     </ol>
     <h3 class="heading settled" data-level="6.2" id="security-leakage"><span class="secno">6.2. </span><span class="content">Credential Leakage</span><a class="self-link" href="#security-leakage"></a></h3>
@@ -3068,11 +3075,11 @@ store user credentials for future use.</p>
     <p>If framed pages have access to the APIs defined here, it might be possible to confuse a user into
   granting access to credentials for an origin other than the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context" id="ref-for-top-level-browsing-context③">top-level browsing context</a>,
   which is the only security origin which users can reasonably be expected to understand.</p>
-    <p>Therefore, both <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get②③">get()</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-store" id="ref-for-dom-credentialscontainer-store①③">store()</a></code> will result in a rejected <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-promise" id="ref-for-idl-promise⑤">Promise</a></code> when called from
+    <p>Therefore, both <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get②④">get()</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-store" id="ref-for-dom-credentialscontainer-store①③">store()</a></code> will result in a rejected <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-promise" id="ref-for-idl-promise⑤">Promise</a></code> when called from
   a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context">nested browsing context</a>, and the API and related interfaces are not exposed inside <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#worker" id="ref-for-worker">Worker</a></code> contexts.</p>
     <p>The algorithms in <a href="#algorithm-request">§2.5.1 Request a Credential</a> and <a href="#algorithm-store">§2.5.3 Store a Credential</a> contain more detail.</p>
     <h3 class="heading settled" data-level="6.5" id="security-timing"><span class="secno">6.5. </span><span class="content">Timing Attacks</span><a class="self-link" href="#security-timing"></a></h3>
-    <p>If the user has no credentials for an origin, a call to <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get②④">get()</a></code> will
+    <p>If the user has no credentials for an origin, a call to <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get②⑤">get()</a></code> will
   resolve very quickly indeed. A malicious website could distinguish between a user with no
   credentials and a user with credentials who chooses not to share them.</p>
     <p>User agents SHOULD also rate-limit credential requests. It’s almost certainly abusive for a page
@@ -3134,8 +3141,8 @@ interface ExampleCredential : Credential {
 </pre>
       </div>
      <li data-md="">
-      <p>Define appropriate <code class="idl"><a data-link-type="idl" href="#dom-credential-create-slot" id="ref-for-dom-credential-create-slot③">[[Create]](options)</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-credential-collectfromcredentialstore-slot" id="ref-for-dom-credential-collectfromcredentialstore-slot①">[[CollectFromCredentialStore]](options)</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-credential-discoverfromexternalsource-slot" id="ref-for-dom-credential-discoverfromexternalsource-slot⑤">[[DiscoverFromExternalSource]](options)</a></code>, and <code class="idl"><a data-link-type="idl" href="#dom-credential-store-slot" id="ref-for-dom-credential-store-slot①">[[Store]](credential)</a></code> methods on <code>ExampleCredential</code>'s <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object①⑧">interface object</a>. <code class="idl"><a data-link-type="idl" href="#dom-credential-collectfromcredentialstore-slot" id="ref-for-dom-credential-collectfromcredentialstore-slot②">[[CollectFromCredentialStore]](options)</a></code> is appropriate for <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential①⑦">credentials</a> that remain <a data-link-type="dfn" href="#credential-effective" id="ref-for-credential-effective③">effective</a> forever and
-  can therefore simply be copied out of the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store②⑥">credential store</a>, while <code class="idl"><a data-link-type="idl" href="#dom-credential-discoverfromexternalsource-slot" id="ref-for-dom-credential-discoverfromexternalsource-slot⑥">[[DiscoverFromExternalSource]](options)</a></code> is appropriate for <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential①⑧">credentials</a> that need to be re-generated from a <a data-link-type="dfn" href="#credential-source" id="ref-for-credential-source①">credential source</a>.</p>
+      <p>Define appropriate <code class="idl"><a data-link-type="idl" href="#dom-credential-create-slot" id="ref-for-dom-credential-create-slot①">[[Create]](options)</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-credential-collectfromcredentialstore-slot" id="ref-for-dom-credential-collectfromcredentialstore-slot①">[[CollectFromCredentialStore]](options)</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-credential-discoverfromexternalsource-slot" id="ref-for-dom-credential-discoverfromexternalsource-slot③">[[DiscoverFromExternalSource]](options)</a></code>, and <code class="idl"><a data-link-type="idl" href="#dom-credential-store-slot" id="ref-for-dom-credential-store-slot①">[[Store]](credential)</a></code> methods on <code>ExampleCredential</code>'s <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object①⑧">interface object</a>. <code class="idl"><a data-link-type="idl" href="#dom-credential-collectfromcredentialstore-slot" id="ref-for-dom-credential-collectfromcredentialstore-slot②">[[CollectFromCredentialStore]](options)</a></code> is appropriate for <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential①⑦">credentials</a> that remain <a data-link-type="dfn" href="#credential-effective" id="ref-for-credential-effective③">effective</a> forever and
+  can therefore simply be copied out of the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store②⑥">credential store</a>, while <code class="idl"><a data-link-type="idl" href="#dom-credential-discoverfromexternalsource-slot" id="ref-for-dom-credential-discoverfromexternalsource-slot④">[[DiscoverFromExternalSource]](options)</a></code> is appropriate for <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential①⑧">credentials</a> that need to be re-generated from a <a data-link-type="dfn" href="#credential-source" id="ref-for-credential-source①">credential source</a>.</p>
       <div class="example" id="example-b597dd69">
        <a class="self-link" href="#example-b597dd69"></a> <code>ExampleCredential</code>'s <code>[[CollectFromCredentialStore]](options)</code> internal method is called
     with a CredentialRequestOptions object (<code>options</code>), and returns a set of <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential⑤③">Credential</a></code> objects that match the options provided. If no matching <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential⑤④">Credential</a></code> objects are
@@ -3163,7 +3170,7 @@ interface ExampleCredential : Credential {
     value is "<code class="idl"><a data-link-type="idl" href="#dom-credential-discovery-credential-store" id="ref-for-dom-credential-discovery-credential-store③">credential store</a></code>". </div>
      <li data-md="">
       <p>Extend <code class="idl"><a data-link-type="idl" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions①⑥">CredentialRequestOptions</a></code> with the options the new credential type needs to respond
-  reasonably to <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get②⑤">get()</a></code>:</p>
+  reasonably to <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get②⑥">get()</a></code>:</p>
       <div class="example" id="example-f0110d62">
        <a class="self-link" href="#example-f0110d62"></a> 
 <pre>dictionary ExampleCredentialRequestOptions {
@@ -3176,7 +3183,7 @@ partial dictionary CredentialRequestOptions {
 </pre>
       </div>
      <li data-md="">
-      <p>Extend <code class="idl"><a data-link-type="idl" href="#dictdef-credentialcreationoptions" id="ref-for-dictdef-credentialcreationoptions①⓪">CredentialCreationOptions</a></code> with the data the new credential type needs to create <code>Credential</code> objects in response to <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-create" id="ref-for-dom-credentialscontainer-create⑥">create()</a></code>:</p>
+      <p>Extend <code class="idl"><a data-link-type="idl" href="#dictdef-credentialcreationoptions" id="ref-for-dictdef-credentialcreationoptions①⓪">CredentialCreationOptions</a></code> with the data the new credential type needs to create <code>Credential</code> objects in response to <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-create" id="ref-for-dom-credentialscontainer-create⑦">create()</a></code>:</p>
       <div class="example" id="example-17ce7fc3">
        <a class="self-link" href="#example-17ce7fc3"></a> 
 <pre>dictionary ExampleCredentialInit {
@@ -3200,7 +3207,7 @@ partial dictionary CredentialCreationOptions {
   the behavior of third party credential management software in the same way
   that user agents can improve their own via this imperative approach.</p>
     <p>This could range from a complex new API that the user agent mediates, or
-  simply by allowing extensions to overwrite the <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get②⑥">get()</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-store" id="ref-for-dom-credentialscontainer-store①④">store()</a></code> endpoints for their own purposes.</p>
+  simply by allowing extensions to overwrite the <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get②⑦">get()</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-store" id="ref-for-dom-credentialscontainer-store①④">store()</a></code> endpoints for their own purposes.</p>
    </section>
    <section>
     <h2 class="heading settled" data-level="8" id="teh-futur"><span class="secno">8. </span><span class="content">Future Work</span><a class="self-link" href="#teh-futur"></a></h2>
@@ -3599,9 +3606,9 @@ partial dictionary CredentialCreationOptions {
 
 [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①①">Exposed</a>=<span class="n">Window</span>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext③①">SecureContext</a>]
 <span class="kt">interface</span> <a class="nv" href="#credentialscontainer"><code>CredentialsContainer</code></a> {
-  <span class="kt">Promise</span>&lt;<a class="n" data-link-type="idl-name" href="#credential" id="ref-for-credential②⓪①">Credential</a>?> <a class="nv idl-code" data-link-type="method" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get②⑦">get</a>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions②①">CredentialRequestOptions</a> <a class="nv idl-code" data-link-type="argument" href="#dom-credentialscontainer-get-options-options" id="ref-for-dom-credentialscontainer-get-options-options②">options</a>);
+  <span class="kt">Promise</span>&lt;<a class="n" data-link-type="idl-name" href="#credential" id="ref-for-credential②⓪①">Credential</a>?> <a class="nv idl-code" data-link-type="method" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get②⑧">get</a>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions②①">CredentialRequestOptions</a> <a class="nv idl-code" data-link-type="argument" href="#dom-credentialscontainer-get-options-options" id="ref-for-dom-credentialscontainer-get-options-options②">options</a>);
   <span class="kt">Promise</span>&lt;<a class="n" data-link-type="idl-name" href="#credential" id="ref-for-credential②①①">Credential</a>> <a class="nv idl-code" data-link-type="method" href="#dom-credentialscontainer-store" id="ref-for-dom-credentialscontainer-store①⑤">store</a>(<a class="n" data-link-type="idl-name" href="#credential" id="ref-for-credential②②①">Credential</a> <a class="nv idl-code" data-link-type="argument" href="#dom-credentialscontainer-store-credential-credential" id="ref-for-dom-credentialscontainer-store-credential-credential②">credential</a>);
-  <span class="kt">Promise</span>&lt;<a class="n" data-link-type="idl-name" href="#credential" id="ref-for-credential②③①">Credential</a>?> <a class="nv idl-code" data-link-type="method" href="#dom-credentialscontainer-create" id="ref-for-dom-credentialscontainer-create⑦">create</a>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-credentialcreationoptions" id="ref-for-dictdef-credentialcreationoptions①①">CredentialCreationOptions</a> <a class="nv idl-code" data-link-type="argument" href="#dom-credentialscontainer-create-options-options" id="ref-for-dom-credentialscontainer-create-options-options②">options</a>);
+  <span class="kt">Promise</span>&lt;<a class="n" data-link-type="idl-name" href="#credential" id="ref-for-credential②③①">Credential</a>?> <a class="nv idl-code" data-link-type="method" href="#dom-credentialscontainer-create" id="ref-for-dom-credentialscontainer-create⑧">create</a>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-credentialcreationoptions" id="ref-for-dictdef-credentialcreationoptions①①">CredentialCreationOptions</a> <a class="nv idl-code" data-link-type="argument" href="#dom-credentialscontainer-create-options-options" id="ref-for-dom-credentialscontainer-create-options-options②">options</a>);
   <span class="kt">Promise</span>&lt;<span class="kt">void</span>> <a class="nv idl-code" data-link-type="method" href="#dom-credentialscontainer-preventsilentaccess" id="ref-for-dom-credentialscontainer-preventsilentaccess④">preventSilentAccess</a>();
 };
 
@@ -3611,7 +3618,7 @@ partial dictionary CredentialCreationOptions {
 
 <span class="kt">dictionary</span> <a class="nv" href="#dictdef-credentialrequestoptions"><code>CredentialRequestOptions</code></a> {
   <a class="n" data-link-type="idl-name" href="#enumdef-credentialmediationrequirement" id="ref-for-enumdef-credentialmediationrequirement④">CredentialMediationRequirement</a> <a class="nv idl-code" data-default="&quot;optional&quot;" data-link-type="dict-member" data-type="CredentialMediationRequirement " href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation①⑤">mediation</a> = "optional";
-  <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#abortsignal" id="ref-for-abortsignal④">AbortSignal</a> <a class="nv idl-code" data-link-type="dict-member" data-type="AbortSignal " href="#dom-credentialrequestoptions-signal" id="ref-for-dom-credentialrequestoptions-signal①">signal</a>;
+  <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#abortsignal" id="ref-for-abortsignal①①">AbortSignal</a> <a class="nv idl-code" data-link-type="dict-member" data-type="AbortSignal " href="#dom-credentialrequestoptions-signal" id="ref-for-dom-credentialrequestoptions-signal②">signal</a>;
 };
 
 <span class="kt">enum</span> <a class="nv" href="#enumdef-credentialmediationrequirement"><code>CredentialMediationRequirement</code></a> {
@@ -3621,7 +3628,7 @@ partial dictionary CredentialCreationOptions {
 };
 
 <span class="kt">dictionary</span> <a class="nv" href="#dictdef-credentialcreationoptions"><code>CredentialCreationOptions</code></a> {
-  <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#abortsignal" id="ref-for-abortsignal②①">AbortSignal</a> <a class="nv idl-code" data-link-type="dict-member" data-type="AbortSignal " href="#dom-credentialcreationoptions-signal" id="ref-for-dom-credentialcreationoptions-signal①">signal</a>;
+  <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#abortsignal" id="ref-for-abortsignal③①">AbortSignal</a> <a class="nv idl-code" data-link-type="dict-member" data-type="AbortSignal " href="#dom-credentialcreationoptions-signal" id="ref-for-dom-credentialcreationoptions-signal②">signal</a>;
 };
 
 <span class="kt">typedef</span> (<a class="n" data-link-type="idl-name" href="https://xhr.spec.whatwg.org/#interface-formdata" id="ref-for-interface-formdata③">FormData</a> <span class="kt">or</span> <a class="n" data-link-type="idl-name" href="https://url.spec.whatwg.org/#urlsearchparams" id="ref-for-urlsearchparams①">URLSearchParams</a>) <a class="nv" href="#typedefdef-credentialbodytype"><code>CredentialBodyType</code></a>;
@@ -3884,12 +3891,10 @@ partial dictionary CredentialCreationOptions {
   <aside class="dfn-panel" data-for="dom-credential-discoverfromexternalsource-slot">
    <b><a href="#dom-credential-discoverfromexternalsource-slot">#dom-credential-discoverfromexternalsource-slot</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-credential-discoverfromexternalsource-slot">2.2.1. Credential Internal Methods</a>
-    <li><a href="#ref-for-dom-credential-discoverfromexternalsource-slot①">2.3.1. The CredentialRequestOptions Dictionary</a>
-    <li><a href="#ref-for-dom-credential-discoverfromexternalsource-slot②">2.5.1. Request a Credential</a>
-    <li><a href="#ref-for-dom-credential-discoverfromexternalsource-slot③">3.2. The PasswordCredential Interface</a>
-    <li><a href="#ref-for-dom-credential-discoverfromexternalsource-slot④">4.1. The FederatedCredential Interface</a>
-    <li><a href="#ref-for-dom-credential-discoverfromexternalsource-slot⑤">7.2. Extension Points</a> <a href="#ref-for-dom-credential-discoverfromexternalsource-slot⑥">(2)</a>
+    <li><a href="#ref-for-dom-credential-discoverfromexternalsource-slot">2.5.1. Request a Credential</a>
+    <li><a href="#ref-for-dom-credential-discoverfromexternalsource-slot①">3.2. The PasswordCredential Interface</a>
+    <li><a href="#ref-for-dom-credential-discoverfromexternalsource-slot②">4.1. The FederatedCredential Interface</a>
+    <li><a href="#ref-for-dom-credential-discoverfromexternalsource-slot③">7.2. Extension Points</a> <a href="#ref-for-dom-credential-discoverfromexternalsource-slot④">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-credential-store-slot">
@@ -3902,10 +3907,8 @@ partial dictionary CredentialCreationOptions {
   <aside class="dfn-panel" data-for="dom-credential-create-slot">
    <b><a href="#dom-credential-create-slot">#dom-credential-create-slot</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-credential-create-slot">2.2.1. Credential Internal Methods</a>
-    <li><a href="#ref-for-dom-credential-create-slot①">2.4. The CredentialCreationOptions Dictionary</a>
-    <li><a href="#ref-for-dom-credential-create-slot②">2.5.4. Create a Credential</a>
-    <li><a href="#ref-for-dom-credential-create-slot③">7.2. Extension Points</a>
+    <li><a href="#ref-for-dom-credential-create-slot">2.5.4. Create a Credential</a>
+    <li><a href="#ref-for-dom-credential-create-slot①">7.2. Extension Points</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="credentialuserdata">
@@ -3988,18 +3991,18 @@ partial dictionary CredentialCreationOptions {
    <b><a href="#dom-credentialscontainer-get">#dom-credentialscontainer-get</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credentialscontainer-get">2.3. navigator.credentials</a> <a href="#ref-for-dom-credentialscontainer-get①">(2)</a> <a href="#ref-for-dom-credentialscontainer-get②">(3)</a>
-    <li><a href="#ref-for-dom-credentialscontainer-get③">2.3.1. The CredentialRequestOptions Dictionary</a> <a href="#ref-for-dom-credentialscontainer-get④">(2)</a>
-    <li><a href="#ref-for-dom-credentialscontainer-get⑤">2.3.2. Mediation Requirements</a> <a href="#ref-for-dom-credentialscontainer-get⑥">(2)</a>
-    <li><a href="#ref-for-dom-credentialscontainer-get⑦">2.3.2.1. Examples</a> <a href="#ref-for-dom-credentialscontainer-get⑧">(2)</a> <a href="#ref-for-dom-credentialscontainer-get⑨">(3)</a> <a href="#ref-for-dom-credentialscontainer-get①⓪">(4)</a> <a href="#ref-for-dom-credentialscontainer-get①①">(5)</a> <a href="#ref-for-dom-credentialscontainer-get①②">(6)</a> <a href="#ref-for-dom-credentialscontainer-get①③">(7)</a>
-    <li><a href="#ref-for-dom-credentialscontainer-get①④">3.1.1. Password-based Sign-in</a> <a href="#ref-for-dom-credentialscontainer-get①⑤">(2)</a> <a href="#ref-for-dom-credentialscontainer-get①⑥">(3)</a> <a href="#ref-for-dom-credentialscontainer-get①⑦">(4)</a>
-    <li><a href="#ref-for-dom-credentialscontainer-get①⑧">3.3.6. 
+    <li><a href="#ref-for-dom-credentialscontainer-get③">2.3.1. The CredentialRequestOptions Dictionary</a> <a href="#ref-for-dom-credentialscontainer-get④">(2)</a> <a href="#ref-for-dom-credentialscontainer-get⑤">(3)</a>
+    <li><a href="#ref-for-dom-credentialscontainer-get⑥">2.3.2. Mediation Requirements</a> <a href="#ref-for-dom-credentialscontainer-get⑦">(2)</a>
+    <li><a href="#ref-for-dom-credentialscontainer-get⑧">2.3.2.1. Examples</a> <a href="#ref-for-dom-credentialscontainer-get⑨">(2)</a> <a href="#ref-for-dom-credentialscontainer-get①⓪">(3)</a> <a href="#ref-for-dom-credentialscontainer-get①①">(4)</a> <a href="#ref-for-dom-credentialscontainer-get①②">(5)</a> <a href="#ref-for-dom-credentialscontainer-get①③">(6)</a> <a href="#ref-for-dom-credentialscontainer-get①④">(7)</a>
+    <li><a href="#ref-for-dom-credentialscontainer-get①⑤">3.1.1. Password-based Sign-in</a> <a href="#ref-for-dom-credentialscontainer-get①⑥">(2)</a> <a href="#ref-for-dom-credentialscontainer-get①⑦">(3)</a> <a href="#ref-for-dom-credentialscontainer-get①⑧">(4)</a>
+    <li><a href="#ref-for-dom-credentialscontainer-get①⑨">3.3.6. 
     CredentialRequestOptions Matching for PasswordCredential </a>
-    <li><a href="#ref-for-dom-credentialscontainer-get①⑨">5.3. Credential Selection</a>
-    <li><a href="#ref-for-dom-credentialscontainer-get②⓪">6.1. Cross-domain credential access</a> <a href="#ref-for-dom-credentialscontainer-get②①">(2)</a> <a href="#ref-for-dom-credentialscontainer-get②②">(3)</a>
-    <li><a href="#ref-for-dom-credentialscontainer-get②③">6.4. Origin Confusion</a>
-    <li><a href="#ref-for-dom-credentialscontainer-get②④">6.5. Timing Attacks</a>
-    <li><a href="#ref-for-dom-credentialscontainer-get②⑤">7.2. Extension Points</a>
-    <li><a href="#ref-for-dom-credentialscontainer-get②⑥">7.3. Browser Extensions</a>
+    <li><a href="#ref-for-dom-credentialscontainer-get②⓪">5.3. Credential Selection</a>
+    <li><a href="#ref-for-dom-credentialscontainer-get②①">6.1. Cross-domain credential access</a> <a href="#ref-for-dom-credentialscontainer-get②②">(2)</a> <a href="#ref-for-dom-credentialscontainer-get②③">(3)</a>
+    <li><a href="#ref-for-dom-credentialscontainer-get②④">6.4. Origin Confusion</a>
+    <li><a href="#ref-for-dom-credentialscontainer-get②⑤">6.5. Timing Attacks</a>
+    <li><a href="#ref-for-dom-credentialscontainer-get②⑥">7.2. Extension Points</a>
+    <li><a href="#ref-for-dom-credentialscontainer-get②⑦">7.3. Browser Extensions</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-credentialscontainer-get-options-options">
@@ -4031,10 +4034,10 @@ partial dictionary CredentialCreationOptions {
    <b><a href="#dom-credentialscontainer-create">#dom-credentialscontainer-create</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credentialscontainer-create">2.3. navigator.credentials</a> <a href="#ref-for-dom-credentialscontainer-create①">(2)</a> <a href="#ref-for-dom-credentialscontainer-create②">(3)</a>
-    <li><a href="#ref-for-dom-credentialscontainer-create③">2.4. The CredentialCreationOptions Dictionary</a>
-    <li><a href="#ref-for-dom-credentialscontainer-create④">3.2. The PasswordCredential Interface</a>
-    <li><a href="#ref-for-dom-credentialscontainer-create⑤">4.1. The FederatedCredential Interface</a>
-    <li><a href="#ref-for-dom-credentialscontainer-create⑥">7.2. Extension Points</a>
+    <li><a href="#ref-for-dom-credentialscontainer-create③">2.4. The CredentialCreationOptions Dictionary</a> <a href="#ref-for-dom-credentialscontainer-create④">(2)</a>
+    <li><a href="#ref-for-dom-credentialscontainer-create⑤">3.2. The PasswordCredential Interface</a>
+    <li><a href="#ref-for-dom-credentialscontainer-create⑥">4.1. The FederatedCredential Interface</a>
+    <li><a href="#ref-for-dom-credentialscontainer-create⑦">7.2. Extension Points</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-credentialscontainer-create-options-options">
@@ -4084,6 +4087,7 @@ partial dictionary CredentialCreationOptions {
    <b><a href="#dom-credentialrequestoptions-signal">#dom-credentialrequestoptions-signal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credentialrequestoptions-signal">2.3.1. The CredentialRequestOptions Dictionary</a>
+    <li><a href="#ref-for-dom-credentialrequestoptions-signal①">2.5.1. Request a Credential</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="credentialrequestoptions-relevant-credential-interface-objects">
@@ -4155,6 +4159,7 @@ partial dictionary CredentialCreationOptions {
    <b><a href="#dom-credentialcreationoptions-signal">#dom-credentialcreationoptions-signal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credentialcreationoptions-signal">2.4. The CredentialCreationOptions Dictionary</a>
+    <li><a href="#ref-for-dom-credentialcreationoptions-signal①">2.5.4. Create a Credential</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="abstract-opdef-request-a-credential">

--- a/index.html
+++ b/index.html
@@ -1178,7 +1178,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 4679d5ca787d737883d9c905dd138257fc2cec85" name="generator">
   <link href="http://www.w3.org/TR/credential-management-1/" rel="canonical">
-  <meta content="81bb577ef1ee915328c4dd67f805343d24525a5a" name="document-revision">
+  <meta content="35220d6c86ebcb937a7121816ef9b06176485cb5" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1425,7 +1425,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Credential Management Level 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-10-30">30 October 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-11-01">1 November 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1946,7 +1946,7 @@ store user credentials for future use.</p>
   Processing details are defined in <a href="#algorithm-request">§2.5.1 Request a Credential</a>.</p>
       <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="CredentialRequestOptions" data-dfn-type="dict-member" data-export="" id="dom-credentialrequestoptions-signal"><code>signal</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#abortsignal" id="ref-for-abortsignal①">AbortSignal</a></span>
       <dd data-md="">
-       <p>This property allow the developer to abort an ongoing <code class="idl"><a data-link-type="idl" href="#dom-credential-discoverfromexternalsource-slot" id="ref-for-dom-credential-discoverfromexternalsource-slot①">[[DiscoverFromExternalSource]](options)</a></code> operation and subequently all related <a data-link-type="dfn">authenticatorGetAssertion</a> operations. Aborted romise would 
+       <p>This property lets the developer abort an ongoing <code class="idl"><a data-link-type="idl" href="#dom-credential-discoverfromexternalsource-slot" id="ref-for-dom-credential-discoverfromexternalsource-slot①">[[DiscoverFromExternalSource]](options)</a></code> operation and subsequently all related <a data-link-type="dfn">authenticatorGetAssertion</a> operations. Aborted promise would 
   be rejected with an "AbortError" DOMException.</p>
      </dl>
     </div>
@@ -2126,9 +2126,10 @@ store user credentials for future use.</p>
      <dl>
       <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="CredentialCreationOptions" data-dfn-type="dict-member" data-export="" id="dom-credentialcreationoptions-signal"><code>signal</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#abortsignal" id="ref-for-abortsignal③">AbortSignal</a></span>
       <dd data-md="">
-       <p>This property allow the developer to abort an ongoing <code class="idl"><a data-link-type="idl" href="#dom-credential-create-slot" id="ref-for-dom-credential-create-slot①">[[Create]](options)</a></code> operation
-  and susquently all related <a data-link-type="dfn">authenticatorMakeCredential</a> operations. Aborted romise would 
-  be rejected with an "AbortError" DOMException.</p>
+       <p>This property lets the developer abort an ongoing <code class="idl"><a data-link-type="idl" href="#dom-credential-create-slot" id="ref-for-dom-credential-create-slot①">[[Create]](options)</a></code> operation
+  and susquently all related <a data-link-type="dfn">authenticatorMakeCredential</a> operations. An aborted operation 
+  may complete successfully (if the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#abortsignal-aborted-flag" id="ref-for-abortsignal-aborted-flag">aborted flag</a> was set after the operation completed) 
+  or be rejected with an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#aborterror" id="ref-for-aborterror">AbortError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException">DOMException</a></code>.</p>
      </dl>
     </div>
     <h3 class="heading settled" data-level="2.5" id="algorithms"><span class="secno">2.5. </span><span class="content">Algorithms</span><a class="self-link" href="#algorithms"></a></h3>
@@ -3417,6 +3418,7 @@ partial dictionary CredentialCreationOptions {
     <a data-link-type="biblio">[DOM]</a> defines the following terms:
     <ul>
      <li><a href="https://dom.spec.whatwg.org/#abortsignal">AbortSignal</a>
+     <li><a href="https://dom.spec.whatwg.org/#abortsignal-aborted-flag">aborted flag</a>
      <li><a href="https://dom.spec.whatwg.org/#context-object">context object</a>
      <li><a href="https://dom.spec.whatwg.org/#concept-tree-order">tree order</a>
     </ul>
@@ -3505,6 +3507,8 @@ partial dictionary CredentialCreationOptions {
    <li>
     <a data-link-type="biblio">[WebIDL]</a> defines the following terms:
     <ul>
+     <li><a href="https://heycam.github.io/webidl/#aborterror">AbortError</a>
+     <li><a href="https://heycam.github.io/webidl/#idl-DOMException">DOMException</a>
      <li><a href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a>
      <li><a href="https://heycam.github.io/webidl/#Exposed">Exposed</a>
      <li><a href="https://heycam.github.io/webidl/#NoInterfaceObject">NoInterfaceObject</a>

--- a/index.html
+++ b/index.html
@@ -1178,7 +1178,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 4679d5ca787d737883d9c905dd138257fc2cec85" name="generator">
   <link href="http://www.w3.org/TR/credential-management-1/" rel="canonical">
-  <meta content="56cd1580b6cfbe9bbaef88a8997d991f02c24c60" name="document-revision">
+  <meta content="8c467830744d60c72780cee38eb2fadb3c24c7cc" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1425,7 +1425,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Credential Management Level 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-11-01">1 November 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-11-02">2 November 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -3113,7 +3113,7 @@ store user credentials for future use.</p>
   origin, and SHOULD make it easy for users to remove such data when they’re no longer interested in
   keeping it around.</p>
    </section>
-   <section>
+   <section class="non-normative">
     <h2 class="heading settled" data-level="7" id="implementation"><span class="secno">7. </span><span class="content">Implementation Considerations</span><a class="self-link" href="#implementation"></a></h2>
     <p><em>This section is non-normative.</em></p>
     <h3 class="heading settled" data-level="7.1" id="implementation-authors"><span class="secno">7.1. </span><span class="content">Website Authors</span><a class="self-link" href="#implementation-authors"></a></h3>
@@ -3573,8 +3573,6 @@ partial dictionary CredentialCreationOptions {
    <dd>Mike West. <a href="https://www.w3.org/TR/secure-contexts/">Secure Contexts</a>. 15 September 2016. CR. URL: <a href="https://www.w3.org/TR/secure-contexts/">https://www.w3.org/TR/secure-contexts/</a>
    <dt id="biblio-url">[URL]
    <dd>Anne van Kesteren. <a href="https://url.spec.whatwg.org/">URL Standard</a>. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
-   <dt id="biblio-webauthn">[WEBAUTHN]
-   <dd>Vijay Bharadwaj; et al. <a href="https://www.w3.org/TR/webauthn/">Web Authentication: An API for accessing Public Key Credentials Level 1</a>. 11 August 2017. WD. URL: <a href="https://www.w3.org/TR/webauthn/">https://www.w3.org/TR/webauthn/</a>
    <dt id="biblio-webidl">[WebIDL]
    <dd>Cameron McCormack; Boris Zbarsky; Tobie Langel. <a href="https://heycam.github.io/webidl/">Web IDL</a>. 15 December 2016. ED. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
    <dt id="biblio-xhr">[XHR]
@@ -3588,6 +3586,8 @@ partial dictionary CredentialCreationOptions {
    <dd>Devdatta Akhawe; et al. <a href="https://www.w3.org/TR/SRI/">Subresource Integrity</a>. 23 June 2016. REC. URL: <a href="https://www.w3.org/TR/SRI/">https://www.w3.org/TR/SRI/</a>
    <dt id="biblio-web-login">[WEB-LOGIN]
    <dd>Jason Denizac; Robin Berjon; Anne van Kesteren. <a href="https://github.com/jden/web-login">web-login</a>. URL: <a href="https://github.com/jden/web-login">https://github.com/jden/web-login</a>
+   <dt id="biblio-webauthn">[WEBAUTHN]
+   <dd>Vijay Bharadwaj; et al. <a href="https://www.w3.org/TR/webauthn/">Web Authentication: An API for accessing Public Key Credentials Level 1</a>. 11 August 2017. WD. URL: <a href="https://www.w3.org/TR/webauthn/">https://www.w3.org/TR/webauthn/</a>
    <dt id="biblio-webmessaging">[WEBMESSAGING]
    <dd>Ian Hickson. <a href="https://www.w3.org/TR/webmessaging/">HTML5 Web Messaging</a>. 19 May 2015. REC. URL: <a href="https://www.w3.org/TR/webmessaging/">https://www.w3.org/TR/webmessaging/</a>
    <dt id="biblio-xmlhttprequest">[XMLHTTPREQUEST]

--- a/index.html
+++ b/index.html
@@ -1178,7 +1178,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 4679d5ca787d737883d9c905dd138257fc2cec85" name="generator">
   <link href="http://www.w3.org/TR/credential-management-1/" rel="canonical">
-  <meta content="a568516f39b8d5707ce16d4151f457eef1bbfe03" name="document-revision">
+  <meta content="56cd1580b6cfbe9bbaef88a8997d991f02c24c60" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1763,10 +1763,7 @@ store user credentials for future use.</p>
     <p>Some <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential⑤">Credential</a></code> objects are <dfn class="dfn-paneled" data-dfn-for="Credential" data-dfn-type="dfn" data-noexport="" id="credential-origin-bound">origin bound</dfn>: these contain an
   internal slot named <dfn class="dfn-paneled idl-code" data-dfn-for="Credential" data-dfn-type="attribute" data-export="" id="dom-credential-origin-slot"><code>[[origin]]</code></dfn>, which stores the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin②">origin</a> for which the <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential⑥">Credential</a></code> may be <a data-link-type="dfn" href="#credential-effective" id="ref-for-credential-effective①">effective</a>.</p>
     <h4 class="heading settled" data-level="2.2.1" id="credential-internal-methods"><span class="secno">2.2.1. </span><span class="content"><code>Credential</code> Internal Methods</span><a class="self-link" href="#credential-internal-methods"></a></h4>
-    <p>Each <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object④">interface object</a> created for interfaces which <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherit" id="ref-for-dfn-inherit①">inherit</a> from <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential⑦">Credential</a></code> defines several internal methods that allow retrieval and storage of <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential⑧">Credential</a></code> objects. The
-  methods taking an <code>options</code> argument receive an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#abortsignal" id="ref-for-abortsignal">AbortSignal</a></code>, with which they
-  can <a href="https://dom.spec.whatwg.org/#abortcontroller-api-integration">respond</a> to a caller attempting
-  to abort them.</p>
+    <p>Each <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object④">interface object</a> created for interfaces which <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherit" id="ref-for-dfn-inherit①">inherit</a> from <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential⑦">Credential</a></code> defines several internal methods that allow retrieval and storage of <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential⑧">Credential</a></code> objects:</p>
     <section class="algorithm" data-algorithm="&apos;collect credentials&apos; internal method">
       <dfn class="dfn-paneled idl-code" data-dfn-for="Credential" data-dfn-type="method" data-export="" id="dom-credential-collectfromcredentialstore-slot"><code>[[CollectFromCredentialStore]](options)</code></dfn> is called
     with a <code class="idl"><a data-link-type="idl" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions">CredentialRequestOptions</a></code>, and returns a set of <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential⑨">Credential</a></code> objects from the user
@@ -1937,7 +1934,7 @@ store user credentials for future use.</p>
   dictionary so they can be passed into the request. See <a href="#implementation-extension">§7.2 Extension Points</a>.</p>
 <pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-credentialrequestoptions"><code>CredentialRequestOptions</code></dfn> {
   <a class="n" data-link-type="idl-name" href="#enumdef-credentialmediationrequirement" id="ref-for-enumdef-credentialmediationrequirement">CredentialMediationRequirement</a> <a class="nv idl-code" data-default="&quot;optional&quot;" data-link-type="dict-member" data-type="CredentialMediationRequirement " href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation">mediation</a> = "optional";
-  <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#abortsignal" id="ref-for-abortsignal①">AbortSignal</a> <a class="nv idl-code" data-link-type="dict-member" data-type="AbortSignal " href="#dom-credentialrequestoptions-signal" id="ref-for-dom-credentialrequestoptions-signal">signal</a>;
+  <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#abortsignal" id="ref-for-abortsignal">AbortSignal</a> <a class="nv idl-code" data-link-type="dict-member" data-type="AbortSignal " href="#dom-credentialrequestoptions-signal" id="ref-for-dom-credentialrequestoptions-signal">signal</a>;
 };
 </pre>
     <div>
@@ -1947,7 +1944,7 @@ store user credentials for future use.</p>
        <p>This property specifies the mediation requirements for a given credential request. The
   meaning of each enum value is described below in <code class="idl"><a data-link-type="idl" href="#enumdef-credentialmediationrequirement" id="ref-for-enumdef-credentialmediationrequirement②">CredentialMediationRequirement</a></code>.
   Processing details are defined in <a href="#algorithm-request">§2.5.1 Request a Credential</a>.</p>
-      <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="CredentialRequestOptions" data-dfn-type="dict-member" data-export="" id="dom-credentialrequestoptions-signal"><code>signal</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#abortsignal" id="ref-for-abortsignal②">AbortSignal</a></span>
+      <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="CredentialRequestOptions" data-dfn-type="dict-member" data-export="" id="dom-credentialrequestoptions-signal"><code>signal</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#abortsignal" id="ref-for-abortsignal①">AbortSignal</a></span>
       <dd data-md="">
        <p>This property lets the developer abort an ongoing <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get④">get()</a></code> operation.
   An aborted operation may complete normally (generally if the abort was received after the
@@ -2123,12 +2120,12 @@ store user credentials for future use.</p>
   credentials are introduced, they will add to the dictionary so they can be passed into the
   creation method. See <a href="#implementation-extension">§7.2 Extension Points</a>, and the extensions introduced in this document: <a href="#passwordcredential-interface">§3.2 The PasswordCredential Interface</a> and <a href="#federatedcredential-interface">§4.1 The FederatedCredential Interface</a>.</p>
 <pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-credentialcreationoptions"><code>CredentialCreationOptions</code></dfn> {
-  <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#abortsignal" id="ref-for-abortsignal③">AbortSignal</a> <a class="nv idl-code" data-link-type="dict-member" data-type="AbortSignal " href="#dom-credentialcreationoptions-signal" id="ref-for-dom-credentialcreationoptions-signal">signal</a>;
+  <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#abortsignal" id="ref-for-abortsignal②">AbortSignal</a> <a class="nv idl-code" data-link-type="dict-member" data-type="AbortSignal " href="#dom-credentialcreationoptions-signal" id="ref-for-dom-credentialcreationoptions-signal">signal</a>;
 };
 </pre>
     <div>
      <dl>
-      <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="CredentialCreationOptions" data-dfn-type="dict-member" data-export="" id="dom-credentialcreationoptions-signal"><code>signal</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#abortsignal" id="ref-for-abortsignal④">AbortSignal</a></span>
+      <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="CredentialCreationOptions" data-dfn-type="dict-member" data-export="" id="dom-credentialcreationoptions-signal"><code>signal</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#abortsignal" id="ref-for-abortsignal③">AbortSignal</a></span>
       <dd data-md="">
        <p>This property lets the developer abort an ongoing <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-create" id="ref-for-dom-credentialscontainer-create④">create()</a></code> operation. An aborted operation may complete normally (generally if the abort was received
   after the operation finished) or reject with an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#aborterror" id="ref-for-aborterror①">AbortError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException①">DOMException</a></code>."</p>
@@ -3143,6 +3140,8 @@ interface ExampleCredential : Credential {
      <li data-md="">
       <p>Define appropriate <code class="idl"><a data-link-type="idl" href="#dom-credential-create-slot" id="ref-for-dom-credential-create-slot①">[[Create]](options)</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-credential-collectfromcredentialstore-slot" id="ref-for-dom-credential-collectfromcredentialstore-slot①">[[CollectFromCredentialStore]](options)</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-credential-discoverfromexternalsource-slot" id="ref-for-dom-credential-discoverfromexternalsource-slot③">[[DiscoverFromExternalSource]](options)</a></code>, and <code class="idl"><a data-link-type="idl" href="#dom-credential-store-slot" id="ref-for-dom-credential-store-slot①">[[Store]](credential)</a></code> methods on <code>ExampleCredential</code>'s <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object①⑧">interface object</a>. <code class="idl"><a data-link-type="idl" href="#dom-credential-collectfromcredentialstore-slot" id="ref-for-dom-credential-collectfromcredentialstore-slot②">[[CollectFromCredentialStore]](options)</a></code> is appropriate for <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential①⑦">credentials</a> that remain <a data-link-type="dfn" href="#credential-effective" id="ref-for-credential-effective③">effective</a> forever and
   can therefore simply be copied out of the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store②⑥">credential store</a>, while <code class="idl"><a data-link-type="idl" href="#dom-credential-discoverfromexternalsource-slot" id="ref-for-dom-credential-discoverfromexternalsource-slot④">[[DiscoverFromExternalSource]](options)</a></code> is appropriate for <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential①⑧">credentials</a> that need to be re-generated from a <a data-link-type="dfn" href="#credential-source" id="ref-for-credential-source①">credential source</a>.</p>
+      <p>Long-running operations, like those in <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/webauthn/#publickeycredential" id="ref-for-publickeycredential">PublicKeyCredential</a></code>'s <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/webauthn/#dom-publickeycredential-create-slot" id="ref-for-dom-publickeycredential-create-slot">[[Create]](options)</a></code> and <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/webauthn/#dom-publickeycredential-discoverfromexternalsource-slot" id="ref-for-dom-publickeycredential-discoverfromexternalsource-slot">[[DiscoverFromExternalSource]](options)</a></code> operations are encouraged to use <code>options.signal</code> to allow developers to abort
+  the operation. See <a href="https://dom.spec.whatwg.org/#abortcontroller-api-integration">DOM §3.3 Using AbortController and AbortSignal objects in APIs</a> for detailed instructions.</p>
       <div class="example" id="example-b597dd69">
        <a class="self-link" href="#example-b597dd69"></a> <code>ExampleCredential</code>'s <code>[[CollectFromCredentialStore]](options)</code> internal method is called
     with a CredentialRequestOptions object (<code>options</code>), and returns a set of <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential⑤③">Credential</a></code> objects that match the options provided. If no matching <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential⑤④">Credential</a></code> objects are
@@ -3512,6 +3511,13 @@ partial dictionary CredentialCreationOptions {
      <li><a href="https://url.spec.whatwg.org/#urlsearchparams">URLSearchParams</a>
     </ul>
    <li>
+    <a data-link-type="biblio">[WEBAUTHN]</a> defines the following terms:
+    <ul>
+     <li><a href="https://w3c.github.io/webauthn/#publickeycredential">PublicKeyCredential</a>
+     <li><a href="https://w3c.github.io/webauthn/#dom-publickeycredential-create-slot">[[Create]](options)</a>
+     <li><a href="https://w3c.github.io/webauthn/#dom-publickeycredential-discoverfromexternalsource-slot">[[DiscoverFromExternalSource]](options)</a>
+    </ul>
+   <li>
     <a data-link-type="biblio">[WebIDL]</a> defines the following terms:
     <ul>
      <li><a href="https://heycam.github.io/webidl/#aborterror">AbortError</a>
@@ -3567,6 +3573,8 @@ partial dictionary CredentialCreationOptions {
    <dd>Mike West. <a href="https://www.w3.org/TR/secure-contexts/">Secure Contexts</a>. 15 September 2016. CR. URL: <a href="https://www.w3.org/TR/secure-contexts/">https://www.w3.org/TR/secure-contexts/</a>
    <dt id="biblio-url">[URL]
    <dd>Anne van Kesteren. <a href="https://url.spec.whatwg.org/">URL Standard</a>. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
+   <dt id="biblio-webauthn">[WEBAUTHN]
+   <dd>Vijay Bharadwaj; et al. <a href="https://www.w3.org/TR/webauthn/">Web Authentication: An API for accessing Public Key Credentials Level 1</a>. 11 August 2017. WD. URL: <a href="https://www.w3.org/TR/webauthn/">https://www.w3.org/TR/webauthn/</a>
    <dt id="biblio-webidl">[WebIDL]
    <dd>Cameron McCormack; Boris Zbarsky; Tobie Langel. <a href="https://heycam.github.io/webidl/">Web IDL</a>. 15 December 2016. ED. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
    <dt id="biblio-xhr">[XHR]
@@ -3580,8 +3588,6 @@ partial dictionary CredentialCreationOptions {
    <dd>Devdatta Akhawe; et al. <a href="https://www.w3.org/TR/SRI/">Subresource Integrity</a>. 23 June 2016. REC. URL: <a href="https://www.w3.org/TR/SRI/">https://www.w3.org/TR/SRI/</a>
    <dt id="biblio-web-login">[WEB-LOGIN]
    <dd>Jason Denizac; Robin Berjon; Anne van Kesteren. <a href="https://github.com/jden/web-login">web-login</a>. URL: <a href="https://github.com/jden/web-login">https://github.com/jden/web-login</a>
-   <dt id="biblio-webauthn">[WEBAUTHN]
-   <dd>Vijay Bharadwaj; et al. <a href="https://www.w3.org/TR/webauthn/">Web Authentication: An API for accessing Public Key Credentials Level 1</a>. 11 August 2017. WD. URL: <a href="https://www.w3.org/TR/webauthn/">https://www.w3.org/TR/webauthn/</a>
    <dt id="biblio-webmessaging">[WEBMESSAGING]
    <dd>Ian Hickson. <a href="https://www.w3.org/TR/webmessaging/">HTML5 Web Messaging</a>. 19 May 2015. REC. URL: <a href="https://www.w3.org/TR/webmessaging/">https://www.w3.org/TR/webmessaging/</a>
    <dt id="biblio-xmlhttprequest">[XMLHTTPREQUEST]
@@ -3618,7 +3624,7 @@ partial dictionary CredentialCreationOptions {
 
 <span class="kt">dictionary</span> <a class="nv" href="#dictdef-credentialrequestoptions"><code>CredentialRequestOptions</code></a> {
   <a class="n" data-link-type="idl-name" href="#enumdef-credentialmediationrequirement" id="ref-for-enumdef-credentialmediationrequirement④">CredentialMediationRequirement</a> <a class="nv idl-code" data-default="&quot;optional&quot;" data-link-type="dict-member" data-type="CredentialMediationRequirement " href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation①⑤">mediation</a> = "optional";
-  <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#abortsignal" id="ref-for-abortsignal①①">AbortSignal</a> <a class="nv idl-code" data-link-type="dict-member" data-type="AbortSignal " href="#dom-credentialrequestoptions-signal" id="ref-for-dom-credentialrequestoptions-signal②">signal</a>;
+  <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#abortsignal" id="ref-for-abortsignal④">AbortSignal</a> <a class="nv idl-code" data-link-type="dict-member" data-type="AbortSignal " href="#dom-credentialrequestoptions-signal" id="ref-for-dom-credentialrequestoptions-signal②">signal</a>;
 };
 
 <span class="kt">enum</span> <a class="nv" href="#enumdef-credentialmediationrequirement"><code>CredentialMediationRequirement</code></a> {
@@ -3628,7 +3634,7 @@ partial dictionary CredentialCreationOptions {
 };
 
 <span class="kt">dictionary</span> <a class="nv" href="#dictdef-credentialcreationoptions"><code>CredentialCreationOptions</code></a> {
-  <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#abortsignal" id="ref-for-abortsignal③①">AbortSignal</a> <a class="nv idl-code" data-link-type="dict-member" data-type="AbortSignal " href="#dom-credentialcreationoptions-signal" id="ref-for-dom-credentialcreationoptions-signal②">signal</a>;
+  <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#abortsignal" id="ref-for-abortsignal②①">AbortSignal</a> <a class="nv idl-code" data-link-type="dict-member" data-type="AbortSignal " href="#dom-credentialcreationoptions-signal" id="ref-for-dom-credentialcreationoptions-signal②">signal</a>;
 };
 
 <span class="kt">typedef</span> (<a class="n" data-link-type="idl-name" href="https://xhr.spec.whatwg.org/#interface-formdata" id="ref-for-interface-formdata③">FormData</a> <span class="kt">or</span> <a class="n" data-link-type="idl-name" href="https://url.spec.whatwg.org/#urlsearchparams" id="ref-for-urlsearchparams①">URLSearchParams</a>) <a class="nv" href="#typedefdef-credentialbodytype"><code>CredentialBodyType</code></a>;

--- a/index.html
+++ b/index.html
@@ -1176,8 +1176,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version fa5b8b17ec5b76772d473054c6882432da32a814" name="generator">
+  <meta content="Bikeshed version 4679d5ca787d737883d9c905dd138257fc2cec85" name="generator">
   <link href="http://www.w3.org/TR/credential-management-1/" rel="canonical">
+  <meta content="81bb577ef1ee915328c4dd67f805343d24525a5a" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1424,7 +1425,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Credential Management Level 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-09-05">5 September 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-10-30">30 October 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1440,7 +1441,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
      <dt class="editor">Editor:
      <dd class="editor p-author h-card vcard" data-editor-id="56384"><a class="p-name fn u-email email" href="mailto:mkwst@google.com">Mike West</a> (<span class="p-org org">Google Inc.</span>)
      <dt>Participate:
-     <dd><span><a href="https://github.com/w3c/webappsec-credential-management/issues/new">File an issue</a> (<a href="https://github.com/w3c/webappsec-credential-management/issues">open issues</a>)</span>
+     <dd><a href="https://github.com/w3c/webappsec-credential-management/issues/new">File an issue</a> (<a href="https://github.com/w3c/webappsec-credential-management/issues">open issues</a>)
     </dl>
    </div>
    <div data-fill-with="warning"></div>
@@ -1725,7 +1726,6 @@ store user credentials for future use.</p>
 <span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="credential"><code>Credential</code></dfn> {
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString"><span class="kt">USVString</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-credential-id" id="ref-for-dom-credential-id">id</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString"><span class="kt">DOMString</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-credential-type" id="ref-for-dom-credential-type">type</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#abortsignal" id="ref-for-abortsignal">AbortSignal</a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="AbortSignal" href="#dom-credential-signal" id="ref-for-dom-credential-signal">signal</a>;
 };
 </pre>
     <div>
@@ -1737,11 +1737,6 @@ store user credentials for future use.</p>
       <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="Credential" data-dfn-type="attribute" data-export="" id="dom-credential-type"><code>type</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①">DOMString</a>, readonly</span>
       <dd data-md="">
        <p>This attribute’s getter returns the value of the object’s <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object">interface object</a>'s <code class="idl"><a data-link-type="idl" href="#dom-credential-type-slot" id="ref-for-dom-credential-type-slot">[[type]]</a></code> slot, which specifies the kind of credential represented by this object.</p>
-      <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="Credential" data-dfn-type="attribute" data-export="" id="dom-credential-signal"><code>signal</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#abortsignal" id="ref-for-abortsignal①">AbortSignal</a>, readonly</span>
-      <dd data-md="">
-       <p>The credential object has an associated signal (an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#abortsignal" id="ref-for-abortsignal②">AbortSignal</a></code> object), initially
-  a new <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#abortsignal" id="ref-for-abortsignal③">AbortSignal</a></code> object. Developers can use AbortSignal to <a data-link-type="dfn" href="#concept-credman-terminated" id="ref-for-concept-credman-terminated">terminate</a> an 
-  ongoing <code class="idl"><a data-link-type="idl" href="#dom-passwordcredential-create-slot" id="ref-for-dom-passwordcredential-create-slot">[[Create]](options)</a></code> operation or <code class="idl"><a data-link-type="idl" href="#dom-credential-discoverfromexternalsource-slot" id="ref-for-dom-credential-discoverfromexternalsource-slot">[[DiscoverFromExternalSource]](options)</a></code> operation.</p>
       <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="Credential" data-dfn-type="attribute" data-export="" id="dom-credential-type-slot"><code>[[type]]</code></dfn>
       <dd data-md="">
        <p>The <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential②">Credential</a></code> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object①">interface object</a> has an internal slot named <code>[[type]]</code>, which
@@ -1755,8 +1750,8 @@ store user credentials for future use.</p>
        <p>The <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential④">Credential</a></code> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object②">interface object</a> has an internal slot named <code>[[discovery]]</code>,
   representing the mechanism by which the user agent can collect credentials of
   a given type. Its value is either
-  "<dfn class="dfn-paneled idl-code" data-dfn-for="Credential/[[discovery]]" data-dfn-type="enum-value" data-export="" id="dom-credential-discovery-credential-store"><code><code>credential store</code></code></dfn>" or
-  "<dfn class="idl-code" data-dfn-for="Credential/[[discovery]]" data-dfn-type="enum-value" data-export="" id="dom-credential-discovery-remote"><code><code>remote</code></code><a class="self-link" href="#dom-credential-discovery-remote"></a></dfn>". The former value means that
+  "<dfn class="dfn-paneled idl-code" data-dfn-for="Credential/[[discovery]]" data-dfn-type="enum-value" data-export="" id="dom-credential-discovery-credential-store"><code>credential store</code></dfn>" or
+  "<dfn class="idl-code" data-dfn-for="Credential/[[discovery]]" data-dfn-type="enum-value" data-export="" id="dom-credential-discovery-remote"><code>remote</code><a class="self-link" href="#dom-credential-discovery-remote"></a></dfn>". The former value means that
   all available credential information is stored in the user agent’s <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store④">credential store</a>,
   while the latter means that the user agent can discover credentials outside of those
   explicitly represented in the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store⑤">credential store</a> via interaction with some external device
@@ -1768,7 +1763,7 @@ store user credentials for future use.</p>
     <p>Some <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential⑤">Credential</a></code> objects are <dfn class="dfn-paneled" data-dfn-for="Credential" data-dfn-type="dfn" data-noexport="" id="credential-origin-bound">origin bound</dfn>: these contain an
   internal slot named <dfn class="dfn-paneled idl-code" data-dfn-for="Credential" data-dfn-type="attribute" data-export="" id="dom-credential-origin-slot"><code>[[origin]]</code></dfn>, which stores the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin②">origin</a> for which the <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential⑥">Credential</a></code> may be <a data-link-type="dfn" href="#credential-effective" id="ref-for-credential-effective①">effective</a>.</p>
     <h4 class="heading settled" data-level="2.2.1" id="credential-internal-methods"><span class="secno">2.2.1. </span><span class="content"><code>Credential</code> Internal Methods</span><a class="self-link" href="#credential-internal-methods"></a></h4>
-    <p>Each <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object④">interface object</a> created for interfaces which <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherit" id="ref-for-dfn-inherit①">inherit</a> from <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential⑦">Credential</a></code> defines several internal methods that allow retrieval and storage of <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential⑧">Credential</a></code> objects. The <code class="idl"><a data-link-type="idl" href="#dom-credential-create-slot" id="ref-for-dom-credential-create-slot">[[Create]](options)</a></code> method and <code class="idl"><a data-link-type="idl" href="#dom-credential-discoverfromexternalsource-slot" id="ref-for-dom-credential-discoverfromexternalsource-slot①">[[DiscoverFromExternalSource]](options)</a></code> method can be <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="concept-credman-terminated">terminated</dfn> with flag <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#abortsignal-aborted-flag" id="ref-for-abortsignal-aborted-flag">aborted flag</a>, which is unset unless otherwise specificed. When methods are <a data-link-type="dfn" href="#concept-credman-terminated" id="ref-for-concept-credman-terminated①">terminated</a>, the promise MUST be rejected with an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#aborterror" id="ref-for-aborterror">AbortError</a></code> <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException">DOMException</a></code>.</p>
+    <p>Each <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object④">interface object</a> created for interfaces which <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherit" id="ref-for-dfn-inherit①">inherit</a> from <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential⑦">Credential</a></code> defines several internal methods that allow retrieval and storage of <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential⑧">Credential</a></code> objects. The <code class="idl"><a data-link-type="idl" href="#dom-credential-create-slot" id="ref-for-dom-credential-create-slot">[[Create]](options)</a></code> method and <code class="idl"><a data-link-type="idl" href="#dom-credential-discoverfromexternalsource-slot" id="ref-for-dom-credential-discoverfromexternalsource-slot">[[DiscoverFromExternalSource]](options)</a></code> method can be aborted.</p>
     <section class="algorithm" data-algorithm="&apos;collect credentials&apos; internal method">
       <dfn class="dfn-paneled idl-code" data-dfn-for="Credential" data-dfn-type="method" data-export="" id="dom-credential-collectfromcredentialstore-slot"><code>[[CollectFromCredentialStore]](options)</code></dfn> is called
     with a <code class="idl"><a data-link-type="idl" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions">CredentialRequestOptions</a></code>, and returns a set of <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential⑨">Credential</a></code> objects from the user
@@ -1836,8 +1831,8 @@ store user credentials for future use.</p>
   [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext②">SecureContext</a>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SameObject" id="ref-for-SameObject">SameObject</a>] <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#credentialscontainer" id="ref-for-credentialscontainer②">CredentialsContainer</a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="CredentialsContainer" href="#dom-navigator-credentials" id="ref-for-dom-navigator-credentials①">credentials</a>;
 };
 </pre>
-    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="Navigator" data-dfn-type="attribute" data-export="" id="dom-navigator-credentials"><code><code>credentials</code></code></dfn> attribute MUST return the <code class="idl"><a data-link-type="idl" href="#credentialscontainer" id="ref-for-credentialscontainer③">CredentialsContainer</a></code> associated with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object" id="ref-for-context-object">context object</a>.</p>
-    <p class="note" role="note"><span>Note:</span> As discussed in <a href="#insecure-sites">§6.3 Insecure Sites</a>, the credential management API is exposed only in <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context" id="ref-for-secure-context">Secure Contexts</a>.</p>
+    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="Navigator" data-dfn-type="attribute" data-export="" id="dom-navigator-credentials"><code>credentials</code></dfn> attribute MUST return the <code class="idl"><a data-link-type="idl" href="#credentialscontainer" id="ref-for-credentialscontainer③">CredentialsContainer</a></code> associated with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object" id="ref-for-context-object">context object</a>.</p>
+    <p class="note" role="note"><span>Note:</span> As discussed in <a href="#insecure-sites">§6.3 Insecure Sites</a>, the credential management API is exposed only in <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-contexts" id="ref-for-secure-contexts">Secure Contexts</a>.</p>
 <pre class="idl highlight def">[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①">Exposed</a>=<span class="n">Window</span>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext③">SecureContext</a>]
 <span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="credentialscontainer"><code>CredentialsContainer</code></dfn> {
   <span class="kt">Promise</span>&lt;<a class="n" data-link-type="idl-name" href="#credential" id="ref-for-credential②⓪">Credential</a>?> <a class="nv idl-code" data-link-type="method" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get">get</a>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions②">CredentialRequestOptions</a> <a class="nv idl-code" data-link-type="argument" href="#dom-credentialscontainer-get-options-options" id="ref-for-dom-credentialscontainer-get-options-options">options</a>);
@@ -1856,71 +1851,65 @@ store user credentials for future use.</p>
       <dd data-md="">
        <p>When <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get①">get()</a></code> is called, the user agent MUST return the result of
   executing <a data-link-type="abstract-op" href="#abstract-opdef-request-a-credential" id="ref-for-abstract-opdef-request-a-credential">Request a <code>Credential</code></a> on <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get-options-options" id="ref-for-dom-credentialscontainer-get-options-options①">options</a></code>.</p>
-     </dl>
-     <table class="argumentdef data">
-      <caption>Arguments for the <a class="idl-code" data-link-type="method" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get②">CredentialsContainer.get(options)</a> method.</caption>
-      <thead>
-       <tr>
-        <th>Parameter 
-        <th>Type 
-        <th>Nullable 
-        <th>Optional 
-        <th>Description 
-      <tbody>
-       <tr>
-        <td><dfn class="dfn-paneled idl-code" data-dfn-for="CredentialsContainer/get(options)" data-dfn-type="argument" data-export="" id="dom-credentialscontainer-get-options-options"><code>options</code></dfn> 
-        <td> CredentialRequestOptions 
-        <td> <span class="no">✘</span>
-        <td> <span class="yes">✔</span>
-        <td>The set of properties governing the scope of the request. 
-     </table>
-     <dl>
+       <table class="argumentdef data">
+        <caption>Arguments for the <a class="idl-code" data-link-type="method" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get②">CredentialsContainer.get(options)</a> method.</caption>
+        <thead>
+         <tr>
+          <th>Parameter 
+          <th>Type 
+          <th>Nullable 
+          <th>Optional 
+          <th>Description 
+        <tbody>
+         <tr>
+          <td><dfn class="dfn-paneled idl-code" data-dfn-for="CredentialsContainer/get(options)" data-dfn-type="argument" data-export="" id="dom-credentialscontainer-get-options-options"><code>options</code></dfn> 
+          <td> CredentialRequestOptions 
+          <td> <span class="no">✘</span>
+          <td> <span class="yes">✔</span>
+          <td>The set of properties governing the scope of the request. 
+       </table>
       <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="CredentialsContainer" data-dfn-type="method" data-export="" data-lt="store(credential)|store()" id="dom-credentialscontainer-store"><code>store(credential)</code></dfn>
       <dd data-md="">
        <p>When <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-store" id="ref-for-dom-credentialscontainer-store②">store()</a></code> is called, the user agent MUST return the result of
   executing <a data-link-type="abstract-op" href="#abstract-opdef-store-a-credential" id="ref-for-abstract-opdef-store-a-credential">Store a <code>Credential</code></a> on <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-store-credential-credential" id="ref-for-dom-credentialscontainer-store-credential-credential①">credential</a></code>.</p>
-     </dl>
-     <table class="argumentdef data">
-      <caption>Arguments for the <a class="idl-code" data-link-type="method" href="#dom-credentialscontainer-store" id="ref-for-dom-credentialscontainer-store③">CredentialsContainer.store(credential)</a> method.</caption>
-      <thead>
-       <tr>
-        <th>Parameter 
-        <th>Type 
-        <th>Nullable 
-        <th>Optional 
-        <th>Description 
-      <tbody>
-       <tr>
-        <td><dfn class="dfn-paneled idl-code" data-dfn-for="CredentialsContainer/store(credential)" data-dfn-type="argument" data-export="" id="dom-credentialscontainer-store-credential-credential"><code>credential</code></dfn> 
-        <td> Credential 
-        <td> <span class="no">✘</span>
-        <td> <span class="no">✘</span>
-        <td>The credential to be stored. 
-     </table>
-     <dl>
+       <table class="argumentdef data">
+        <caption>Arguments for the <a class="idl-code" data-link-type="method" href="#dom-credentialscontainer-store" id="ref-for-dom-credentialscontainer-store③">CredentialsContainer.store(credential)</a> method.</caption>
+        <thead>
+         <tr>
+          <th>Parameter 
+          <th>Type 
+          <th>Nullable 
+          <th>Optional 
+          <th>Description 
+        <tbody>
+         <tr>
+          <td><dfn class="dfn-paneled idl-code" data-dfn-for="CredentialsContainer/store(credential)" data-dfn-type="argument" data-export="" id="dom-credentialscontainer-store-credential-credential"><code>credential</code></dfn> 
+          <td> Credential 
+          <td> <span class="no">✘</span>
+          <td> <span class="no">✘</span>
+          <td>The credential to be stored. 
+       </table>
       <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="CredentialsContainer" data-dfn-type="method" data-export="" data-lt="create(options)|create()" id="dom-credentialscontainer-create"><code>create(options)</code></dfn>
       <dd data-md="">
        <p>When <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-create" id="ref-for-dom-credentialscontainer-create①">create()</a></code> is called, the user agent MUST return the result of
   executing <a data-link-type="abstract-op" href="#abstract-opdef-create-a-credential" id="ref-for-abstract-opdef-create-a-credential">Create a <code>Credential</code></a> on <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-create-options-options" id="ref-for-dom-credentialscontainer-create-options-options①">options</a></code>.</p>
-     </dl>
-     <table class="argumentdef data">
-      <caption>Arguments for the <a class="idl-code" data-link-type="method" href="#dom-credentialscontainer-create" id="ref-for-dom-credentialscontainer-create②">CredentialsContainer.create(options)</a> method.</caption>
-      <thead>
-       <tr>
-        <th>Parameter 
-        <th>Type 
-        <th>Nullable 
-        <th>Optional 
-        <th>Description 
-      <tbody>
-       <tr>
-        <td><dfn class="dfn-paneled idl-code" data-dfn-for="CredentialsContainer/create(options)" data-dfn-type="argument" data-export="" id="dom-credentialscontainer-create-options-options"><code>options</code></dfn> 
-        <td> CredentialCreationOptions 
-        <td> <span class="no">✘</span>
-        <td> <span class="yes">✔</span>
-        <td>The options used to create a <code>Credential</code>. 
-     </table>
-     <dl>
+       <table class="argumentdef data">
+        <caption>Arguments for the <a class="idl-code" data-link-type="method" href="#dom-credentialscontainer-create" id="ref-for-dom-credentialscontainer-create②">CredentialsContainer.create(options)</a> method.</caption>
+        <thead>
+         <tr>
+          <th>Parameter 
+          <th>Type 
+          <th>Nullable 
+          <th>Optional 
+          <th>Description 
+        <tbody>
+         <tr>
+          <td><dfn class="dfn-paneled idl-code" data-dfn-for="CredentialsContainer/create(options)" data-dfn-type="argument" data-export="" id="dom-credentialscontainer-create-options-options"><code>options</code></dfn> 
+          <td> CredentialCreationOptions 
+          <td> <span class="no">✘</span>
+          <td> <span class="yes">✔</span>
+          <td>The options used to create a <code>Credential</code>. 
+       </table>
       <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="CredentialsContainer" data-dfn-type="method" data-export="" id="dom-credentialscontainer-preventsilentaccess"><code>preventSilentAccess()</code></dfn>
       <dd data-md="">
        <p>When <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-preventsilentaccess" id="ref-for-dom-credentialscontainer-preventsilentaccess①">preventSilentAccess()</a></code> is called, the user agent MUST return
@@ -1945,6 +1934,7 @@ store user credentials for future use.</p>
   dictionary so they can be passed into the request. See <a href="#implementation-extension">§7.2 Extension Points</a>.</p>
 <pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-credentialrequestoptions"><code>CredentialRequestOptions</code></dfn> {
   <a class="n" data-link-type="idl-name" href="#enumdef-credentialmediationrequirement" id="ref-for-enumdef-credentialmediationrequirement">CredentialMediationRequirement</a> <a class="nv idl-code" data-default="&quot;optional&quot;" data-link-type="dict-member" data-type="CredentialMediationRequirement " href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation">mediation</a> = "optional";
+  <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#abortsignal" id="ref-for-abortsignal">AbortSignal</a> <a class="nv idl-code" data-link-type="dict-member" data-type="AbortSignal " href="#dom-credentialrequestoptions-signal" id="ref-for-dom-credentialrequestoptions-signal">signal</a>;
 };
 </pre>
     <div>
@@ -1954,6 +1944,10 @@ store user credentials for future use.</p>
        <p>This property specifies the mediation requirements for a given credential request. The
   meaning of each enum value is described below in <code class="idl"><a data-link-type="idl" href="#enumdef-credentialmediationrequirement" id="ref-for-enumdef-credentialmediationrequirement②">CredentialMediationRequirement</a></code>.
   Processing details are defined in <a href="#algorithm-request">§2.5.1 Request a Credential</a>.</p>
+      <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="CredentialRequestOptions" data-dfn-type="dict-member" data-export="" id="dom-credentialrequestoptions-signal"><code>signal</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#abortsignal" id="ref-for-abortsignal①">AbortSignal</a></span>
+      <dd data-md="">
+       <p>This property allow the developer to abort an ongoing <code class="idl"><a data-link-type="idl" href="#dom-credential-discoverfromexternalsource-slot" id="ref-for-dom-credential-discoverfromexternalsource-slot①">[[DiscoverFromExternalSource]](options)</a></code> operation and subequently all related <a data-link-type="dfn">authenticatorGetAssertion</a> operations. Aborted romise would 
+  be rejected with an "AbortError" DOMException.</p>
      </dl>
     </div>
     <div class="note" role="note">
@@ -2125,8 +2119,18 @@ store user credentials for future use.</p>
   credentials are introduced, they will add to the dictionary so they can be passed into the
   creation method. See <a href="#implementation-extension">§7.2 Extension Points</a>, and the extensions introduced in this document: <a href="#passwordcredential-interface">§3.2 The PasswordCredential Interface</a> and <a href="#federatedcredential-interface">§4.1 The FederatedCredential Interface</a>.</p>
 <pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-credentialcreationoptions"><code>CredentialCreationOptions</code></dfn> {
+  <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#abortsignal" id="ref-for-abortsignal②">AbortSignal</a> <a class="nv idl-code" data-link-type="dict-member" data-type="AbortSignal " href="#dom-credentialcreationoptions-signal" id="ref-for-dom-credentialcreationoptions-signal">signal</a>;
 };
 </pre>
+    <div>
+     <dl>
+      <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="CredentialCreationOptions" data-dfn-type="dict-member" data-export="" id="dom-credentialcreationoptions-signal"><code>signal</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#abortsignal" id="ref-for-abortsignal③">AbortSignal</a></span>
+      <dd data-md="">
+       <p>This property allow the developer to abort an ongoing <code class="idl"><a data-link-type="idl" href="#dom-credential-create-slot" id="ref-for-dom-credential-create-slot①">[[Create]](options)</a></code> operation
+  and susquently all related <a data-link-type="dfn">authenticatorMakeCredential</a> operations. Aborted romise would 
+  be rejected with an "AbortError" DOMException.</p>
+     </dl>
+    </div>
     <h3 class="heading settled" data-level="2.5" id="algorithms"><span class="secno">2.5. </span><span class="content">Algorithms</span><a class="self-link" href="#algorithms"></a></h3>
     <h4 class="heading settled algorithm" data-algorithm="Request a Credential" data-level="2.5.1" id="algorithm-request"><span class="secno">2.5.1. </span><span class="content">Request a <code>Credential</code></span><a class="self-link" href="#algorithm-request"></a></h4>
     <p>The <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export="" id="abstract-opdef-request-a-credential">Request a <code>Credential</code></dfn> algorithm accepts a <code class="idl"><a data-link-type="idl" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions⑧">CredentialRequestOptions</a></code> (<var>options</var>), and returns a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-promise" id="ref-for-idl-promise">Promise</a></code> that resolves with a <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential②⑦">Credential</a></code> if one can be
@@ -2135,7 +2139,7 @@ store user credentials for future use.</p>
      <li data-md="">
       <p>Let <var>settings</var> be the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object" id="ref-for-current-settings-object②">current settings object</a></p>
      <li data-md="">
-      <p class="assertion">Assert: <var>settings</var> is a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context" id="ref-for-secure-context①">secure context</a>.</p>
+      <p class="assertion">Assert: <var>settings</var> is a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-contexts" id="ref-for-secure-contexts①">secure context</a>.</p>
      <li data-md="">
       <p>Return <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#a-promise-rejected-with" id="ref-for-a-promise-rejected-with">a promise rejected with</a> <code>NotSupportedError</code> if any of the following statements
   are true:</p>
@@ -2224,7 +2228,7 @@ store user credentials for future use.</p>
      <li data-md="">
       <p>Let <var>settings</var> be the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object" id="ref-for-current-settings-object③">current settings object</a></p>
      <li data-md="">
-      <p class="assertion">Assert: <var>settings</var> is a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context" id="ref-for-secure-context②">secure context</a>.</p>
+      <p class="assertion">Assert: <var>settings</var> is a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-contexts" id="ref-for-secure-contexts②">secure context</a>.</p>
      <li data-md="">
       <p>Return <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#a-promise-rejected-with" id="ref-for-a-promise-rejected-with①">a promise rejected with</a> <code>NotSupportedError</code> if any of the following statements
   are true:</p>
@@ -2255,7 +2259,7 @@ store user credentials for future use.</p>
      <li data-md="">
       <p>Let <var>settings</var> be the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object" id="ref-for-current-settings-object④">current settings object</a></p>
      <li data-md="">
-      <p class="assertion">Assert: <var>settings</var> is a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context" id="ref-for-secure-context③">secure context</a>.</p>
+      <p class="assertion">Assert: <var>settings</var> is a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-contexts" id="ref-for-secure-contexts③">secure context</a>.</p>
      <li data-md="">
       <p>Let <var>interfaces</var> be the set of <var>options</var>’ <a data-link-type="dfn" href="#credentialrequestoptions-relevant-credential-interface-objects" id="ref-for-credentialrequestoptions-relevant-credential-interface-objects②">relevant credential interface objects</a>.</p>
      <li data-md="">
@@ -2276,10 +2280,10 @@ store user credentials for future use.</p>
      <li data-md="">
       <p>Let <var>p</var> be <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#a-new-promise" id="ref-for-a-new-promise②">a new promise</a>.</p>
      <li data-md="">
-      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel②">in parallel</a> but abort if the execution is <a data-link-type="dfn" href="#concept-credman-terminated" id="ref-for-concept-credman-terminated②">terminated</a>:</p>
+      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel②">in parallel</a>:</p>
       <ol>
        <li data-md="">
-        <p>Let <var>r</var> be the result of executing <var>interfaces</var>[0] <code class="idl"><a data-link-type="idl" href="#dom-credential-create-slot" id="ref-for-dom-credential-create-slot①">[[Create]](options)</a></code> internal method on <var>options</var>.</p>
+        <p>Let <var>r</var> be the result of executing <var>interfaces</var>[0] <code class="idl"><a data-link-type="idl" href="#dom-credential-create-slot" id="ref-for-dom-credential-create-slot②">[[Create]](options)</a></code> internal method on <var>options</var>.</p>
        <li data-md="">
         <p>If <var>r</var> is an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception" id="ref-for-dfn-exception②">exception</a>, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#reject-promise" id="ref-for-reject-promise②">reject</a> <var>p</var> with <var>r</var>.</p>
         <p>Otherwise, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#resolve-promise" id="ref-for-resolve-promise③">resolve</a> <var>p</var> with <var>r</var>.</p>
@@ -2351,7 +2355,7 @@ store user credentials for future use.</p>
     }
   });
 </pre>
-     <p>Alternatively, the website could just copy the credential data into a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/forms.html#the-form-element" id="ref-for-the-form-element">form</a></code> and call <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/forms.html#dom-form-submit-2" id="ref-for-dom-form-submit-2">submit()</a></code> on the form:</p>
+     <p>Alternatively, the website could just copy the credential data into a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/forms.html#the-form-element" id="ref-for-the-form-element">form</a></code> and call <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/forms.html#dom-form-submit" id="ref-for-dom-form-submit">submit()</a></code> on the form:</p>
 <pre>navigator.<a class="idl-code" data-link-type="attribute" href="#dom-navigator-credentials" id="ref-for-dom-navigator-credentials⑧">credentials</a>
   .<a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get①⑥">get</a>({ '<a class="idl-code" data-link-type="dict-member" href="#dom-credentialrequestoptions-password" id="ref-for-dom-credentialrequestoptions-password①">password</a>': true })
   .then(credential => {
@@ -2490,7 +2494,7 @@ store user credentials for future use.</p>
       <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-credential-type-slot" id="ref-for-dom-credential-type-slot③">[[type]]</a></code>
       <dd data-md="">
        <p>The <code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential⑤">PasswordCredential</a></code> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object①①">interface object</a> has an internal slot named <code>[[type]]</code> whose
-  value is "<dfn class="dfn-paneled idl-code" data-dfn-for="Credential/[[type]]" data-dfn-type="const" data-export="" id="dom-credential-type-password"><code><code>password</code></code></dfn>".</p>
+  value is "<dfn class="dfn-paneled idl-code" data-dfn-for="Credential/[[type]]" data-dfn-type="const" data-export="" id="dom-credential-type-password"><code>password</code></dfn>".</p>
       <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-credential-discovery-slot" id="ref-for-dom-credential-discovery-slot①">[[discovery]]</a></code>
       <dd data-md="">
        <p>The <code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential⑥">PasswordCredential</a></code> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object①②">interface object</a> has an internal slot named <code>[[discovery]]</code> whose value is "<code class="idl"><a data-link-type="idl" href="#dom-credential-discovery-credential-store" id="ref-for-dom-credential-discovery-credential-store①">credential store</a></code>".</p>
@@ -2532,7 +2536,7 @@ store user credentials for future use.</p>
 };
 </pre>
     <p><code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential⑧">PasswordCredential</a></code> objects are <a data-link-type="dfn" href="#credential-origin-bound" id="ref-for-credential-origin-bound">origin bound</a>.</p>
-    <p><code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential⑨">PasswordCredential</a></code>'s <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object①③">interface object</a> inherits <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential③⑥">Credential</a></code>'s implementation of <code class="idl"><a data-link-type="idl" href="#dom-credential-discoverfromexternalsource-slot" id="ref-for-dom-credential-discoverfromexternalsource-slot③">[[DiscoverFromExternalSource]](options)</a></code>, and defines its own implementation of <code class="idl"><a data-link-type="idl" href="#dom-passwordcredential-collectfromcredentialstore-slot" id="ref-for-dom-passwordcredential-collectfromcredentialstore-slot">[[CollectFromCredentialStore]](options)</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-passwordcredential-create-slot" id="ref-for-dom-passwordcredential-create-slot①">[[Create]](options)</a></code>, and <code class="idl"><a data-link-type="idl" href="#dom-passwordcredential-store-slot" id="ref-for-dom-passwordcredential-store-slot">[[Store]](credential)</a></code>.</p>
+    <p><code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential⑨">PasswordCredential</a></code>'s <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object①③">interface object</a> inherits <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential③⑥">Credential</a></code>'s implementation of <code class="idl"><a data-link-type="idl" href="#dom-credential-discoverfromexternalsource-slot" id="ref-for-dom-credential-discoverfromexternalsource-slot③">[[DiscoverFromExternalSource]](options)</a></code>, and defines its own implementation of <code class="idl"><a data-link-type="idl" href="#dom-passwordcredential-collectfromcredentialstore-slot" id="ref-for-dom-passwordcredential-collectfromcredentialstore-slot">[[CollectFromCredentialStore]](options)</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-passwordcredential-create-slot" id="ref-for-dom-passwordcredential-create-slot">[[Create]](options)</a></code>, and <code class="idl"><a data-link-type="idl" href="#dom-passwordcredential-store-slot" id="ref-for-dom-passwordcredential-store-slot">[[Store]](credential)</a></code>.</p>
     <h3 class="heading settled" data-level="3.3" id="passwordcredential-algorithms"><span class="secno">3.3. </span><span class="content">Algorithms</span><a class="self-link" href="#passwordcredential-algorithms"></a></h3>
     <h4 class="heading settled algorithm" data-algorithm="PasswordCredential&apos;s [[CollectFromCredentialStore]](options)" data-level="3.3.1" id="collectfromcredentialstore-passwordcredential"><span class="secno">3.3.1. </span><span class="content"> <code>PasswordCredential</code>'s <code>[[CollectFromCredentialStore]](options)</code> </span><a class="self-link" href="#collectfromcredentialstore-passwordcredential"></a></h4>
     <p><dfn class="dfn-paneled idl-code" data-dfn-for="PasswordCredential" data-dfn-type="method" data-export="" id="dom-passwordcredential-collectfromcredentialstore-slot"><code>[[CollectFromCredentialStore]](options)</code></dfn> is called
@@ -2765,7 +2769,7 @@ store user credentials for future use.</p>
       <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-credential-type-slot" id="ref-for-dom-credential-type-slot④">[[type]]</a></code>
       <dd data-md="">
        <p>The <code class="idl"><a data-link-type="idl" href="#federatedcredential" id="ref-for-federatedcredential②">FederatedCredential</a></code> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object①④">interface object</a> has an internal slot named <code>[[type]]</code> whose
-  value is "<dfn class="idl-code" data-dfn-for="FederatedCredential" data-dfn-type="const" data-export="" id="dom-federatedcredential-federated"><code><code>federated</code></code><a class="self-link" href="#dom-federatedcredential-federated"></a></dfn>".</p>
+  value is "<dfn class="idl-code" data-dfn-for="FederatedCredential" data-dfn-type="const" data-export="" id="dom-federatedcredential-federated"><code>federated</code><a class="self-link" href="#dom-federatedcredential-federated"></a></dfn>".</p>
       <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-credential-discovery-slot" id="ref-for-dom-credential-discovery-slot②">[[discovery]]</a></code>
       <dd data-md="">
        <p>The <code class="idl"><a data-link-type="idl" href="#federatedcredential" id="ref-for-federatedcredential③">FederatedCredential</a></code> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object①⑤">interface object</a> has an internal slot named <code>[[discovery]]</code> whose value is "<code class="idl"><a data-link-type="idl" href="#dom-credential-discovery-credential-store" id="ref-for-dom-credential-discovery-credential-store②">credential store</a></code>".</p>
@@ -3054,17 +3058,17 @@ store user credentials for future use.</p>
   to the ways in which credential data can be transmitted over the wire. It might be reasonable,
   for example, to define transmission mechanisms which are restricted to same-origin endpoints.</p>
     <h3 class="heading settled" data-level="6.3" id="insecure-sites"><span class="secno">6.3. </span><span class="content">Insecure Sites</span><a class="self-link" href="#insecure-sites"></a></h3>
-    <p>User agents MUST NOT expose the APIs defined here to environments which are not <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context" id="ref-for-secure-context④">secure
+    <p>User agents MUST NOT expose the APIs defined here to environments which are not <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-contexts" id="ref-for-secure-contexts④">secure
   contexts</a>. User agents might implement autofill mechanisms which store user credentials and fill
   sign-in forms on non-<a data-link-type="dfn" href="https://w3c.github.io/webappsec-mixed-content/#a-priori-authenticated-url" id="ref-for-a-priori-authenticated-url①"><i lang="la">a priori</i> authenticated URLs</a>, but those sites cannot
   be trusted to interact directly with the credential manager in any meaningful way, and those sites
-  MUST NOT have access to credentials saved in <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context" id="ref-for-secure-context⑤">secure contexts</a>.</p>
+  MUST NOT have access to credentials saved in <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-contexts" id="ref-for-secure-contexts⑤">secure contexts</a>.</p>
     <h3 class="heading settled" data-level="6.4" id="security-origin-confusion"><span class="secno">6.4. </span><span class="content">Origin Confusion</span><a class="self-link" href="#security-origin-confusion"></a></h3>
     <p>If framed pages have access to the APIs defined here, it might be possible to confuse a user into
   granting access to credentials for an origin other than the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context" id="ref-for-top-level-browsing-context③">top-level browsing context</a>,
   which is the only security origin which users can reasonably be expected to understand.</p>
     <p>Therefore, both <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get②③">get()</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-store" id="ref-for-dom-credentialscontainer-store①③">store()</a></code> will result in a rejected <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-promise" id="ref-for-idl-promise⑤">Promise</a></code> when called from
-  a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context">nested browsing context</a>, and the API and related interfaces are not exposed inside <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#worker-2" id="ref-for-worker-2">Worker</a></code> contexts.</p>
+  a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context">nested browsing context</a>, and the API and related interfaces are not exposed inside <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#worker" id="ref-for-worker">Worker</a></code> contexts.</p>
     <p>The algorithms in <a href="#algorithm-request">§2.5.1 Request a Credential</a> and <a href="#algorithm-store">§2.5.3 Store a Credential</a> contain more detail.</p>
     <h3 class="heading settled" data-level="6.5" id="security-timing"><span class="secno">6.5. </span><span class="content">Timing Attacks</span><a class="self-link" href="#security-timing"></a></h3>
     <p>If the user has no credentials for an origin, a call to <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get②④">get()</a></code> will
@@ -3129,7 +3133,7 @@ interface ExampleCredential : Credential {
 </pre>
       </div>
      <li data-md="">
-      <p>Define appropriate <code class="idl"><a data-link-type="idl" href="#dom-credential-create-slot" id="ref-for-dom-credential-create-slot②">[[Create]](options)</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-credential-collectfromcredentialstore-slot" id="ref-for-dom-credential-collectfromcredentialstore-slot①">[[CollectFromCredentialStore]](options)</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-credential-discoverfromexternalsource-slot" id="ref-for-dom-credential-discoverfromexternalsource-slot⑤">[[DiscoverFromExternalSource]](options)</a></code>, and <code class="idl"><a data-link-type="idl" href="#dom-credential-store-slot" id="ref-for-dom-credential-store-slot①">[[Store]](credential)</a></code> methods on <code>ExampleCredential</code>'s <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object①⑧">interface object</a>. <code class="idl"><a data-link-type="idl" href="#dom-credential-collectfromcredentialstore-slot" id="ref-for-dom-credential-collectfromcredentialstore-slot②">[[CollectFromCredentialStore]](options)</a></code> is appropriate for <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential①⑦">credentials</a> that remain <a data-link-type="dfn" href="#credential-effective" id="ref-for-credential-effective③">effective</a> forever and
+      <p>Define appropriate <code class="idl"><a data-link-type="idl" href="#dom-credential-create-slot" id="ref-for-dom-credential-create-slot③">[[Create]](options)</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-credential-collectfromcredentialstore-slot" id="ref-for-dom-credential-collectfromcredentialstore-slot①">[[CollectFromCredentialStore]](options)</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-credential-discoverfromexternalsource-slot" id="ref-for-dom-credential-discoverfromexternalsource-slot⑤">[[DiscoverFromExternalSource]](options)</a></code>, and <code class="idl"><a data-link-type="idl" href="#dom-credential-store-slot" id="ref-for-dom-credential-store-slot①">[[Store]](credential)</a></code> methods on <code>ExampleCredential</code>'s <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object①⑧">interface object</a>. <code class="idl"><a data-link-type="idl" href="#dom-credential-collectfromcredentialstore-slot" id="ref-for-dom-credential-collectfromcredentialstore-slot②">[[CollectFromCredentialStore]](options)</a></code> is appropriate for <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential①⑦">credentials</a> that remain <a data-link-type="dfn" href="#credential-effective" id="ref-for-credential-effective③">effective</a> forever and
   can therefore simply be copied out of the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store②⑥">credential store</a>, while <code class="idl"><a data-link-type="idl" href="#dom-credential-discoverfromexternalsource-slot" id="ref-for-dom-credential-discoverfromexternalsource-slot⑥">[[DiscoverFromExternalSource]](options)</a></code> is appropriate for <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential①⑧">credentials</a> that need to be re-generated from a <a data-link-type="dfn" href="#credential-source" id="ref-for-credential-source①">credential source</a>.</p>
       <div class="example" id="example-b597dd69">
        <a class="self-link" href="#example-b597dd69"></a> <code>ExampleCredential</code>'s <code>[[CollectFromCredentialStore]](options)</code> internal method is called
@@ -3375,7 +3379,12 @@ partial dictionary CredentialCreationOptions {
    <li><a href="#dom-credentialmediationrequirement-required">required</a><span>, in §2.3.2</span>
    <li><a href="#origin-requires-user-mediation">requires user mediation</a><span>, in §2.1</span>
    <li><a href="#abstract-opdef-credential-store-retrieve-a-list-of-credentials">Retrieve a list of credentials</a><span>, in §2.1</span>
-   <li><a href="#dom-credential-signal">signal</a><span>, in §2.2</span>
+   <li>
+    signal
+    <ul>
+     <li><a href="#dom-credentialrequestoptions-signal">dict-member for CredentialRequestOptions</a><span>, in §2.3.1</span>
+     <li><a href="#dom-credentialcreationoptions-signal">dict-member for CredentialCreationOptions</a><span>, in §2.4</span>
+    </ul>
    <li><a href="#dom-credentialmediationrequirement-silent">silent</a><span>, in §2.3.2</span>
    <li><a href="#dom-credentialscontainer-store">store()</a><span>, in §2.3</span>
    <li><a href="#abstract-opdef-credential-store-store-a-credential">Store a credential</a><span>, in §2.1</span>
@@ -3388,7 +3397,6 @@ partial dictionary CredentialCreationOptions {
      <li><a href="#dom-passwordcredential-store-slot">method for PasswordCredential</a><span>, in §3.3.3</span>
      <li><a href="#dom-federatedcredential-store-slot">method for FederatedCredential</a><span>, in §4.2.3</span>
     </ul>
-   <li><a href="#concept-credman-terminated">terminated</a><span>, in §2.2.1</span>
    <li><a href="#dom-credential-type">type</a><span>, in §2.2</span>
    <li><a href="#dom-credential-type-slot">[[type]]</a><span>, in §2.2</span>
    <li><a href="#user-mediated">user mediated</a><span>, in §5</span>
@@ -3397,7 +3405,7 @@ partial dictionary CredentialCreationOptions {
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
   <ul class="index">
    <li>
-    <a data-link-type="biblio">[csp-3]</a> defines the following terms:
+    <a data-link-type="biblio">[CSP]</a> defines the following terms:
     <ul>
      <li><a href="https://w3c.github.io/webappsec-csp/#child-src">child-src</a>
      <li><a href="https://w3c.github.io/webappsec-csp/#connect-src">connect-src</a>
@@ -3409,7 +3417,6 @@ partial dictionary CredentialCreationOptions {
     <a data-link-type="biblio">[DOM]</a> defines the following terms:
     <ul>
      <li><a href="https://dom.spec.whatwg.org/#abortsignal">AbortSignal</a>
-     <li><a href="https://dom.spec.whatwg.org/#abortsignal-aborted-flag">aborted flag</a>
      <li><a href="https://dom.spec.whatwg.org/#context-object">context object</a>
      <li><a href="https://dom.spec.whatwg.org/#concept-tree-order">tree order</a>
     </ul>
@@ -3429,7 +3436,7 @@ partial dictionary CredentialCreationOptions {
     <ul>
      <li><a href="https://html.spec.whatwg.org/multipage/forms.html#htmlformelement">HTMLFormElement</a>
      <li><a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">Navigator</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/workers.html#worker-2">Worker</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/workers.html#worker">Worker</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#active-document">active document</a>
      <li><a href="https://html.spec.whatwg.org/multipage/origin.html#ascii-serialisation-of-an-origin">ascii serialization of an origin</a>
      <li><a href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete">autocomplete</a>
@@ -3452,7 +3459,7 @@ partial dictionary CredentialCreationOptions {
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">relevant realm</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document">responsible document</a>
      <li><a href="https://html.spec.whatwg.org/multipage/origin.html#same-origin">same origin</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/forms.html#dom-form-submit-2">submit()</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/forms.html#dom-form-submit">submit()</a>
      <li><a href="https://html.spec.whatwg.org/multipage/forms.html#category-submit">submittable elements</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">top-level browsing context</a>
      <li><a href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-username">username</a>
@@ -3473,17 +3480,7 @@ partial dictionary CredentialCreationOptions {
      <li><a href="https://w3c.github.io/webappsec-mixed-content/#a-priori-authenticated-url">a priori authenticated url</a>
     </ul>
    <li>
-    <a data-link-type="biblio">[mixed-content-1]</a> defines the following terms:
-    <ul>
-     <li><a href="https://w3c.github.io/webappsec-mixed-content/#a-priori-authenticated-url">a priori authenticated url</a>
-    </ul>
-   <li>
     <a data-link-type="biblio">[promises-guide]</a> defines the following terms:
-    <ul>
-     <li><a href="https://www.w3.org/2001/tag/doc/promises-guide/#a-promise-rejected-with">a promise rejected with</a>
-    </ul>
-   <li>
-    <a data-link-type="biblio">[promises-guide-1]</a> defines the following terms:
     <ul>
      <li><a href="https://www.w3.org/2001/tag/doc/promises-guide/#a-new-promise">a new promise</a>
      <li><a href="https://www.w3.org/2001/tag/doc/promises-guide/#a-promise-rejected-with">a promise rejected with</a>
@@ -3498,12 +3495,7 @@ partial dictionary CredentialCreationOptions {
    <li>
     <a data-link-type="biblio">[secure-contexts]</a> defines the following terms:
     <ul>
-     <li><a href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure context</a>
-    </ul>
-   <li>
-    <a data-link-type="biblio">[secure-contexts-1]</a> defines the following terms:
-    <ul>
-     <li><a href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure context</a>
+     <li><a href="https://w3c.github.io/webappsec-secure-contexts/#secure-contexts">secure contexts</a>
     </ul>
    <li>
     <a data-link-type="biblio">[URL]</a> defines the following terms:
@@ -3513,8 +3505,6 @@ partial dictionary CredentialCreationOptions {
    <li>
     <a data-link-type="biblio">[WebIDL]</a> defines the following terms:
     <ul>
-     <li><a href="https://heycam.github.io/webidl/#aborterror">AbortError</a>
-     <li><a href="https://heycam.github.io/webidl/#idl-DOMException">DOMException</a>
      <li><a href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a>
      <li><a href="https://heycam.github.io/webidl/#Exposed">Exposed</a>
      <li><a href="https://heycam.github.io/webidl/#NoInterfaceObject">NoInterfaceObject</a>
@@ -3545,7 +3535,7 @@ partial dictionary CredentialCreationOptions {
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
   <dl>
    <dt id="biblio-csp">[CSP]
-   <dd>Mike West. <a href="https://www.w3.org/TR/CSP3/">Content Security Policy Level 3</a>. URL: <a href="https://www.w3.org/TR/CSP3/">https://www.w3.org/TR/CSP3/</a>
+   <dd>Mike West. <a href="https://www.w3.org/TR/CSP3/">Content Security Policy Level 3</a>. 13 September 2016. WD. URL: <a href="https://www.w3.org/TR/CSP3/">https://www.w3.org/TR/CSP3/</a>
    <dt id="biblio-dom">[DOM]
    <dd>Anne van Kesteren. <a href="https://dom.spec.whatwg.org/">DOM Standard</a>. Living Standard. URL: <a href="https://dom.spec.whatwg.org/">https://dom.spec.whatwg.org/</a>
    <dt id="biblio-fetch">[FETCH]
@@ -3555,17 +3545,19 @@ partial dictionary CredentialCreationOptions {
    <dt id="biblio-infra">[INFRA]
    <dd>Anne van Kesteren; Domenic Denicola. <a href="https://infra.spec.whatwg.org/">Infra Standard</a>. Living Standard. URL: <a href="https://infra.spec.whatwg.org/">https://infra.spec.whatwg.org/</a>
    <dt id="biblio-mixed-content">[MIXED-CONTENT]
-   <dd>Mike West. <a href="https://www.w3.org/TR/mixed-content/">Mixed Content</a>. URL: <a href="https://www.w3.org/TR/mixed-content/">https://www.w3.org/TR/mixed-content/</a>
+   <dd>Mike West. <a href="https://www.w3.org/TR/mixed-content/">Mixed Content</a>. 2 August 2016. CR. URL: <a href="https://www.w3.org/TR/mixed-content/">https://www.w3.org/TR/mixed-content/</a>
    <dt id="biblio-promises-guide">[PROMISES-GUIDE]
    <dd>Domenic Denicola. <a href="https://www.w3.org/2001/tag/doc/promises-guide">Writing Promise-Using Specifications</a>. 16 February 2016. Finding of the W3C TAG. URL: <a href="https://www.w3.org/2001/tag/doc/promises-guide">https://www.w3.org/2001/tag/doc/promises-guide</a>
    <dt id="biblio-psl">[PSL]
    <dd><cite><a href="https://publicsuffix.org/">Public Suffix List</a></cite>.    Mozilla Foundation.
    <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
+   <dt id="biblio-secure-contexts">[SECURE-CONTEXTS]
+   <dd>Mike West. <a href="https://www.w3.org/TR/secure-contexts/">Secure Contexts</a>. 15 September 2016. CR. URL: <a href="https://www.w3.org/TR/secure-contexts/">https://www.w3.org/TR/secure-contexts/</a>
    <dt id="biblio-url">[URL]
    <dd>Anne van Kesteren. <a href="https://url.spec.whatwg.org/">URL Standard</a>. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
    <dt id="biblio-webidl">[WebIDL]
-   <dd>Cameron McCormack; Boris Zbarsky; Tobie Langel. <a href="https://heycam.github.io/webidl/">Web IDL</a>. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
+   <dd>Cameron McCormack; Boris Zbarsky; Tobie Langel. <a href="https://heycam.github.io/webidl/">Web IDL</a>. 15 December 2016. ED. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
    <dt id="biblio-xhr">[XHR]
    <dd>Anne van Kesteren. <a href="https://xhr.spec.whatwg.org/">XMLHttpRequest Standard</a>. Living Standard. URL: <a href="https://xhr.spec.whatwg.org/">https://xhr.spec.whatwg.org/</a>
   </dl>
@@ -3573,25 +3565,22 @@ partial dictionary CredentialCreationOptions {
   <dl>
    <dt id="biblio-browserid">[BROWSERID]
    <dd>Ben Adida; et al. <a href="https://github.com/mozilla/id-specs/blob/prod/browserid/index.md">BrowserID</a>. 26 February 2013. URL: <a href="https://github.com/mozilla/id-specs/blob/prod/browserid/index.md">https://github.com/mozilla/id-specs/blob/prod/browserid/index.md</a>
-   <dt id="biblio-secure-contexts">[SECURE-CONTEXTS]
-   <dd>Mike West. <a href="https://www.w3.org/TR/secure-contexts/">Secure Contexts</a>. URL: <a href="https://www.w3.org/TR/secure-contexts/">https://www.w3.org/TR/secure-contexts/</a>
    <dt id="biblio-sri">[SRI]
-   <dd>Devdatta Akhawe; et al. <a href="https://www.w3.org/TR/SRI/">Subresource Integrity</a>. URL: <a href="https://www.w3.org/TR/SRI/">https://www.w3.org/TR/SRI/</a>
+   <dd>Devdatta Akhawe; et al. <a href="https://www.w3.org/TR/SRI/">Subresource Integrity</a>. 23 June 2016. REC. URL: <a href="https://www.w3.org/TR/SRI/">https://www.w3.org/TR/SRI/</a>
    <dt id="biblio-web-login">[WEB-LOGIN]
    <dd>Jason Denizac; Robin Berjon; Anne van Kesteren. <a href="https://github.com/jden/web-login">web-login</a>. URL: <a href="https://github.com/jden/web-login">https://github.com/jden/web-login</a>
    <dt id="biblio-webauthn">[WEBAUTHN]
-   <dd>Vijay Bharadwaj; et al. <a href="https://www.w3.org/TR/webauthn/">Web Authentication: An API for accessing Public Key Credentials Level 1</a>. URL: <a href="https://www.w3.org/TR/webauthn/">https://www.w3.org/TR/webauthn/</a>
+   <dd>Vijay Bharadwaj; et al. <a href="https://www.w3.org/TR/webauthn/">Web Authentication: An API for accessing Public Key Credentials Level 1</a>. 11 August 2017. WD. URL: <a href="https://www.w3.org/TR/webauthn/">https://www.w3.org/TR/webauthn/</a>
    <dt id="biblio-webmessaging">[WEBMESSAGING]
-   <dd>Ian Hickson. <a href="https://www.w3.org/TR/webmessaging/">HTML5 Web Messaging</a>. URL: <a href="https://www.w3.org/TR/webmessaging/">https://www.w3.org/TR/webmessaging/</a>
+   <dd>Ian Hickson. <a href="https://www.w3.org/TR/webmessaging/">HTML5 Web Messaging</a>. 19 May 2015. REC. URL: <a href="https://www.w3.org/TR/webmessaging/">https://www.w3.org/TR/webmessaging/</a>
    <dt id="biblio-xmlhttprequest">[XMLHTTPREQUEST]
-   <dd>Anne van Kesteren; et al. <a href="https://www.w3.org/TR/XMLHttpRequest/">XMLHttpRequest Level 1</a>. URL: <a href="https://www.w3.org/TR/XMLHttpRequest/">https://www.w3.org/TR/XMLHttpRequest/</a>
+   <dd>Anne van Kesteren; et al. <a href="https://www.w3.org/TR/XMLHttpRequest/">XMLHttpRequest Level 1</a>. 6 October 2016. NOTE. URL: <a href="https://www.w3.org/TR/XMLHttpRequest/">https://www.w3.org/TR/XMLHttpRequest/</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
 <pre class="idl highlight def">[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed④">Exposed</a>=<span class="n">Window</span>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext⑥">SecureContext</a>]
 <span class="kt">interface</span> <a class="nv" href="#credential"><code>Credential</code></a> {
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①⑧"><span class="kt">USVString</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-credential-id" id="ref-for-dom-credential-id①①">id</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑥"><span class="kt">DOMString</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-credential-type" id="ref-for-dom-credential-type③">type</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#abortsignal" id="ref-for-abortsignal④">AbortSignal</a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="AbortSignal" href="#dom-credential-signal" id="ref-for-dom-credential-signal①">signal</a>;
 };
 
 [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#NoInterfaceObject" id="ref-for-NoInterfaceObject①">NoInterfaceObject</a>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext①①">SecureContext</a>]
@@ -3618,6 +3607,7 @@ partial dictionary CredentialCreationOptions {
 
 <span class="kt">dictionary</span> <a class="nv" href="#dictdef-credentialrequestoptions"><code>CredentialRequestOptions</code></a> {
   <a class="n" data-link-type="idl-name" href="#enumdef-credentialmediationrequirement" id="ref-for-enumdef-credentialmediationrequirement④">CredentialMediationRequirement</a> <a class="nv idl-code" data-default="&quot;optional&quot;" data-link-type="dict-member" data-type="CredentialMediationRequirement " href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation①⑤">mediation</a> = "optional";
+  <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#abortsignal" id="ref-for-abortsignal④">AbortSignal</a> <a class="nv idl-code" data-link-type="dict-member" data-type="AbortSignal " href="#dom-credentialrequestoptions-signal" id="ref-for-dom-credentialrequestoptions-signal①">signal</a>;
 };
 
 <span class="kt">enum</span> <a class="nv" href="#enumdef-credentialmediationrequirement"><code>CredentialMediationRequirement</code></a> {
@@ -3627,6 +3617,7 @@ partial dictionary CredentialCreationOptions {
 };
 
 <span class="kt">dictionary</span> <a class="nv" href="#dictdef-credentialcreationoptions"><code>CredentialCreationOptions</code></a> {
+  <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#abortsignal" id="ref-for-abortsignal②①">AbortSignal</a> <a class="nv idl-code" data-link-type="dict-member" data-type="AbortSignal " href="#dom-credentialcreationoptions-signal" id="ref-for-dom-credentialcreationoptions-signal①">signal</a>;
 };
 
 <span class="kt">typedef</span> (<a class="n" data-link-type="idl-name" href="https://xhr.spec.whatwg.org/#interface-formdata" id="ref-for-interface-formdata③">FormData</a> <span class="kt">or</span> <a class="n" data-link-type="idl-name" href="https://url.spec.whatwg.org/#urlsearchparams" id="ref-for-urlsearchparams①">URLSearchParams</a>) <a class="nv" href="#typedefdef-credentialbodytype"><code>CredentialBodyType</code></a>;
@@ -3826,12 +3817,6 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-dom-credential-type①">3.1.1. Password-based Sign-in</a> <a href="#ref-for-dom-credential-type②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-credential-signal">
-   <b><a href="#dom-credential-signal">#dom-credential-signal</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dom-credential-signal">2.2. The Credential Interface</a>
-   </ul>
-  </aside>
   <aside class="dfn-panel" data-for="dom-credential-type-slot">
    <b><a href="#dom-credential-type-slot">#dom-credential-type-slot</a></b><b>Referenced in:</b>
    <ul>
@@ -3885,14 +3870,6 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-dom-credential-origin-slot①②">6.1. Cross-domain credential access</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-credman-terminated">
-   <b><a href="#concept-credman-terminated">#concept-credman-terminated</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-credman-terminated">2.2. The Credential Interface</a>
-    <li><a href="#ref-for-concept-credman-terminated①">2.2.1. Credential Internal Methods</a>
-    <li><a href="#ref-for-concept-credman-terminated②">2.5.4. Create a Credential</a>
-   </ul>
-  </aside>
   <aside class="dfn-panel" data-for="dom-credential-collectfromcredentialstore-slot">
    <b><a href="#dom-credential-collectfromcredentialstore-slot">#dom-credential-collectfromcredentialstore-slot</a></b><b>Referenced in:</b>
    <ul>
@@ -3903,8 +3880,8 @@ partial dictionary CredentialCreationOptions {
   <aside class="dfn-panel" data-for="dom-credential-discoverfromexternalsource-slot">
    <b><a href="#dom-credential-discoverfromexternalsource-slot">#dom-credential-discoverfromexternalsource-slot</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-credential-discoverfromexternalsource-slot">2.2. The Credential Interface</a>
-    <li><a href="#ref-for-dom-credential-discoverfromexternalsource-slot①">2.2.1. Credential Internal Methods</a>
+    <li><a href="#ref-for-dom-credential-discoverfromexternalsource-slot">2.2.1. Credential Internal Methods</a>
+    <li><a href="#ref-for-dom-credential-discoverfromexternalsource-slot①">2.3.1. The CredentialRequestOptions Dictionary</a>
     <li><a href="#ref-for-dom-credential-discoverfromexternalsource-slot②">2.5.1. Request a Credential</a>
     <li><a href="#ref-for-dom-credential-discoverfromexternalsource-slot③">3.2. The PasswordCredential Interface</a>
     <li><a href="#ref-for-dom-credential-discoverfromexternalsource-slot④">4.1. The FederatedCredential Interface</a>
@@ -3922,8 +3899,9 @@ partial dictionary CredentialCreationOptions {
    <b><a href="#dom-credential-create-slot">#dom-credential-create-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credential-create-slot">2.2.1. Credential Internal Methods</a>
-    <li><a href="#ref-for-dom-credential-create-slot①">2.5.4. Create a Credential</a>
-    <li><a href="#ref-for-dom-credential-create-slot②">7.2. Extension Points</a>
+    <li><a href="#ref-for-dom-credential-create-slot①">2.4. The CredentialCreationOptions Dictionary</a>
+    <li><a href="#ref-for-dom-credential-create-slot②">2.5.4. Create a Credential</a>
+    <li><a href="#ref-for-dom-credential-create-slot③">7.2. Extension Points</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="credentialuserdata">
@@ -4098,6 +4076,12 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-dom-credentialrequestoptions-mediation①④">7.1. Website Authors</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="dom-credentialrequestoptions-signal">
+   <b><a href="#dom-credentialrequestoptions-signal">#dom-credentialrequestoptions-signal</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-credentialrequestoptions-signal">2.3.1. The CredentialRequestOptions Dictionary</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="credentialrequestoptions-relevant-credential-interface-objects">
    <b><a href="#credentialrequestoptions-relevant-credential-interface-objects">#credentialrequestoptions-relevant-credential-interface-objects</a></b><b>Referenced in:</b>
    <ul>
@@ -4161,6 +4145,12 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-dictdef-credentialcreationoptions⑨">4.2.2. 
     FederatedCredential's [[Create]](options) </a>
     <li><a href="#ref-for-dictdef-credentialcreationoptions①⓪">7.2. Extension Points</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-credentialcreationoptions-signal">
+   <b><a href="#dom-credentialcreationoptions-signal">#dom-credentialcreationoptions-signal</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-credentialcreationoptions-signal">2.4. The CredentialCreationOptions Dictionary</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="abstract-opdef-request-a-credential">
@@ -4312,8 +4302,7 @@ partial dictionary CredentialCreationOptions {
   <aside class="dfn-panel" data-for="dom-passwordcredential-create-slot">
    <b><a href="#dom-passwordcredential-create-slot">#dom-passwordcredential-create-slot</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-passwordcredential-create-slot">2.2. The Credential Interface</a>
-    <li><a href="#ref-for-dom-passwordcredential-create-slot①">3.2. The PasswordCredential Interface</a>
+    <li><a href="#ref-for-dom-passwordcredential-create-slot">3.2. The PasswordCredential Interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-passwordcredential-store-slot">

--- a/index.html
+++ b/index.html
@@ -1800,7 +1800,7 @@ store user credentials for future use.</p>
     </section>
     <section class="algorithm" data-algorithm="&apos;create a credential&apos; internal method">
       <dfn class="dfn-paneled idl-code" data-dfn-for="Credential" data-dfn-type="method" data-export="" id="dom-credential-create-slot"><code>[[Create]](options)</code></dfn> is called with a <code class="idl"><a data-link-type="idl" href="#dictdef-credentialcreationoptions" id="ref-for-dictdef-credentialcreationoptions">CredentialCreationOptions</a></code>, and returns either a <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential①⑤">Credential</a></code>, if one can be created, <code>null</code> if no credential was created, or an error if creation fails due to exceptional situations
-    (for example, incorrect options could produce a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror①">TypeError</a></code>). 
+    (for example, incorrect options could produce a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror①">TypeError</a></code>): 
      <ol class="algorithm">
       <li data-md="">
        <p>Return <code>null</code>.</p>

--- a/index.html
+++ b/index.html
@@ -1176,155 +1176,155 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 760cc1c5c9221f585aba069d03f7e9f2a0ecb1df" name="generator">
+  <meta content="Bikeshed version fa5b8b17ec5b76772d473054c6882432da32a814" name="generator">
   <link href="http://www.w3.org/TR/credential-management-1/" rel="canonical">
 <style>/* style-md-lists */
 
-            /* This is a weird hack for me not yet following the commonmark spec
-               regarding paragraph and lists. */
-            [data-md] > :first-child {
-                margin-top: 0;
-            }
-            [data-md] > :last-child {
-                margin-bottom: 0;
-            }</style>
+/* This is a weird hack for me not yet following the commonmark spec
+   regarding paragraph and lists. */
+[data-md] > :first-child {
+    margin-top: 0;
+}
+[data-md] > :last-child {
+    margin-bottom: 0;
+}</style>
 <style>/* style-selflinks */
 
-            .heading, .issue, .note, .example, li, dt {
-                position: relative;
-            }
-            a.self-link {
-                position: absolute;
-                top: 0;
-                left: calc(-1 * (3.5rem - 26px));
-                width: calc(3.5rem - 26px);
-                height: 2em;
-                text-align: center;
-                border: none;
-                transition: opacity .2s;
-                opacity: .5;
-            }
-            a.self-link:hover {
-                opacity: 1;
-            }
-            .heading > a.self-link {
-                font-size: 83%;
-            }
-            li > a.self-link {
-                left: calc(-1 * (3.5rem - 26px) - 2em);
-            }
-            dfn > a.self-link {
-                top: auto;
-                left: auto;
-                opacity: 0;
-                width: 1.5em;
-                height: 1.5em;
-                background: gray;
-                color: white;
-                font-style: normal;
-                transition: opacity .2s, background-color .2s, color .2s;
-            }
-            dfn:hover > a.self-link {
-                opacity: 1;
-            }
-            dfn > a.self-link:hover {
-                color: black;
-            }
+.heading, .issue, .note, .example, li, dt {
+    position: relative;
+}
+a.self-link {
+    position: absolute;
+    top: 0;
+    left: calc(-1 * (3.5rem - 26px));
+    width: calc(3.5rem - 26px);
+    height: 2em;
+    text-align: center;
+    border: none;
+    transition: opacity .2s;
+    opacity: .5;
+}
+a.self-link:hover {
+    opacity: 1;
+}
+.heading > a.self-link {
+    font-size: 83%;
+}
+li > a.self-link {
+    left: calc(-1 * (3.5rem - 26px) - 2em);
+}
+dfn > a.self-link {
+    top: auto;
+    left: auto;
+    opacity: 0;
+    width: 1.5em;
+    height: 1.5em;
+    background: gray;
+    color: white;
+    font-style: normal;
+    transition: opacity .2s, background-color .2s, color .2s;
+}
+dfn:hover > a.self-link {
+    opacity: 1;
+}
+dfn > a.self-link:hover {
+    color: black;
+}
 
-            a.self-link::before            { content: "¶"; }
-            .heading > a.self-link::before { content: "§"; }
-            dfn > a.self-link::before      { content: "#"; }</style>
+a.self-link::before            { content: "¶"; }
+.heading > a.self-link::before { content: "§"; }
+dfn > a.self-link::before      { content: "#"; }</style>
 <style>/* style-counters */
 
-            body {
-                counter-reset: example figure issue;
-            }
-            .issue {
-                counter-increment: issue;
-            }
-            .issue:not(.no-marker)::before {
-                content: "Issue " counter(issue);
-            }
+body {
+    counter-reset: example figure issue;
+}
+.issue {
+    counter-increment: issue;
+}
+.issue:not(.no-marker)::before {
+    content: "Issue " counter(issue);
+}
 
-            .example {
-                counter-increment: example;
-            }
-            .example:not(.no-marker)::before {
-                content: "Example " counter(example);
-            }
-            .invalid.example:not(.no-marker)::before,
-            .illegal.example:not(.no-marker)::before {
-                content: "Invalid Example" counter(example);
-            }
+.example {
+    counter-increment: example;
+}
+.example:not(.no-marker)::before {
+    content: "Example " counter(example);
+}
+.invalid.example:not(.no-marker)::before,
+.illegal.example:not(.no-marker)::before {
+    content: "Invalid Example" counter(example);
+}
 
-            figcaption {
-                counter-increment: figure;
-            }
-            figcaption:not(.no-marker)::before {
-                content: "Figure " counter(figure) " ";
-            }</style>
+figcaption {
+    counter-increment: figure;
+}
+figcaption:not(.no-marker)::before {
+    content: "Figure " counter(figure) " ";
+}</style>
 <style>/* style-autolinks */
 
-            .css.css, .property.property, .descriptor.descriptor {
-                color: #005a9c;
-                font-size: inherit;
-                font-family: inherit;
-            }
-            .css::before, .property::before, .descriptor::before {
-                content: "‘";
-            }
-            .css::after, .property::after, .descriptor::after {
-                content: "’";
-            }
-            .property, .descriptor {
-                /* Don't wrap property and descriptor names */
-                white-space: nowrap;
-            }
-            .type { /* CSS value <type> */
-                font-style: italic;
-            }
-            pre .property::before, pre .property::after {
-                content: "";
-            }
-            [data-link-type="property"]::before,
-            [data-link-type="propdesc"]::before,
-            [data-link-type="descriptor"]::before,
-            [data-link-type="value"]::before,
-            [data-link-type="function"]::before,
-            [data-link-type="at-rule"]::before,
-            [data-link-type="selector"]::before,
-            [data-link-type="maybe"]::before {
-                content: "‘";
-            }
-            [data-link-type="property"]::after,
-            [data-link-type="propdesc"]::after,
-            [data-link-type="descriptor"]::after,
-            [data-link-type="value"]::after,
-            [data-link-type="function"]::after,
-            [data-link-type="at-rule"]::after,
-            [data-link-type="selector"]::after,
-            [data-link-type="maybe"]::after {
-                content: "’";
-            }
+.css.css, .property.property, .descriptor.descriptor {
+    color: #005a9c;
+    font-size: inherit;
+    font-family: inherit;
+}
+.css::before, .property::before, .descriptor::before {
+    content: "‘";
+}
+.css::after, .property::after, .descriptor::after {
+    content: "’";
+}
+.property, .descriptor {
+    /* Don't wrap property and descriptor names */
+    white-space: nowrap;
+}
+.type { /* CSS value <type> */
+    font-style: italic;
+}
+pre .property::before, pre .property::after {
+    content: "";
+}
+[data-link-type="property"]::before,
+[data-link-type="propdesc"]::before,
+[data-link-type="descriptor"]::before,
+[data-link-type="value"]::before,
+[data-link-type="function"]::before,
+[data-link-type="at-rule"]::before,
+[data-link-type="selector"]::before,
+[data-link-type="maybe"]::before {
+    content: "‘";
+}
+[data-link-type="property"]::after,
+[data-link-type="propdesc"]::after,
+[data-link-type="descriptor"]::after,
+[data-link-type="value"]::after,
+[data-link-type="function"]::after,
+[data-link-type="at-rule"]::after,
+[data-link-type="selector"]::after,
+[data-link-type="maybe"]::after {
+    content: "’";
+}
 
-            [data-link-type].production::before,
-            [data-link-type].production::after,
-            .prod [data-link-type]::before,
-            .prod [data-link-type]::after {
-                content: "";
-            }
+[data-link-type].production::before,
+[data-link-type].production::after,
+.prod [data-link-type]::before,
+.prod [data-link-type]::after {
+    content: "";
+}
 
-            [data-link-type=element],
-            [data-link-type=element-attr] {
-                font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
-                font-size: .9em;
-            }
-            [data-link-type=element]::before { content: "<" }
-            [data-link-type=element]::after  { content: ">" }
+[data-link-type=element],
+[data-link-type=element-attr] {
+    font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
+    font-size: .9em;
+}
+[data-link-type=element]::before { content: "<" }
+[data-link-type=element]::after  { content: ">" }
 
-            [data-link-type=biblio] {
-                white-space: pre;
-            }</style>
+[data-link-type=biblio] {
+    white-space: pre;
+}</style>
 <style>/* style-dfn-panel */
 
         .dfn-panel {
@@ -1424,7 +1424,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1>Credential Management Level 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-08-04">4 August 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-09-05">5 September 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1611,22 +1611,22 @@ store user credentials for future use.</p>
     <p>Signing into websites is more difficult than it should be. The user agent is in a unique position
   to improve the experience in a number of ways, and most modern user agents have recognized this by
   providing some measure of  credential management natively in the browser. Users can save usernames
-  and passwords for websites, and those <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential-1">credentials</a> are autofilled into sign-in forms with
+  and passwords for websites, and those <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential">credentials</a> are autofilled into sign-in forms with
   varying degrees of success.</p>
-    <p>The <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete">autocomplete</a></code> attribute offers a declarative mechanism by which websites can work
+    <p>The <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete" id="ref-for-attr-fe-autocomplete">autocomplete</a></code> attribute offers a declarative mechanism by which websites can work
   with user agents to improve the latter’s ability to detect and fill sign-in forms by marking
   specific fields as "username" or "password", and user agents implement a wide variety of detection
   heuristics to work with websites which haven’t taken the time to provide this detail in markup.</p>
     <p>While this combination of heuristic and declarative detection works relatively well, the status
   quo leaves some large gaps where detection is problematic. Sites with uncommon sign-in
-  mechanisms (submitting credentials via <code class="idl"><a data-link-type="idl" href="https://xhr.spec.whatwg.org/#xmlhttprequest">XMLHttpRequest</a></code> <a data-link-type="biblio" href="#biblio-xmlhttprequest">[XMLHTTPREQUEST]</a>, for instance) are
+  mechanisms (submitting credentials via <code class="idl"><a data-link-type="idl" href="https://xhr.spec.whatwg.org/#xmlhttprequest" id="ref-for-xmlhttprequest">XMLHttpRequest</a></code> <a data-link-type="biblio" href="#biblio-xmlhttprequest">[XMLHTTPREQUEST]</a>, for instance) are
   difficult to reliably detect, as is the increasingly common case in which users wish to
   authenticate themselves using a federated identity provider. Allowing websites to more directly
   interact with the user agent’s credential manager would allow the credential manager to be more
   accurate on the one hand, and to assist users with federated sign-in on the other.</p>
     <p>These use cases are explored in more detail in <a href="#use-cases">§1.1 Use Cases</a> and in <a href="https://w3c.github.io/webappsec/usecases/credentialmanagement/">Credential Management:
   Use Cases and Requirements</a>; this specification attempts to address many of the requirements
-  that document outlines by defining a Credential Manager API which a website can use to request <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential-2">credentials</a> for a user, and to ask the user agent to persist credentials when a user signs in
+  that document outlines by defining a Credential Manager API which a website can use to request <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential①">credentials</a> for a user, and to ask the user agent to persist credentials when a user signs in
   successfully.</p>
     <p class="note" role="note"><span>Note:</span> The API defined here is intentionally small and simple: it does not intend to provide
   authentication in and of itself, but is limited to providing an interface to the existing
@@ -1654,7 +1654,7 @@ store user credentials for future use.</p>
      <li data-md="">
       <p>Likewise, user agents struggle to detect more esoteric sign-in
   mechanisms than simple username/password forms. Authors increasingly
-  asynchronously sign users in via <code class="idl"><a data-link-type="idl" href="https://xhr.spec.whatwg.org/#xmlhttprequest">XMLHttpRequest</a></code> or similar
+  asynchronously sign users in via <code class="idl"><a data-link-type="idl" href="https://xhr.spec.whatwg.org/#xmlhttprequest" id="ref-for-xmlhttprequest①">XMLHttpRequest</a></code> or similar
   mechanisms in order to improve the experience and take more control over
   the presentation. This is good for users, but tough for user agents to
   integrate into their password managers. It would be nice if a website
@@ -1670,13 +1670,13 @@ store user credentials for future use.</p>
     <h2 class="heading settled" data-level="2" id="core"><span class="secno">2. </span><span class="content">Core API</span><a class="self-link" href="#core"></a></h2>
     <p>From a developer’s perspective, a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="concept-credential">credential</dfn> is an
   object which allows a developer to make an authentication decision for a particular action. This
-  section defines a generic and extensible <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-1">Credential</a></code> interface which serves as a base class
-  for <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential-3">credentials</a> defined in this and other documents, along with a set of APIs
-  hanging off of <code class="idl"><a data-link-type="idl" href="#credentialscontainer" id="ref-for-credentialscontainer-1">navigator.credentials.*</a></code> which enable developers to
+  section defines a generic and extensible <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential">Credential</a></code> interface which serves as a base class
+  for <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential②">credentials</a> defined in this and other documents, along with a set of APIs
+  hanging off of <code class="idl"><a data-link-type="idl" href="#credentialscontainer" id="ref-for-credentialscontainer">navigator.credentials.*</a></code> which enable developers to
   obtain them.</p>
-    <p>Various types of <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential-4">credentials</a> are represented to JavaScript as an interface which <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherit">inherits</a>, either directly or indirectly, from the <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-2">Credential</a></code> interface. This
-  document defines two such interfaces, <code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential-1">PasswordCredential</a></code> and <code class="idl"><a data-link-type="idl" href="#federatedcredential" id="ref-for-federatedcredential-1">FederatedCredential</a></code>.</p>
-    <p>A <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential-5">credential</a> is <dfn class="dfn-paneled" data-dfn-for="credential" data-dfn-type="dfn" data-export="" id="credential-effective">effective</dfn> for a particular <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">origin</a> if it
+    <p>Various types of <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential③">credentials</a> are represented to JavaScript as an interface which <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherit" id="ref-for-dfn-inherit">inherits</a>, either directly or indirectly, from the <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential①">Credential</a></code> interface. This
+  document defines two such interfaces, <code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential">PasswordCredential</a></code> and <code class="idl"><a data-link-type="idl" href="#federatedcredential" id="ref-for-federatedcredential">FederatedCredential</a></code>.</p>
+    <p>A <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential④">credential</a> is <dfn class="dfn-paneled" data-dfn-for="credential" data-dfn-type="dfn" data-export="" id="credential-effective">effective</dfn> for a particular <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin">origin</a> if it
   is accepted as authentication on that origin. Even if a credential is effective at a particular
   point in time, the UA can’t assume that the same credential will be effective at any future time,
   for a couple reasons:</p>
@@ -1687,7 +1687,7 @@ store user credentials for future use.</p>
       <p>A credential made from a token received over SMS is likely to only be effective for a single
  use.</p>
     </ol>
-    <p>Single-use <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential-6">credentials</a> are generated by a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="credential-source">credential source</dfn>, which could be
+    <p>Single-use <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential⑤">credentials</a> are generated by a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="credential-source">credential source</dfn>, which could be
   a private key, access to a federated account, the ability to receive SMS messages at a particular
   phone number, or something else. Credential sources are not exposed to Javascript or explicitly
   represented in this specification. To unify the model, we consider a password to be a credential
@@ -1695,78 +1695,84 @@ store user credentials for future use.</p>
     <p>Even though the UA can’t assume that an effective credential will still be effective if used a
   second time, or that a credential source that has generated an effective credential will be able
   to generate a second effective credential in the future, the second is more likely than the first.
-  By recording (with <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-store" id="ref-for-dom-credentialscontainer-store-1">store()</a></code>) which credentials have been effective in the
+  By recording (with <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-store" id="ref-for-dom-credentialscontainer-store">store()</a></code>) which credentials have been effective in the
   past, the UA has a better chance of <a href="#user-mediated-selection">offering</a> effective credential
   sources to the user in the future.</p>
     <h3 class="heading settled" data-level="2.1" id="core-infrastructure"><span class="secno">2.1. </span><span class="content">Infrastructure</span><a class="self-link" href="#core-infrastructure"></a></h3>
     <p>User agents MUST internally provide a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="credential store" id="concept-credential-store">credential
-  store</dfn>, which is a vendor-specific, opaque storage mechanism to record which <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential-7">credentials</a> have been <a data-link-type="dfn" href="#credential-effective" id="ref-for-credential-effective-1">effective</a>. It offers the following capabilities for <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential-8">credential</a> access and
+  store</dfn>, which is a vendor-specific, opaque storage mechanism to record which <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential⑥">credentials</a> have been <a data-link-type="dfn" href="#credential-effective" id="ref-for-credential-effective">effective</a>. It offers the following capabilities for <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential⑦">credential</a> access and
   persistence:</p>
     <ol>
      <li data-md="">
       <p><dfn data-dfn-for="credential store" data-dfn-type="abstract-op" data-export="" id="abstract-opdef-credential-store-store-a-credential">Store a credential<a class="self-link" href="#abstract-opdef-credential-store-store-a-credential"></a></dfn> for later retrieval.
-  This accepts a <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential-9">credential</a>, and inserts it into the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store-1">credential store</a>.</p>
+  This accepts a <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential⑧">credential</a>, and inserts it into the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store">credential store</a>.</p>
      <li data-md="">
       <p><dfn class="dfn-paneled" data-dfn-for="credential store" data-dfn-type="abstract-op" data-export="" id="abstract-opdef-credential-store-retrieve-a-list-of-credentials">Retrieve a list of credentials</dfn>. This
-  accepts an arbitrary filter, and returns a set of <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential-10">credentials</a> that match the filter.</p>
+  accepts an arbitrary filter, and returns a set of <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential⑨">credentials</a> that match the filter.</p>
      <li data-md="">
-      <p><dfn data-dfn-for="credential store" data-dfn-type="abstract-op" data-export="" id="abstract-opdef-credential-store-modify-a-credential">Modify a credential<a class="self-link" href="#abstract-opdef-credential-store-modify-a-credential"></a></dfn>. This accepts a <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential-11">credential</a>, and overwrites the state of an existing <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential-12">credential</a> in the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store-2">credential store</a>.</p>
+      <p><dfn data-dfn-for="credential store" data-dfn-type="abstract-op" data-export="" id="abstract-opdef-credential-store-modify-a-credential">Modify a credential<a class="self-link" href="#abstract-opdef-credential-store-modify-a-credential"></a></dfn>. This accepts a <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential①⓪">credential</a>, and overwrites the state of an existing <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential①①">credential</a> in the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store①">credential store</a>.</p>
     </ol>
-    <p>Additionally, the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store-3">credential store</a> should maintain a <dfn class="dfn-paneled" data-dfn-for="origin" data-dfn-type="dfn" data-noexport="" id="origin-prevent-silent-access-flag"><code>prevent silent access</code> flag</dfn> for <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">origins</a> (which is set to <code>true</code> unless otherwise specified).
+    <p>Additionally, the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store②">credential store</a> should maintain a <dfn class="dfn-paneled" data-dfn-for="origin" data-dfn-type="dfn" data-noexport="" id="origin-prevent-silent-access-flag"><code>prevent silent access</code> flag</dfn> for <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin①">origins</a> (which is set to <code>true</code> unless otherwise specified).
   An origin <dfn class="dfn-paneled" data-dfn-for="origin" data-dfn-type="dfn" data-noexport="" id="origin-requires-user-mediation">requires user mediation</dfn> if its flag is set to <code>true</code>.</p>
     <p class="note" role="note"><span>Note:</span> The importance of user mediation is discussed in more detail in <a href="#user-mediation">§5 User Mediation</a>.</p>
-    <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store-4">credential store</a> is an internal implementation detail of a user agent’s
+    <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store③">credential store</a> is an internal implementation detail of a user agent’s
   implementation of the API specified in this document, and is not exposed to the web directly.
-  More capabilities may be specified by other documents in support of specific <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential-13">credential</a> types.</p>
+  More capabilities may be specified by other documents in support of specific <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential①②">credential</a> types.</p>
     <p>This document depends on the Infra Standard for a number of foundational concepts used in its
   algorithms and prose <a data-link-type="biblio" href="#biblio-infra">[INFRA]</a>.</p>
     <h3 class="heading settled" data-level="2.2" id="the-credential-interface"><span class="secno">2.2. </span><span class="content">The <code>Credential</code> Interface</span><a class="self-link" href="#the-credential-interface"></a></h3>
-<pre class="idl highlight def">[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">Window</span>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext">SecureContext</a>]
+<pre class="idl highlight def">[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed">Exposed</a>=<span class="n">Window</span>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext">SecureContext</a>]
 <span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="credential"><code>Credential</code></dfn> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString"><span class="kt">USVString</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-credential-id" id="ref-for-dom-credential-id-1">id</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-credential-type" id="ref-for-dom-credential-type-1">type</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString"><span class="kt">USVString</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-credential-id" id="ref-for-dom-credential-id">id</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString"><span class="kt">DOMString</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-credential-type" id="ref-for-dom-credential-type">type</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#abortsignal" id="ref-for-abortsignal">AbortSignal</a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="AbortSignal" href="#dom-credential-signal" id="ref-for-dom-credential-signal">signal</a>;
 };
 </pre>
     <div>
      <dl>
-      <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="Credential" data-dfn-type="attribute" data-export="" id="dom-credential-id"><code>id</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-USVString">USVString</a>, readonly</span>
+      <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="Credential" data-dfn-type="attribute" data-export="" id="dom-credential-id"><code>id</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①">USVString</a>, readonly</span>
       <dd data-md="">
        <p>The credential’s identifier. The requirements for the identifier are distinct for each type
-  of <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential-14">credential</a>. It might represent a username for username/password tuples, for example.</p>
-      <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="Credential" data-dfn-type="attribute" data-export="" id="dom-credential-type"><code>type</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a>, readonly</span>
+  of <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential①③">credential</a>. It might represent a username for username/password tuples, for example.</p>
+      <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="Credential" data-dfn-type="attribute" data-export="" id="dom-credential-type"><code>type</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①">DOMString</a>, readonly</span>
       <dd data-md="">
-       <p>This attribute’s getter returns the value of the object’s <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object">interface object</a>'s <code class="idl"><a data-link-type="idl" href="#dom-credential-type-slot" id="ref-for-dom-credential-type-slot-1">[[type]]</a></code> slot, which specifies the kind of credential represented by this object.</p>
+       <p>This attribute’s getter returns the value of the object’s <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object">interface object</a>'s <code class="idl"><a data-link-type="idl" href="#dom-credential-type-slot" id="ref-for-dom-credential-type-slot">[[type]]</a></code> slot, which specifies the kind of credential represented by this object.</p>
+      <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="Credential" data-dfn-type="attribute" data-export="" id="dom-credential-signal"><code>signal</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#abortsignal" id="ref-for-abortsignal①">AbortSignal</a>, readonly</span>
+      <dd data-md="">
+       <p>The credential object has an associated signal (an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#abortsignal" id="ref-for-abortsignal②">AbortSignal</a></code> object), initially
+  a new <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#abortsignal" id="ref-for-abortsignal③">AbortSignal</a></code> object. Developers can use AbortSignal to <a data-link-type="dfn" href="#concept-credman-terminated" id="ref-for-concept-credman-terminated">terminate</a> an 
+  ongoing <code class="idl"><a data-link-type="idl" href="#dom-passwordcredential-create-slot" id="ref-for-dom-passwordcredential-create-slot">[[Create]](options)</a></code> operation or <code class="idl"><a data-link-type="idl" href="#dom-credential-discoverfromexternalsource-slot" id="ref-for-dom-credential-discoverfromexternalsource-slot">[[DiscoverFromExternalSource]](options)</a></code> operation.</p>
       <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="Credential" data-dfn-type="attribute" data-export="" id="dom-credential-type-slot"><code>[[type]]</code></dfn>
       <dd data-md="">
-       <p>The <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-3">Credential</a></code> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object">interface object</a> has an internal slot named <code>[[type]]</code>, which
+       <p>The <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential②">Credential</a></code> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object①">interface object</a> has an internal slot named <code>[[type]]</code>, which
   unsurprisingly contains a string representing the type of the credential. The slot’s value
   is the empty string unless otherwise specified.</p>
-       <p class="note" role="note"><span>Note:</span> The <code class="idl"><a data-link-type="idl" href="#dom-credential-type-slot" id="ref-for-dom-credential-type-slot-2">[[type]]</a></code> slot’s value will be the same for all credentials implementing a
+       <p class="note" role="note"><span>Note:</span> The <code class="idl"><a data-link-type="idl" href="#dom-credential-type-slot" id="ref-for-dom-credential-type-slot①">[[type]]</a></code> slot’s value will be the same for all credentials implementing a
   particular interface, which means that developers can rely on <code>obj.type</code> returning a string
-  that unambigiously represents the specific kind of <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-4">Credential</a></code> they’re dealing with.</p>
+  that unambigiously represents the specific kind of <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential③">Credential</a></code> they’re dealing with.</p>
       <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="Credential" data-dfn-type="attribute" data-export="" id="dom-credential-discovery-slot"><code>[[discovery]]</code></dfn>
       <dd data-md="">
-       <p>The <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-5">Credential</a></code> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object">interface object</a> has an internal slot named <code>[[discovery]]</code>,
+       <p>The <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential④">Credential</a></code> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object②">interface object</a> has an internal slot named <code>[[discovery]]</code>,
   representing the mechanism by which the user agent can collect credentials of
   a given type. Its value is either
   "<dfn class="dfn-paneled idl-code" data-dfn-for="Credential/[[discovery]]" data-dfn-type="enum-value" data-export="" id="dom-credential-discovery-credential-store"><code><code>credential store</code></code></dfn>" or
   "<dfn class="idl-code" data-dfn-for="Credential/[[discovery]]" data-dfn-type="enum-value" data-export="" id="dom-credential-discovery-remote"><code><code>remote</code></code><a class="self-link" href="#dom-credential-discovery-remote"></a></dfn>". The former value means that
-  all available credential information is stored in the user agent’s <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store-5">credential store</a>,
+  all available credential information is stored in the user agent’s <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store④">credential store</a>,
   while the latter means that the user agent can discover credentials outside of those
-  explicitly represented in the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store-6">credential store</a> via interaction with some external device
+  explicitly represented in the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store⑤">credential store</a> via interaction with some external device
   or service.</p>
      </dl>
     </div>
-    <p class="issue" id="issue-1bc838e3"><a class="self-link" href="#issue-1bc838e3"></a> Talk to Tobie/Dominic about the <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object">interface object</a> bits, here and in <a href="#algorithm-request">§2.5.1 Request a Credential</a>, etc. I’m not sure I’ve gotten the terminology right. <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-prototype-object">interface prototype
+    <p class="issue" id="issue-1bc838e3"><a class="self-link" href="#issue-1bc838e3"></a> Talk to Tobie/Dominic about the <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object③">interface object</a> bits, here and in <a href="#algorithm-request">§2.5.1 Request a Credential</a>, etc. I’m not sure I’ve gotten the terminology right. <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-prototype-object" id="ref-for-dfn-interface-prototype-object">interface prototype
   object</a>, maybe?</p>
-    <p>Some <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-6">Credential</a></code> objects are <dfn class="dfn-paneled" data-dfn-for="Credential" data-dfn-type="dfn" data-noexport="" id="credential-origin-bound">origin bound</dfn>: these contain an
-  internal slot named <dfn class="dfn-paneled idl-code" data-dfn-for="Credential" data-dfn-type="attribute" data-export="" id="dom-credential-origin-slot"><code>[[origin]]</code></dfn>, which stores the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">origin</a> for which the <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-7">Credential</a></code> may be <a data-link-type="dfn" href="#credential-effective" id="ref-for-credential-effective-2">effective</a>.</p>
+    <p>Some <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential⑤">Credential</a></code> objects are <dfn class="dfn-paneled" data-dfn-for="Credential" data-dfn-type="dfn" data-noexport="" id="credential-origin-bound">origin bound</dfn>: these contain an
+  internal slot named <dfn class="dfn-paneled idl-code" data-dfn-for="Credential" data-dfn-type="attribute" data-export="" id="dom-credential-origin-slot"><code>[[origin]]</code></dfn>, which stores the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin②">origin</a> for which the <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential⑥">Credential</a></code> may be <a data-link-type="dfn" href="#credential-effective" id="ref-for-credential-effective①">effective</a>.</p>
     <h4 class="heading settled" data-level="2.2.1" id="credential-internal-methods"><span class="secno">2.2.1. </span><span class="content"><code>Credential</code> Internal Methods</span><a class="self-link" href="#credential-internal-methods"></a></h4>
-    <p>Each <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object">interface object</a> created for interfaces which <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherit">inherit</a> from <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-8">Credential</a></code> defines several internal methods that allow retrieval and storage of <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-9">Credential</a></code> objects:</p>
+    <p>Each <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object④">interface object</a> created for interfaces which <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherit" id="ref-for-dfn-inherit①">inherit</a> from <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential⑦">Credential</a></code> defines several internal methods that allow retrieval and storage of <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential⑧">Credential</a></code> objects. The <code class="idl"><a data-link-type="idl" href="#dom-credential-create-slot" id="ref-for-dom-credential-create-slot">[[Create]](options)</a></code> method and <code class="idl"><a data-link-type="idl" href="#dom-credential-discoverfromexternalsource-slot" id="ref-for-dom-credential-discoverfromexternalsource-slot①">[[DiscoverFromExternalSource]](options)</a></code> method can be <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="concept-credman-terminated">terminated</dfn> with flag <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#abortsignal-aborted-flag" id="ref-for-abortsignal-aborted-flag">aborted flag</a>, which is unset unless otherwise specificed. When methods are <a data-link-type="dfn" href="#concept-credman-terminated" id="ref-for-concept-credman-terminated①">terminated</a>, the promise MUST be rejected with an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#aborterror" id="ref-for-aborterror">AbortError</a></code> <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException">DOMException</a></code>.</p>
     <section class="algorithm" data-algorithm="&apos;collect credentials&apos; internal method">
       <dfn class="dfn-paneled idl-code" data-dfn-for="Credential" data-dfn-type="method" data-export="" id="dom-credential-collectfromcredentialstore-slot"><code>[[CollectFromCredentialStore]](options)</code></dfn> is called
-    with a <code class="idl"><a data-link-type="idl" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions-1">CredentialRequestOptions</a></code>, and returns a set of <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-10">Credential</a></code> objects from the user
-    agent’s <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store-7">credential store</a> that match the options provided. If no matching <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-11">Credential</a></code> objects are available, the returned set will be empty. 
+    with a <code class="idl"><a data-link-type="idl" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions">CredentialRequestOptions</a></code>, and returns a set of <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential⑨">Credential</a></code> objects from the user
+    agent’s <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store⑥">credential store</a> that match the options provided. If no matching <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential①⓪">Credential</a></code> objects are available, the returned set will be empty. 
      <ol class="algorithm">
       <li data-md="">
        <p>Return an empty set.</p>
@@ -1774,85 +1780,85 @@ store user credentials for future use.</p>
     </section>
     <section class="algorithm" data-algorithm="&apos;discover credentials&apos; internal method">
       <dfn class="dfn-paneled idl-code" data-dfn-for="Credential" data-dfn-type="method" data-export="" id="dom-credential-discoverfromexternalsource-slot"><code>[[DiscoverFromExternalSource]](options)</code></dfn> is called
-    with a <code class="idl"><a data-link-type="idl" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions-2">CredentialRequestOptions</a></code> object. It returns a <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-12">Credential</a></code> if one can be
+    with a <code class="idl"><a data-link-type="idl" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions①">CredentialRequestOptions</a></code> object. It returns a <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential①①">Credential</a></code> if one can be
     returned given the options provided, <code>null</code> if no credential is available, or an error if
-    discovery fails (for example, incorrect options could produce a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#exceptiondef-typeerror">TypeError</a></code>). If this
-    kind of <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-13">Credential</a></code> is only <a data-link-type="dfn" href="#credential-effective" id="ref-for-credential-effective-3">effective</a> for a single use or a limited time, this
-    method is responsible for generating new <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential-15">credentials</a> using a <a data-link-type="dfn" href="#credential-source" id="ref-for-credential-source-1">credential source</a>. 
+    discovery fails (for example, incorrect options could produce a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror">TypeError</a></code>). If this
+    kind of <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential①②">Credential</a></code> is only <a data-link-type="dfn" href="#credential-effective" id="ref-for-credential-effective②">effective</a> for a single use or a limited time, this
+    method is responsible for generating new <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential①④">credentials</a> using a <a data-link-type="dfn" href="#credential-source" id="ref-for-credential-source">credential source</a>. 
      <ol class="algorithm">
       <li data-md="">
        <p>Return <code>null</code>.</p>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="&apos;store a credential&apos; internal method">
-      <dfn class="dfn-paneled idl-code" data-dfn-for="Credential" data-dfn-type="method" data-export="" id="dom-credential-store-slot"><code>[[Store]](credential)</code></dfn> is called with a <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-14">Credential</a></code>,
-    and returns once <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-15">Credential</a></code> is persisted to the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store-8">credential store</a>: 
+      <dfn class="dfn-paneled idl-code" data-dfn-for="Credential" data-dfn-type="method" data-export="" id="dom-credential-store-slot"><code>[[Store]](credential)</code></dfn> is called with a <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential①③">Credential</a></code>,
+    and returns once <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential①④">Credential</a></code> is persisted to the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store⑦">credential store</a>: 
      <ol class="algorithm">
       <li data-md="">
        <p>Return.</p>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="&apos;create a credential&apos; internal method">
-      <dfn class="dfn-paneled idl-code" data-dfn-for="Credential" data-dfn-type="method" data-export="" id="dom-credential-create-slot"><code>[[Create]](options)</code></dfn> is called with a <code class="idl"><a data-link-type="idl" href="#dictdef-credentialcreationoptions" id="ref-for-dictdef-credentialcreationoptions-1">CredentialCreationOptions</a></code>, and returns either a <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-16">Credential</a></code>, if one can be created, <code>null</code> if no credential was created, or an error if creation fails due to exceptional situations
-    (for example, incorrect options could produce a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#exceptiondef-typeerror">TypeError</a></code>): 
+      <dfn class="dfn-paneled idl-code" data-dfn-for="Credential" data-dfn-type="method" data-export="" id="dom-credential-create-slot"><code>[[Create]](options)</code></dfn> is called with a <code class="idl"><a data-link-type="idl" href="#dictdef-credentialcreationoptions" id="ref-for-dictdef-credentialcreationoptions">CredentialCreationOptions</a></code>, and returns either a <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential①⑤">Credential</a></code>, if one can be created, <code>null</code> if no credential was created, or an error if creation fails due to exceptional situations
+    (for example, incorrect options could produce a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror①">TypeError</a></code>). 
      <ol class="algorithm">
       <li data-md="">
        <p>Return <code>null</code>.</p>
      </ol>
     </section>
-    <p>Unless otherwise specified, the <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object">interface objects</a> for <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface">interfaces</a> which <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherit">inherit</a> from <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-17">Credential</a></code> will alias <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-18">Credential</a></code>'s implementation of these three internal methods. Since that
+    <p>Unless otherwise specified, the <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object⑤">interface objects</a> for <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface" id="ref-for-dfn-interface">interfaces</a> which <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherit" id="ref-for-dfn-inherit②">inherit</a> from <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential①⑥">Credential</a></code> will alias <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential①⑦">Credential</a></code>'s implementation of these three internal methods. Since that
   implementation isn’t particularly useful, derived interfaces MUST override one or the other.</p>
     <h4 class="heading settled" data-level="2.2.2" id="credentialuserdata-mixin"><span class="secno">2.2.2. </span><span class="content"><code>CredentialUserData</code> Mixin</span><a class="self-link" href="#credentialuserdata-mixin"></a></h4>
-    <p>Some <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-19">Credential</a></code> objects contain data which aims to give users a human-readable disambiguation
-  mechanism in the <a data-link-type="dfn" href="#credential-chooser" id="ref-for-credential-chooser-1">credential chooser</a> by providing a friendly name and icon:</p>
-<pre class="idl highlight def">[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#NoInterfaceObject">NoInterfaceObject</a>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext">SecureContext</a>]
+    <p>Some <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential①⑧">Credential</a></code> objects contain data which aims to give users a human-readable disambiguation
+  mechanism in the <a data-link-type="dfn" href="#credential-chooser" id="ref-for-credential-chooser">credential chooser</a> by providing a friendly name and icon:</p>
+<pre class="idl highlight def">[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#NoInterfaceObject" id="ref-for-NoInterfaceObject">NoInterfaceObject</a>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext①">SecureContext</a>]
 <span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="credentialuserdata"><code>CredentialUserData</code></dfn> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString"><span class="kt">USVString</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-credentialuserdata-name" id="ref-for-dom-credentialuserdata-name-1">name</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString"><span class="kt">USVString</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-credentialuserdata-iconurl" id="ref-for-dom-credentialuserdata-iconurl-1">iconURL</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString②"><span class="kt">USVString</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-credentialuserdata-name" id="ref-for-dom-credentialuserdata-name">name</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString③"><span class="kt">USVString</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-credentialuserdata-iconurl" id="ref-for-dom-credentialuserdata-iconurl">iconURL</a>;
 };
 </pre>
     <div>
      <dl>
-      <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="CredentialUserData" data-dfn-type="attribute" data-export="" id="dom-credentialuserdata-name"><code>name</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-USVString">USVString</a>, readonly</span>
+      <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="CredentialUserData" data-dfn-type="attribute" data-export="" id="dom-credentialuserdata-name"><code>name</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString④">USVString</a>, readonly</span>
       <dd data-md="">
        <p>A name associated with the credential, intended as a human-understandable public name for
-  display in a <a data-link-type="dfn" href="#credential-chooser" id="ref-for-credential-chooser-2">credential chooser</a>.</p>
-      <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="CredentialUserData" data-dfn-type="attribute" data-export="" id="dom-credentialuserdata-iconurl"><code>iconURL</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-USVString">USVString</a>, readonly</span>
+  display in a <a data-link-type="dfn" href="#credential-chooser" id="ref-for-credential-chooser①">credential chooser</a>.</p>
+      <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="CredentialUserData" data-dfn-type="attribute" data-export="" id="dom-credentialuserdata-iconurl"><code>iconURL</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑤">USVString</a>, readonly</span>
       <dd data-md="">
-       <p>A URL pointing to an image for the credential, intended for display in a <a data-link-type="dfn" href="#credential-chooser" id="ref-for-credential-chooser-3">credential chooser</a>. This URL MUST be an <a data-link-type="dfn" href="https://w3c.github.io/webappsec-mixed-content/#a-priori-authenticated-url"><i lang="la">a priori</i> authenticated
+       <p>A URL pointing to an image for the credential, intended for display in a <a data-link-type="dfn" href="#credential-chooser" id="ref-for-credential-chooser②">credential chooser</a>. This URL MUST be an <a data-link-type="dfn" href="https://w3c.github.io/webappsec-mixed-content/#a-priori-authenticated-url" id="ref-for-a-priori-authenticated-url"><i lang="la">a priori</i> authenticated
   URL</a>.</p>
      </dl>
     </div>
     <h3 class="heading settled" data-level="2.3" id="framework-credential-management"><span class="secno">2.3. </span><span class="content"><code>navigator.credentials</code></span><a class="self-link" href="#framework-credential-management"></a></h3>
-    <p>Developers retrieve <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-20">Credential</a></code>s and interact with the user agent’s <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store-9">credential store</a> via
-  methods exposed on the <code class="idl"><a data-link-type="idl" href="#credentialscontainer" id="ref-for-credentialscontainer-2">CredentialsContainer</a></code> interface, which hangs off the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/webappapis.html#navigator">Navigator</a></code> object as <a class="idl-code" data-link-type="attribute" href="#dom-navigator-credentials" id="ref-for-dom-navigator-credentials-1"><code>navigator.credentials</code></a>.</p>
-<pre class="idl highlight def"><span class="kt">partial</span> <span class="kt">interface</span> <a class="nv idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/webappapis.html#navigator">Navigator</a> {
-  [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext">SecureContext</a>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SameObject">SameObject</a>] <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#credentialscontainer" id="ref-for-credentialscontainer-3">CredentialsContainer</a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="CredentialsContainer" href="#dom-navigator-credentials" id="ref-for-dom-navigator-credentials-2">credentials</a>;
+    <p>Developers retrieve <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential①⑨">Credential</a></code>s and interact with the user agent’s <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store⑧">credential store</a> via
+  methods exposed on the <code class="idl"><a data-link-type="idl" href="#credentialscontainer" id="ref-for-credentialscontainer①">CredentialsContainer</a></code> interface, which hangs off the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/system-state.html#navigator" id="ref-for-navigator">Navigator</a></code> object as <a class="idl-code" data-link-type="attribute" href="#dom-navigator-credentials" id="ref-for-dom-navigator-credentials"><code>navigator.credentials</code></a>.</p>
+<pre class="idl highlight def"><span class="kt">partial</span> <span class="kt">interface</span> <a class="nv idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/system-state.html#navigator" id="ref-for-navigator①">Navigator</a> {
+  [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext②">SecureContext</a>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SameObject" id="ref-for-SameObject">SameObject</a>] <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#credentialscontainer" id="ref-for-credentialscontainer②">CredentialsContainer</a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="CredentialsContainer" href="#dom-navigator-credentials" id="ref-for-dom-navigator-credentials①">credentials</a>;
 };
 </pre>
-    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="Navigator" data-dfn-type="attribute" data-export="" id="dom-navigator-credentials"><code><code>credentials</code></code></dfn> attribute MUST return the <code class="idl"><a data-link-type="idl" href="#credentialscontainer" id="ref-for-credentialscontainer-4">CredentialsContainer</a></code> associated with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
-    <p class="note" role="note"><span>Note:</span> As discussed in <a href="#insecure-sites">§6.3 Insecure Sites</a>, the credential management API is exposed only in <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">Secure Contexts</a>.</p>
-<pre class="idl highlight def">[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">Window</span>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext">SecureContext</a>]
+    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="Navigator" data-dfn-type="attribute" data-export="" id="dom-navigator-credentials"><code><code>credentials</code></code></dfn> attribute MUST return the <code class="idl"><a data-link-type="idl" href="#credentialscontainer" id="ref-for-credentialscontainer③">CredentialsContainer</a></code> associated with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object" id="ref-for-context-object">context object</a>.</p>
+    <p class="note" role="note"><span>Note:</span> As discussed in <a href="#insecure-sites">§6.3 Insecure Sites</a>, the credential management API is exposed only in <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context" id="ref-for-secure-context">Secure Contexts</a>.</p>
+<pre class="idl highlight def">[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①">Exposed</a>=<span class="n">Window</span>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext③">SecureContext</a>]
 <span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="credentialscontainer"><code>CredentialsContainer</code></dfn> {
-  <span class="kt">Promise</span>&lt;<a class="n" data-link-type="idl-name" href="#credential" id="ref-for-credential-21">Credential</a>?> <a class="nv idl-code" data-link-type="method" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get-1">get</a>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions-3">CredentialRequestOptions</a> <a class="nv idl-code" data-link-type="argument" href="#dom-credentialscontainer-get-options-options" id="ref-for-dom-credentialscontainer-get-options-options-1">options</a>);
-  <span class="kt">Promise</span>&lt;<a class="n" data-link-type="idl-name" href="#credential" id="ref-for-credential-22">Credential</a>> <a class="nv idl-code" data-link-type="method" href="#dom-credentialscontainer-store" id="ref-for-dom-credentialscontainer-store-2">store</a>(<a class="n" data-link-type="idl-name" href="#credential" id="ref-for-credential-23">Credential</a> <a class="nv idl-code" data-link-type="argument" href="#dom-credentialscontainer-store-credential-credential" id="ref-for-dom-credentialscontainer-store-credential-credential-1">credential</a>);
-  <span class="kt">Promise</span>&lt;<a class="n" data-link-type="idl-name" href="#credential" id="ref-for-credential-24">Credential</a>?> <a class="nv idl-code" data-link-type="method" href="#dom-credentialscontainer-create" id="ref-for-dom-credentialscontainer-create-1">create</a>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-credentialcreationoptions" id="ref-for-dictdef-credentialcreationoptions-2">CredentialCreationOptions</a> <a class="nv idl-code" data-link-type="argument" href="#dom-credentialscontainer-create-options-options" id="ref-for-dom-credentialscontainer-create-options-options-1">options</a>);
-  <span class="kt">Promise</span>&lt;<span class="kt">void</span>> <a class="nv idl-code" data-link-type="method" href="#dom-credentialscontainer-preventsilentaccess" id="ref-for-dom-credentialscontainer-preventsilentaccess-1">preventSilentAccess</a>();
+  <span class="kt">Promise</span>&lt;<a class="n" data-link-type="idl-name" href="#credential" id="ref-for-credential②⓪">Credential</a>?> <a class="nv idl-code" data-link-type="method" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get">get</a>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions②">CredentialRequestOptions</a> <a class="nv idl-code" data-link-type="argument" href="#dom-credentialscontainer-get-options-options" id="ref-for-dom-credentialscontainer-get-options-options">options</a>);
+  <span class="kt">Promise</span>&lt;<a class="n" data-link-type="idl-name" href="#credential" id="ref-for-credential②①">Credential</a>> <a class="nv idl-code" data-link-type="method" href="#dom-credentialscontainer-store" id="ref-for-dom-credentialscontainer-store①">store</a>(<a class="n" data-link-type="idl-name" href="#credential" id="ref-for-credential②②">Credential</a> <a class="nv idl-code" data-link-type="argument" href="#dom-credentialscontainer-store-credential-credential" id="ref-for-dom-credentialscontainer-store-credential-credential">credential</a>);
+  <span class="kt">Promise</span>&lt;<a class="n" data-link-type="idl-name" href="#credential" id="ref-for-credential②③">Credential</a>?> <a class="nv idl-code" data-link-type="method" href="#dom-credentialscontainer-create" id="ref-for-dom-credentialscontainer-create">create</a>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-credentialcreationoptions" id="ref-for-dictdef-credentialcreationoptions①">CredentialCreationOptions</a> <a class="nv idl-code" data-link-type="argument" href="#dom-credentialscontainer-create-options-options" id="ref-for-dom-credentialscontainer-create-options-options">options</a>);
+  <span class="kt">Promise</span>&lt;<span class="kt">void</span>> <a class="nv idl-code" data-link-type="method" href="#dom-credentialscontainer-preventsilentaccess" id="ref-for-dom-credentialscontainer-preventsilentaccess">preventSilentAccess</a>();
 };
 
 <span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-credentialdata"><code>CredentialData</code></dfn> {
-  <span class="kt">required</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString"><span class="kt">USVString</span></a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="CredentialData" data-dfn-type="dict-member" data-export="" data-type="USVString " id="dom-credentialdata-id"><code>id</code></dfn>;
+  <span class="kt">required</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑥"><span class="kt">USVString</span></a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="CredentialData" data-dfn-type="dict-member" data-export="" data-type="USVString " id="dom-credentialdata-id"><code>id</code></dfn>;
 };
 </pre>
     <div>
      <dl>
       <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="CredentialsContainer" data-dfn-type="method" data-export="" data-lt="get(options)|get()" id="dom-credentialscontainer-get"><code>get(options)</code></dfn>
       <dd data-md="">
-       <p>When <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get-2">get()</a></code> is called, the user agent MUST return the result of
-  executing <a data-link-type="abstract-op" href="#abstract-opdef-request-a-credential" id="ref-for-abstract-opdef-request-a-credential-1">Request a <code>Credential</code></a> on <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get-options-options" id="ref-for-dom-credentialscontainer-get-options-options-2">options</a></code>.</p>
+       <p>When <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get①">get()</a></code> is called, the user agent MUST return the result of
+  executing <a data-link-type="abstract-op" href="#abstract-opdef-request-a-credential" id="ref-for-abstract-opdef-request-a-credential">Request a <code>Credential</code></a> on <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get-options-options" id="ref-for-dom-credentialscontainer-get-options-options①">options</a></code>.</p>
      </dl>
      <table class="argumentdef data">
-      <caption>Arguments for the <a class="idl-code" data-link-type="method" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get-3">CredentialsContainer.get(options)</a> method.</caption>
+      <caption>Arguments for the <a class="idl-code" data-link-type="method" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get②">CredentialsContainer.get(options)</a> method.</caption>
       <thead>
        <tr>
         <th>Parameter 
@@ -1871,11 +1877,11 @@ store user credentials for future use.</p>
      <dl>
       <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="CredentialsContainer" data-dfn-type="method" data-export="" data-lt="store(credential)|store()" id="dom-credentialscontainer-store"><code>store(credential)</code></dfn>
       <dd data-md="">
-       <p>When <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-store" id="ref-for-dom-credentialscontainer-store-3">store()</a></code> is called, the user agent MUST return the result of
-  executing <a data-link-type="abstract-op" href="#abstract-opdef-store-a-credential" id="ref-for-abstract-opdef-store-a-credential-1">Store a <code>Credential</code></a> on <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-store-credential-credential" id="ref-for-dom-credentialscontainer-store-credential-credential-2">credential</a></code>.</p>
+       <p>When <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-store" id="ref-for-dom-credentialscontainer-store②">store()</a></code> is called, the user agent MUST return the result of
+  executing <a data-link-type="abstract-op" href="#abstract-opdef-store-a-credential" id="ref-for-abstract-opdef-store-a-credential">Store a <code>Credential</code></a> on <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-store-credential-credential" id="ref-for-dom-credentialscontainer-store-credential-credential①">credential</a></code>.</p>
      </dl>
      <table class="argumentdef data">
-      <caption>Arguments for the <a class="idl-code" data-link-type="method" href="#dom-credentialscontainer-store" id="ref-for-dom-credentialscontainer-store-4">CredentialsContainer.store(credential)</a> method.</caption>
+      <caption>Arguments for the <a class="idl-code" data-link-type="method" href="#dom-credentialscontainer-store" id="ref-for-dom-credentialscontainer-store③">CredentialsContainer.store(credential)</a> method.</caption>
       <thead>
        <tr>
         <th>Parameter 
@@ -1894,11 +1900,11 @@ store user credentials for future use.</p>
      <dl>
       <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="CredentialsContainer" data-dfn-type="method" data-export="" data-lt="create(options)|create()" id="dom-credentialscontainer-create"><code>create(options)</code></dfn>
       <dd data-md="">
-       <p>When <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-create" id="ref-for-dom-credentialscontainer-create-2">create()</a></code> is called, the user agent MUST return the result of
-  executing <a data-link-type="abstract-op" href="#abstract-opdef-create-a-credential" id="ref-for-abstract-opdef-create-a-credential-1">Create a <code>Credential</code></a> on <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-create-options-options" id="ref-for-dom-credentialscontainer-create-options-options-2">options</a></code>.</p>
+       <p>When <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-create" id="ref-for-dom-credentialscontainer-create①">create()</a></code> is called, the user agent MUST return the result of
+  executing <a data-link-type="abstract-op" href="#abstract-opdef-create-a-credential" id="ref-for-abstract-opdef-create-a-credential">Create a <code>Credential</code></a> on <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-create-options-options" id="ref-for-dom-credentialscontainer-create-options-options①">options</a></code>.</p>
      </dl>
      <table class="argumentdef data">
-      <caption>Arguments for the <a class="idl-code" data-link-type="method" href="#dom-credentialscontainer-create" id="ref-for-dom-credentialscontainer-create-3">CredentialsContainer.create(options)</a> method.</caption>
+      <caption>Arguments for the <a class="idl-code" data-link-type="method" href="#dom-credentialscontainer-create" id="ref-for-dom-credentialscontainer-create②">CredentialsContainer.create(options)</a> method.</caption>
       <thead>
        <tr>
         <th>Parameter 
@@ -1917,64 +1923,64 @@ store user credentials for future use.</p>
      <dl>
       <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="CredentialsContainer" data-dfn-type="method" data-export="" id="dom-credentialscontainer-preventsilentaccess"><code>preventSilentAccess()</code></dfn>
       <dd data-md="">
-       <p>When <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-preventsilentaccess" id="ref-for-dom-credentialscontainer-preventsilentaccess-2">preventSilentAccess()</a></code> is called, the user agent MUST return
-  the result of executing <a data-link-type="abstract-op" href="#abstract-opdef-prevent-silent-access" id="ref-for-abstract-opdef-prevent-silent-access-1">Prevent Silent Access</a> on the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">current settings
+       <p>When <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-preventsilentaccess" id="ref-for-dom-credentialscontainer-preventsilentaccess①">preventSilentAccess()</a></code> is called, the user agent MUST return
+  the result of executing <a data-link-type="abstract-op" href="#abstract-opdef-prevent-silent-access" id="ref-for-abstract-opdef-prevent-silent-access">Prevent Silent Access</a> on the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object" id="ref-for-current-settings-object">current settings
   object</a>.</p>
        <p class="note" role="note"><span>Note:</span> The intent here is a signal from the origin that the user has signed out. That
   is, after a click on a "Sign out" button, the site updates the user’s session info, and
-  calls <code>navigator.credentials.preventSilentAccess()</code>. This sets the <a data-link-type="dfn" href="#origin-prevent-silent-access-flag" id="ref-for-origin-prevent-silent-access-flag-1"><code>prevent silent access</code> flag</a>, meaning that credentials will not be automagically handed back to the
+  calls <code>navigator.credentials.preventSilentAccess()</code>. This sets the <a data-link-type="dfn" href="#origin-prevent-silent-access-flag" id="ref-for-origin-prevent-silent-access-flag"><code>prevent silent access</code> flag</a>, meaning that credentials will not be automagically handed back to the
   page next time the user visits.</p>
        <p class="note" role="note"><span>Note:</span> This function was previously called <code>requireUserMediation()</code> which should be considered
   deprecated.</p>
      </dl>
     </div>
-    <div class="algorithm" data-algorithm="create credentialscontainer"> When a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/webappapis.html#navigator">Navigator</a></code> object (<var>navigator</var>) is created, the user agent MUST create a
-    new <code class="idl"><a data-link-type="idl" href="#credentialscontainer" id="ref-for-credentialscontainer-5">CredentialsContainer</a></code> object, using <var>navigator</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">relevant Realm</a>, and associate it
+    <div class="algorithm" data-algorithm="create credentialscontainer"> When a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/system-state.html#navigator" id="ref-for-navigator②">Navigator</a></code> object (<var>navigator</var>) is created, the user agent MUST create a
+    new <code class="idl"><a data-link-type="idl" href="#credentialscontainer" id="ref-for-credentialscontainer④">CredentialsContainer</a></code> object, using <var>navigator</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm">relevant Realm</a>, and associate it
     with <var>navigator</var>. </div>
     <h4 class="heading settled" data-level="2.3.1" id="credentialrequestoptions-dictionary"><span class="secno">2.3.1. </span><span class="content">The <code>CredentialRequestOptions</code> Dictionary</span><a class="self-link" href="#credentialrequestoptions-dictionary"></a></h4>
-    <p>In order to retrieve a <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-25">Credential</a></code> via <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get-4">get()</a></code>, the caller specifies a
-  few parameters in a <code class="idl"><a data-link-type="idl" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions-4">CredentialRequestOptions</a></code> object.</p>
-    <p class="note" role="note"><span>Note:</span> The <code class="idl"><a data-link-type="idl" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions-5">CredentialRequestOptions</a></code> dictionary is an extension point. If and when new types of
+    <p>In order to retrieve a <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential②④">Credential</a></code> via <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get③">get()</a></code>, the caller specifies a
+  few parameters in a <code class="idl"><a data-link-type="idl" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions③">CredentialRequestOptions</a></code> object.</p>
+    <p class="note" role="note"><span>Note:</span> The <code class="idl"><a data-link-type="idl" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions④">CredentialRequestOptions</a></code> dictionary is an extension point. If and when new types of
   credentials are introduced that require options, their dictionary types will be added to the
   dictionary so they can be passed into the request. See <a href="#implementation-extension">§7.2 Extension Points</a>.</p>
 <pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-credentialrequestoptions"><code>CredentialRequestOptions</code></dfn> {
-  <a class="n" data-link-type="idl-name" href="#enumdef-credentialmediationrequirement" id="ref-for-enumdef-credentialmediationrequirement-1">CredentialMediationRequirement</a> <a class="nv idl-code" data-default="&quot;optional&quot;" data-link-type="dict-member" data-type="CredentialMediationRequirement " href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation-1">mediation</a> = "optional";
+  <a class="n" data-link-type="idl-name" href="#enumdef-credentialmediationrequirement" id="ref-for-enumdef-credentialmediationrequirement">CredentialMediationRequirement</a> <a class="nv idl-code" data-default="&quot;optional&quot;" data-link-type="dict-member" data-type="CredentialMediationRequirement " href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation">mediation</a> = "optional";
 };
 </pre>
     <div>
      <dl>
-      <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="CredentialRequestOptions" data-dfn-type="dict-member" data-export="" id="dom-credentialrequestoptions-mediation"><code>mediation</code></dfn>, <span> of type <a data-link-type="idl-name" href="#enumdef-credentialmediationrequirement" id="ref-for-enumdef-credentialmediationrequirement-2">CredentialMediationRequirement</a>, defaulting to <code>"optional"</code></span>
+      <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="CredentialRequestOptions" data-dfn-type="dict-member" data-export="" id="dom-credentialrequestoptions-mediation"><code>mediation</code></dfn>, <span> of type <a data-link-type="idl-name" href="#enumdef-credentialmediationrequirement" id="ref-for-enumdef-credentialmediationrequirement①">CredentialMediationRequirement</a>, defaulting to <code>"optional"</code></span>
       <dd data-md="">
        <p>This property specifies the mediation requirements for a given credential request. The
-  meaning of each enum value is described below in <code class="idl"><a data-link-type="idl" href="#enumdef-credentialmediationrequirement" id="ref-for-enumdef-credentialmediationrequirement-3">CredentialMediationRequirement</a></code>.
+  meaning of each enum value is described below in <code class="idl"><a data-link-type="idl" href="#enumdef-credentialmediationrequirement" id="ref-for-enumdef-credentialmediationrequirement②">CredentialMediationRequirement</a></code>.
   Processing details are defined in <a href="#algorithm-request">§2.5.1 Request a Credential</a>.</p>
      </dl>
     </div>
     <div class="note" role="note">
       Earlier versions of this specification defined a boolean <code>unmediated</code> member. Setting that
-    to <code>true</code> had the effect of setting <code class="idl"><a data-link-type="idl" href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation-2">mediation</a></code> to
-    "<code class="idl"><a data-link-type="idl" href="#dom-credentialmediationrequirement-silent" id="ref-for-dom-credentialmediationrequirement-silent-1">silent</a></code>", and setting it to <code>false</code> had the effect of
-    setting <code class="idl"><a data-link-type="idl" href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation-3">mediation</a></code> to "<code class="idl"><a data-link-type="idl" href="#dom-credentialmediationrequirement-optional" id="ref-for-dom-credentialmediationrequirement-optional-1">optional</a></code>". 
-     <p><code>unmediated</code> should be considered deprecated; new code should instead rely on <code class="idl"><a data-link-type="idl" href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation-4">mediation</a></code>.</p>
+    to <code>true</code> had the effect of setting <code class="idl"><a data-link-type="idl" href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation①">mediation</a></code> to
+    "<code class="idl"><a data-link-type="idl" href="#dom-credentialmediationrequirement-silent" id="ref-for-dom-credentialmediationrequirement-silent">silent</a></code>", and setting it to <code>false</code> had the effect of
+    setting <code class="idl"><a data-link-type="idl" href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation②">mediation</a></code> to "<code class="idl"><a data-link-type="idl" href="#dom-credentialmediationrequirement-optional" id="ref-for-dom-credentialmediationrequirement-optional">optional</a></code>". 
+     <p><code>unmediated</code> should be considered deprecated; new code should instead rely on <code class="idl"><a data-link-type="idl" href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation③">mediation</a></code>.</p>
     </div>
     <div class="algorithm" data-algorithm="relevant credential interfaces">
-      The <dfn class="dfn-paneled" data-dfn-for="CredentialRequestOptions" data-dfn-type="dfn" data-noexport="" id="credentialrequestoptions-relevant-credential-interface-objects">relevant credential interface objects</dfn> for a given <code class="idl"><a data-link-type="idl" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions-6">CredentialRequestOptions</a></code> (<var>options</var>) is a set of <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object">interface objects</a>, collected as follows: 
+      The <dfn class="dfn-paneled" data-dfn-for="CredentialRequestOptions" data-dfn-type="dfn" data-noexport="" id="credentialrequestoptions-relevant-credential-interface-objects">relevant credential interface objects</dfn> for a given <code class="idl"><a data-link-type="idl" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions⑤">CredentialRequestOptions</a></code> (<var>options</var>) is a set of <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object⑥">interface objects</a>, collected as follows: 
      <ol class="algorithm">
       <li data-md="">
-       <p>Let <var>settings</var> be the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">current settings object</a></p>
+       <p>Let <var>settings</var> be the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object" id="ref-for-current-settings-object①">current settings object</a></p>
       <li data-md="">
-       <p>Let <var>interface objects</var> be the set of <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object">interface objects</a> on <var>settings</var>’ <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a>.</p>
+       <p>Let <var>interface objects</var> be the set of <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object⑦">interface objects</a> on <var>settings</var>’ <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global">global object</a>.</p>
       <li data-md="">
        <p>Let <var>relevant interface objects</var> be an empty set.</p>
       <li data-md="">
        <p>For each <var>object</var> in <var>interface objects</var>:</p>
        <ol>
         <li data-md="">
-         <p>If <var>object</var>’s <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-interfaces">inherited interfaces</a> do not <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain">contain</a> <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-26">Credential</a></code>, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue">continue</a>.</p>
+         <p>If <var>object</var>’s <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-inherited-interfaces" id="ref-for-dfn-inherited-interfaces">inherited interfaces</a> do not <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain">contain</a> <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential②⑤">Credential</a></code>, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue">continue</a>.</p>
         <li data-md="">
-         <p>Let <var>key</var> be <var>object</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credential-type-slot" id="ref-for-dom-credential-type-slot-3">[[type]]</a></code> slot’s value.</p>
+         <p>Let <var>key</var> be <var>object</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credential-type-slot" id="ref-for-dom-credential-type-slot②">[[type]]</a></code> slot’s value.</p>
         <li data-md="">
-         <p>If <var>options</var>[<var>key</var>] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists">exists</a>, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append">append</a> <var>object</var> to <var>relevant interface objects</var>.</p>
+         <p>If <var>options</var>[<var>key</var>] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists">exists</a>, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append" id="ref-for-set-append">append</a> <var>object</var> to <var>relevant interface objects</var>.</p>
        </ol>
      </ol>
      <p class="issue" id="issue-1542b290"><a class="self-link" href="#issue-1542b290"></a> jyasskin@ suggests replacing the iteration through the interface objects with a registry.
@@ -1982,33 +1988,33 @@ store user credentials for future use.</p>
     argue about whether this is too much of a <code>COMEFROM</code> interface.</p>
     </div>
     <div class="algorithm" data-algorithm="can collect locally">
-      A given <code class="idl"><a data-link-type="idl" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions-7">CredentialRequestOptions</a></code> <var>options</var> is <dfn class="dfn-paneled" data-dfn-for="CredentialRequestOptions" data-dfn-type="dfn" data-noexport="" id="credentialrequestoptions-matchable-a-priori">matchable <i lang="la">a priori</i></dfn> if the following
+      A given <code class="idl"><a data-link-type="idl" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions⑥">CredentialRequestOptions</a></code> <var>options</var> is <dfn class="dfn-paneled" data-dfn-for="CredentialRequestOptions" data-dfn-type="dfn" data-noexport="" id="credentialrequestoptions-matchable-a-priori">matchable <i lang="la">a priori</i></dfn> if the following
     steps return <code>true</code>: 
      <ol class="algorithm">
       <li data-md="">
-       <p>For each <var>interface</var> in <var>options</var>’ <a data-link-type="dfn" href="#credentialrequestoptions-relevant-credential-interface-objects" id="ref-for-credentialrequestoptions-relevant-credential-interface-objects-1">relevant credential interface objects</a>:</p>
+       <p>For each <var>interface</var> in <var>options</var>’ <a data-link-type="dfn" href="#credentialrequestoptions-relevant-credential-interface-objects" id="ref-for-credentialrequestoptions-relevant-credential-interface-objects">relevant credential interface objects</a>:</p>
        <ol>
         <li data-md="">
-         <p>If <var>interface</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credential-discovery-slot" id="ref-for-dom-credential-discovery-slot-1">[[discovery]]</a></code> slot’s value is not
-  "<code class="idl"><a data-link-type="idl" href="#dom-credential-discovery-credential-store" id="ref-for-dom-credential-discovery-credential-store-1">credential store</a></code>", return <code>false</code>.</p>
+         <p>If <var>interface</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credential-discovery-slot" id="ref-for-dom-credential-discovery-slot">[[discovery]]</a></code> slot’s value is not
+  "<code class="idl"><a data-link-type="idl" href="#dom-credential-discovery-credential-store" id="ref-for-dom-credential-discovery-credential-store">credential store</a></code>", return <code>false</code>.</p>
        </ol>
       <li data-md="">
        <p>Return <code>true</code>.</p>
      </ol>
-     <p class="note" role="note"><span>Note:</span> When executing <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get-5">get(options)</a></code>, we only return credentials without <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated-1">user mediation</a> if
-    the provided <code class="idl"><a data-link-type="idl" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions-8">CredentialRequestOptions</a></code> is <a data-link-type="dfn" href="#credentialrequestoptions-matchable-a-priori" id="ref-for-credentialrequestoptions-matchable-a-priori-1">matchable <i lang="la">a priori</i></a>. If any
+     <p class="note" role="note"><span>Note:</span> When executing <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get④">get(options)</a></code>, we only return credentials without <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated">user mediation</a> if
+    the provided <code class="idl"><a data-link-type="idl" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions⑦">CredentialRequestOptions</a></code> is <a data-link-type="dfn" href="#credentialrequestoptions-matchable-a-priori" id="ref-for-credentialrequestoptions-matchable-a-priori">matchable <i lang="la">a priori</i></a>. If any
     credential types are requested that could require discovery from some external service (OAuth
-    tokens, security key authenticators, etc.), then <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated-2">user mediation</a> will be required in order
+    tokens, security key authenticators, etc.), then <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated①">user mediation</a> will be required in order
     to guide the discovery process (by choosing a federated identity provider, BTLE device, etc).</p>
     </div>
     <h4 class="heading settled" data-level="2.3.2" id="mediation-requirements"><span class="secno">2.3.2. </span><span class="content">Mediation Requirements</span><a class="self-link" href="#mediation-requirements"></a></h4>
-    <p>When making a request via <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get-6">get(options)</a></code>, developers can set a case-by-case requirement for <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated-3">user mediation</a> by choosing the appropriate <code class="idl"><a data-link-type="idl" href="#enumdef-credentialmediationrequirement" id="ref-for-enumdef-credentialmediationrequirement-4">CredentialMediationRequirement</a></code> enum value.</p>
+    <p>When making a request via <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get⑤">get(options)</a></code>, developers can set a case-by-case requirement for <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated②">user mediation</a> by choosing the appropriate <code class="idl"><a data-link-type="idl" href="#enumdef-credentialmediationrequirement" id="ref-for-enumdef-credentialmediationrequirement③">CredentialMediationRequirement</a></code> enum value.</p>
     <p class="note" role="note"><span>Note:</span> The <a href="#user-mediation">§5 User Mediation</a> section gives more detail on the concept in general, and its
   implications on how the user agent deals with individual requests for a given origin).</p>
 <pre class="idl highlight def"><span class="kt">enum</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="enum" data-export="" id="enumdef-credentialmediationrequirement"><code>CredentialMediationRequirement</code></dfn> {
-  <a class="s idl-code" data-link-type="enum-value" href="#dom-credentialmediationrequirement-silent" id="ref-for-dom-credentialmediationrequirement-silent-2">"silent"</a>,
-  <a class="s idl-code" data-link-type="enum-value" href="#dom-credentialmediationrequirement-optional" id="ref-for-dom-credentialmediationrequirement-optional-2">"optional"</a>,
-  <a class="s idl-code" data-link-type="enum-value" href="#dom-credentialmediationrequirement-required" id="ref-for-dom-credentialmediationrequirement-required-1">"required"</a>
+  <a class="s idl-code" data-link-type="enum-value" href="#dom-credentialmediationrequirement-silent" id="ref-for-dom-credentialmediationrequirement-silent①">"silent"</a>,
+  <a class="s idl-code" data-link-type="enum-value" href="#dom-credentialmediationrequirement-optional" id="ref-for-dom-credentialmediationrequirement-optional①">"optional"</a>,
+  <a class="s idl-code" data-link-type="enum-value" href="#dom-credentialmediationrequirement-required" id="ref-for-dom-credentialmediationrequirement-required">"required"</a>
 };
 </pre>
     <div>
@@ -2025,31 +2031,31 @@ store user credentials for future use.</p>
       <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="CredentialMediationRequirement" data-dfn-type="enum-value" data-export="" id="dom-credentialmediationrequirement-optional"><code>optional</code></dfn>
       <dd data-md="">
        <p>If credentials can be handed over for a given operation without user mediation, they will
-  be. If <a data-link-type="dfn" href="#origin-requires-user-mediation" id="ref-for-origin-requires-user-mediation-1">user mediation is required</a>, then the user agent will
+  be. If <a data-link-type="dfn" href="#origin-requires-user-mediation" id="ref-for-origin-requires-user-mediation">user mediation is required</a>, then the user agent will
   involve the user in the decision.</p>
-       <p class="note" role="note"><span>Note:</span> This is the default behavior for <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get-7">get()</a></code>, and is intended to serve a case where a
+       <p class="note" role="note"><span>Note:</span> This is the default behavior for <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get⑥">get()</a></code>, and is intended to serve a case where a
   developer has reasonable confidence that a user expects to start a sign-in operation. If
   a user has just clicked "sign-in" for example, then they won’t be surprised or confused to
-  see a <a data-link-type="dfn" href="#credential-chooser" id="ref-for-credential-chooser-4">credential chooser</a> if necessary.</p>
+  see a <a data-link-type="dfn" href="#credential-chooser" id="ref-for-credential-chooser③">credential chooser</a> if necessary.</p>
       <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="CredentialMediationRequirement" data-dfn-type="enum-value" data-export="" id="dom-credentialmediationrequirement-required"><code>required</code></dfn>
       <dd data-md="">
-       <p>The user agent will not hand over credentials without <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated-4">user mediation</a>, even if the <a data-link-type="dfn" href="#origin-prevent-silent-access-flag" id="ref-for-origin-prevent-silent-access-flag-2">prevent silent access flag</a> is unset for an origin.</p>
+       <p>The user agent will not hand over credentials without <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated③">user mediation</a>, even if the <a data-link-type="dfn" href="#origin-prevent-silent-access-flag" id="ref-for-origin-prevent-silent-access-flag①">prevent silent access flag</a> is unset for an origin.</p>
        <p class="note" role="note"><span>Note:</span> This requirement is intended to support <a href="#example-mediation-require">reauthentication</a> or <a href="#example-mediation-switch">user-switching</a> scenarios. Further, the requirement is tied
-  to a specific operation, and does not affect the <a data-link-type="dfn" href="#origin-prevent-silent-access-flag" id="ref-for-origin-prevent-silent-access-flag-3">prevent silent access flag</a> for the
-  origin. To set that flag, developers should call <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-preventsilentaccess" id="ref-for-dom-credentialscontainer-preventsilentaccess-3">preventSilentAccess()</a></code>.</p>
+  to a specific operation, and does not affect the <a data-link-type="dfn" href="#origin-prevent-silent-access-flag" id="ref-for-origin-prevent-silent-access-flag②">prevent silent access flag</a> for the
+  origin. To set that flag, developers should call <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-preventsilentaccess" id="ref-for-dom-credentialscontainer-preventsilentaccess②">preventSilentAccess()</a></code>.</p>
      </dl>
     </div>
     <h5 class="heading settled" data-level="2.3.2.1" id="mediation-examples"><span class="secno">2.3.2.1. </span><span class="content">Examples</span><a class="self-link" href="#mediation-examples"></a></h5>
     <div class="example" id="example-mediation-silent">
-     <a class="self-link" href="#example-mediation-silent"></a> MegaCorp, Inc. wishes to seamlessly sign in users when possible. They can do so by calling <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get-8">get()</a></code> for all non-signed in users at some convinient point while a landing page is loading,
-    passing in a <code class="idl"><a data-link-type="idl" href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation-5">mediation</a></code> member set to
-    "<code class="idl"><a data-link-type="idl" href="#dom-credentialmediationrequirement-silent" id="ref-for-dom-credentialmediationrequirement-silent-3">silent</a></code>". This ensures that users who have opted-into
+     <a class="self-link" href="#example-mediation-silent"></a> MegaCorp, Inc. wishes to seamlessly sign in users when possible. They can do so by calling <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get⑦">get()</a></code> for all non-signed in users at some convinient point while a landing page is loading,
+    passing in a <code class="idl"><a data-link-type="idl" href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation④">mediation</a></code> member set to
+    "<code class="idl"><a data-link-type="idl" href="#dom-credentialmediationrequirement-silent" id="ref-for-dom-credentialmediationrequirement-silent②">silent</a></code>". This ensures that users who have opted-into
     dropping the requirements for user mediation (as described in <a href="#user-mediation-requirement">§5.2 Requiring User Mediation</a>)
-    are signed in, and users who haven’t opted-into such behavior won’t be bothered with a confusing <a data-link-type="dfn" href="#credential-chooser" id="ref-for-credential-chooser-5">credential chooser</a> popping up without context: 
+    are signed in, and users who haven’t opted-into such behavior won’t be bothered with a confusing <a data-link-type="dfn" href="#credential-chooser" id="ref-for-credential-chooser④">credential chooser</a> popping up without context: 
 <pre>window.addEventListener('load', _ => {
-  var c = await navigatior.<a class="idl-code" data-link-type="attribute" href="#dom-navigator-credentials" id="ref-for-dom-navigator-credentials-3">credentials</a>.<a class="idl-code" data-link-type="method" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get-9">get</a>({
+  var c = await navigatior.<a class="idl-code" data-link-type="attribute" href="#dom-navigator-credentials" id="ref-for-dom-navigator-credentials②">credentials</a>.<a class="idl-code" data-link-type="method" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get⑧">get</a>({
     ...,
-    <a class="idl-code" data-link-type="dict-member" href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation-6">mediation</a>: '<a class="idl-code" data-link-type="enum-value" href="#dom-credentialmediationrequirement-silent" id="ref-for-dom-credentialmediationrequirement-silent-4">silent</a>'
+    <a class="idl-code" data-link-type="dict-member" href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation⑤">mediation</a>: '<a class="idl-code" data-link-type="enum-value" href="#dom-credentialmediationrequirement-silent" id="ref-for-dom-credentialmediationrequirement-silent③">silent</a>'
   });
   if (c) {
     // Hooray! Let’s sign the user in using these credentials!
@@ -2059,33 +2065,33 @@ store user credentials for future use.</p>
     </div>
     <div class="example" id="example-mediation-optional">
      <a class="self-link" href="#example-mediation-optional"></a> When a user clicks "Sign In", MegaCorp, Inc. wishes to give them the smoothest possible
-    experience. If they have <a href="#user-mediation-requirement">opted-into</a> signing in without <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated-5">user mediation</a>, and the user agent can unambigiously choose a credential, great! If
-    not, a <a data-link-type="dfn" href="#credential-chooser" id="ref-for-credential-chooser-6">credential chooser</a> will be presented. 
+    experience. If they have <a href="#user-mediation-requirement">opted-into</a> signing in without <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated④">user mediation</a>, and the user agent can unambigiously choose a credential, great! If
+    not, a <a data-link-type="dfn" href="#credential-chooser" id="ref-for-credential-chooser⑤">credential chooser</a> will be presented. 
 <pre>document.querySelector('#sign-in').addEventListener('click', e => {
-  var c = await navigatior.<a class="idl-code" data-link-type="attribute" href="#dom-navigator-credentials" id="ref-for-dom-navigator-credentials-4">credentials</a>.<a class="idl-code" data-link-type="method" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get-10">get</a>({
+  var c = await navigatior.<a class="idl-code" data-link-type="attribute" href="#dom-navigator-credentials" id="ref-for-dom-navigator-credentials③">credentials</a>.<a class="idl-code" data-link-type="method" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get⑨">get</a>({
     ...,
-    <a class="idl-code" data-link-type="dict-member" href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation-7">mediation</a>: '<a class="idl-code" data-link-type="enum-value" href="#dom-credentialmediationrequirement-optional" id="ref-for-dom-credentialmediationrequirement-optional-3">optional</a>'
+    <a class="idl-code" data-link-type="dict-member" href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation⑥">mediation</a>: '<a class="idl-code" data-link-type="enum-value" href="#dom-credentialmediationrequirement-optional" id="ref-for-dom-credentialmediationrequirement-optional②">optional</a>'
   });
   if (c) {
     // Hooray! Let’s sign the user in using these credentials!
   }
 });
 </pre>
-     <p class="note" role="note"><span>Note:</span> MegaCorp, Inc. could also have left off the <code class="idl"><a data-link-type="idl" href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation-8">mediation</a></code> member entirely, as "<code class="idl"><a data-link-type="idl" href="#dom-credentialmediationrequirement-optional" id="ref-for-dom-credentialmediationrequirement-optional-4">optional</a></code>" is its default.</p>
+     <p class="note" role="note"><span>Note:</span> MegaCorp, Inc. could also have left off the <code class="idl"><a data-link-type="idl" href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation⑦">mediation</a></code> member entirely, as "<code class="idl"><a data-link-type="idl" href="#dom-credentialmediationrequirement-optional" id="ref-for-dom-credentialmediationrequirement-optional③">optional</a></code>" is its default.</p>
     </div>
     <div class="example" id="example-mediation-require">
      <a class="self-link" href="#example-mediation-require"></a> MegaCorp, Inc. wishes to protect a sensitive operation by requiring a user to reauthenticate
     before taking action. Even if a user has <a href="#user-mediation-requirement">opted-into</a> signing in
-    without <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated-6">user mediation</a>, MegaCorp, Inc. can ensure that the user agent requires mediation
-    by calling <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get-11">get()</a></code> with a <code class="idl"><a data-link-type="idl" href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation-9">mediation</a></code> member set to
-    "<code class="idl"><a data-link-type="idl" href="#dom-credentialmediationrequirement-required" id="ref-for-dom-credentialmediationrequirement-required-2">required</a></code>": 
+    without <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated⑤">user mediation</a>, MegaCorp, Inc. can ensure that the user agent requires mediation
+    by calling <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get①⓪">get()</a></code> with a <code class="idl"><a data-link-type="idl" href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation⑧">mediation</a></code> member set to
+    "<code class="idl"><a data-link-type="idl" href="#dom-credentialmediationrequirement-required" id="ref-for-dom-credentialmediationrequirement-required①">required</a></code>": 
      <p class="note" role="note"><span>Note:</span> Depending on the security model of the browser or the credential type, this may require
     the user to authenticate themselves in some way, perhaps by entering a master password, scanning
     a fingerprint, etc. before a credential is handed to the website.</p>
 <pre>document.querySelector('#important-form').addEventListener('submit', e => {
-  var c = await navigatior.<a class="idl-code" data-link-type="attribute" href="#dom-navigator-credentials" id="ref-for-dom-navigator-credentials-5">credentials</a>.<a class="idl-code" data-link-type="method" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get-12">get</a>({
+  var c = await navigatior.<a class="idl-code" data-link-type="attribute" href="#dom-navigator-credentials" id="ref-for-dom-navigator-credentials④">credentials</a>.<a class="idl-code" data-link-type="method" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get①①">get</a>({
     ...,
-    <a class="idl-code" data-link-type="dict-member" href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation-10">mediation</a>: '<a class="idl-code" data-link-type="enum-value" href="#dom-credentialmediationrequirement-required" id="ref-for-dom-credentialmediationrequirement-required-3">required</a>'
+    <a class="idl-code" data-link-type="dict-member" href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation⑨">mediation</a>: '<a class="idl-code" data-link-type="enum-value" href="#dom-credentialmediationrequirement-required" id="ref-for-dom-credentialmediationrequirement-required②">required</a>'
   });
   if (c) {
     // Verify that |c| enables access, and cancel the submission
@@ -2098,13 +2104,13 @@ store user credentials for future use.</p>
     </div>
     <div class="example" id="example-mediation-switch">
      <a class="self-link" href="#example-mediation-switch"></a> MegaCorp, Inc. wishes to support signing into multiple user accounts at once. In order to ensure
-    that the user gets a chance to select a different credential, MegaCorp, Inc. can call <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get-13">get()</a></code> with a <code class="idl"><a data-link-type="idl" href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation-11">mediation</a></code> member set to
-    "<code class="idl"><a data-link-type="idl" href="#dom-credentialmediationrequirement-required" id="ref-for-dom-credentialmediationrequirement-required-4">required</a></code>" in order to ensure that that credentials aren’t
+    that the user gets a chance to select a different credential, MegaCorp, Inc. can call <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get①②">get()</a></code> with a <code class="idl"><a data-link-type="idl" href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation①⓪">mediation</a></code> member set to
+    "<code class="idl"><a data-link-type="idl" href="#dom-credentialmediationrequirement-required" id="ref-for-dom-credentialmediationrequirement-required③">required</a></code>" in order to ensure that that credentials aren’t
     returned automatically in response to clicking on an "Add account" button: 
 <pre>document.querySelector('#switch-button').addEventListener('click', e => {
-  var c = await navigatior.<a class="idl-code" data-link-type="attribute" href="#dom-navigator-credentials" id="ref-for-dom-navigator-credentials-6">credentials</a>.<a class="idl-code" data-link-type="method" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get-14">get</a>({
+  var c = await navigatior.<a class="idl-code" data-link-type="attribute" href="#dom-navigator-credentials" id="ref-for-dom-navigator-credentials⑤">credentials</a>.<a class="idl-code" data-link-type="method" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get①③">get</a>({
     ...,
-    <a class="idl-code" data-link-type="dict-member" href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation-12">mediation</a>: '<a class="idl-code" data-link-type="enum-value" href="#dom-credentialmediationrequirement-required" id="ref-for-dom-credentialmediationrequirement-required-5">required</a>'
+    <a class="idl-code" data-link-type="dict-member" href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation①①">mediation</a>: '<a class="idl-code" data-link-type="enum-value" href="#dom-credentialmediationrequirement-required" id="ref-for-dom-credentialmediationrequirement-required④">required</a>'
   });
   if (c) {
     // Sign the user in using |c|.
@@ -2113,9 +2119,9 @@ store user credentials for future use.</p>
 </pre>
     </div>
     <h3 class="heading settled" data-level="2.4" id="credentialcreationoptions-dictionary"><span class="secno">2.4. </span><span class="content">The <code>CredentialCreationOptions</code> Dictionary</span><a class="self-link" href="#credentialcreationoptions-dictionary"></a></h3>
-    <p>In order to create a <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-27">Credential</a></code> via <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-create" id="ref-for-dom-credentialscontainer-create-4">create()</a></code>, the caller specifies a
-  few parameters in a <code class="idl"><a data-link-type="idl" href="#dictdef-credentialcreationoptions" id="ref-for-dictdef-credentialcreationoptions-3">CredentialCreationOptions</a></code> object.</p>
-    <p class="note" role="note"><span>Note:</span> The <code class="idl"><a data-link-type="idl" href="#dictdef-credentialcreationoptions" id="ref-for-dictdef-credentialcreationoptions-4">CredentialCreationOptions</a></code> dictionary is an extension point. If and when new types of
+    <p>In order to create a <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential②⑥">Credential</a></code> via <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-create" id="ref-for-dom-credentialscontainer-create③">create()</a></code>, the caller specifies a
+  few parameters in a <code class="idl"><a data-link-type="idl" href="#dictdef-credentialcreationoptions" id="ref-for-dictdef-credentialcreationoptions②">CredentialCreationOptions</a></code> object.</p>
+    <p class="note" role="note"><span>Note:</span> The <code class="idl"><a data-link-type="idl" href="#dictdef-credentialcreationoptions" id="ref-for-dictdef-credentialcreationoptions③">CredentialCreationOptions</a></code> dictionary is an extension point. If and when new types of
   credentials are introduced, they will add to the dictionary so they can be passed into the
   creation method. See <a href="#implementation-extension">§7.2 Extension Points</a>, and the extensions introduced in this document: <a href="#passwordcredential-interface">§3.2 The PasswordCredential Interface</a> and <a href="#federatedcredential-interface">§4.1 The FederatedCredential Interface</a>.</p>
 <pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-credentialcreationoptions"><code>CredentialCreationOptions</code></dfn> {
@@ -2123,179 +2129,179 @@ store user credentials for future use.</p>
 </pre>
     <h3 class="heading settled" data-level="2.5" id="algorithms"><span class="secno">2.5. </span><span class="content">Algorithms</span><a class="self-link" href="#algorithms"></a></h3>
     <h4 class="heading settled algorithm" data-algorithm="Request a Credential" data-level="2.5.1" id="algorithm-request"><span class="secno">2.5.1. </span><span class="content">Request a <code>Credential</code></span><a class="self-link" href="#algorithm-request"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export="" id="abstract-opdef-request-a-credential">Request a <code>Credential</code></dfn> algorithm accepts a <code class="idl"><a data-link-type="idl" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions-9">CredentialRequestOptions</a></code> (<var>options</var>), and returns a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-promise">Promise</a></code> that resolves with a <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-28">Credential</a></code> if one can be
+    <p>The <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export="" id="abstract-opdef-request-a-credential">Request a <code>Credential</code></dfn> algorithm accepts a <code class="idl"><a data-link-type="idl" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions⑧">CredentialRequestOptions</a></code> (<var>options</var>), and returns a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-promise" id="ref-for-idl-promise">Promise</a></code> that resolves with a <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential②⑦">Credential</a></code> if one can be
   unambigiously obtained, or with <code>null</code> if not.</p>
     <ol class="algorithm">
      <li data-md="">
-      <p>Let <var>settings</var> be the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">current settings object</a></p>
+      <p>Let <var>settings</var> be the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object" id="ref-for-current-settings-object②">current settings object</a></p>
      <li data-md="">
-      <p class="assertion">Assert: <var>settings</var> is a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure context</a>.</p>
+      <p class="assertion">Assert: <var>settings</var> is a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context" id="ref-for-secure-context①">secure context</a>.</p>
      <li data-md="">
-      <p>Return <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#a-promise-rejected-with">a promise rejected with</a> <code>NotSupportedError</code> if any of the following statements
+      <p>Return <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#a-promise-rejected-with" id="ref-for-a-promise-rejected-with">a promise rejected with</a> <code>NotSupportedError</code> if any of the following statements
   are true:</p>
       <ol>
        <li data-md="">
-        <p><var>settings</var> does not have a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document">responsible document</a>.</p>
+        <p><var>settings</var> does not have a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document" id="ref-for-responsible-document">responsible document</a>.</p>
        <li data-md="">
-        <p><var>settings</var>’ <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document">responsible document</a> is not the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document">active document</a> in a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">top-level browsing context</a>.</p>
+        <p><var>settings</var>’ <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document" id="ref-for-responsible-document①">responsible document</a> is not the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document">active document</a> in a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context" id="ref-for-top-level-browsing-context">top-level browsing context</a>.</p>
       </ol>
      <li data-md="">
-      <p>Let <var>p</var> be <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#a-new-promise">a new promise</a>.</p>
+      <p>Let <var>p</var> be <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#a-new-promise" id="ref-for-a-new-promise">a new promise</a>.</p>
      <li data-md="">
-      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
+      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel">in parallel</a>:</p>
       <ol>
        <li data-md="">
-        <p>Let <var>credentials</var> be the result of <a data-link-type="abstract-op" href="#abstract-opdef-collect-credentials-from-the-credential-store" id="ref-for-abstract-opdef-collect-credentials-from-the-credential-store-1">collecting <code>Credential</code>s from the credential store</a>, given <var>options</var>.</p>
+        <p>Let <var>credentials</var> be the result of <a data-link-type="abstract-op" href="#abstract-opdef-collect-credentials-from-the-credential-store" id="ref-for-abstract-opdef-collect-credentials-from-the-credential-store">collecting <code>Credential</code>s from the credential store</a>, given <var>options</var>.</p>
        <li data-md="">
-        <p>If <var>credentials</var> is an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception">exception</a>, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#reject-promise">reject</a> <var>p</var> with <var>credentials</var>.</p>
+        <p>If <var>credentials</var> is an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception" id="ref-for-dfn-exception">exception</a>, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#reject-promise" id="ref-for-reject-promise">reject</a> <var>p</var> with <var>credentials</var>.</p>
        <li data-md="">
         <p>If all of the following statements are true, resolve <var>p</var> with <var>credentials</var>[0] and
   skip the remaining steps:</p>
         <ol>
          <li data-md="">
-          <p><var>credentials</var>’ <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-size">size</a> is 1</p>
+          <p><var>credentials</var>’ <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-size" id="ref-for-list-size">size</a> is 1</p>
          <li data-md="">
-          <p><var>settings</var>’ <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> does not <a data-link-type="dfn" href="#origin-requires-user-mediation" id="ref-for-origin-requires-user-mediation-2">require user mediation</a></p>
+          <p><var>settings</var>’ <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin">origin</a> does not <a data-link-type="dfn" href="#origin-requires-user-mediation" id="ref-for-origin-requires-user-mediation①">require user mediation</a></p>
          <li data-md="">
-          <p><var>options</var> is <a data-link-type="dfn" href="#credentialrequestoptions-matchable-a-priori" id="ref-for-credentialrequestoptions-matchable-a-priori-2">matchable <i lang="la">a priori</i></a>.</p>
+          <p><var>options</var> is <a data-link-type="dfn" href="#credentialrequestoptions-matchable-a-priori" id="ref-for-credentialrequestoptions-matchable-a-priori①">matchable <i lang="la">a priori</i></a>.</p>
          <li data-md="">
-          <p><var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation-13">mediation</a></code> is not
-  "<code class="idl"><a data-link-type="idl" href="#dom-credentialmediationrequirement-required" id="ref-for-dom-credentialmediationrequirement-required-6">required</a></code>".</p>
+          <p><var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation①②">mediation</a></code> is not
+  "<code class="idl"><a data-link-type="idl" href="#dom-credentialmediationrequirement-required" id="ref-for-dom-credentialmediationrequirement-required⑤">required</a></code>".</p>
         </ol>
         <p class="issue" id="issue-d9160978"><a class="self-link" href="#issue-d9160978"></a> This might be the wrong model. It would be nice to support a site that wished
   to accept either username/passwords or webauthn-style credentials without forcing
   a chooser for those users who use the former, and who wish to remain signed in.</p>
        <li data-md="">
-        <p>If <var>options</var>’ <code class="idl"><a data-link-type="idl" href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation-14">mediation</a></code> is
-  "<code class="idl"><a data-link-type="idl" href="#dom-credentialmediationrequirement-silent" id="ref-for-dom-credentialmediationrequirement-silent-5">silent</a></code>", <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#resolve-promise">resolve</a> <var>p</var> with <code>null</code>, and skip
+        <p>If <var>options</var>’ <code class="idl"><a data-link-type="idl" href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation①③">mediation</a></code> is
+  "<code class="idl"><a data-link-type="idl" href="#dom-credentialmediationrequirement-silent" id="ref-for-dom-credentialmediationrequirement-silent④">silent</a></code>", <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#resolve-promise" id="ref-for-resolve-promise">resolve</a> <var>p</var> with <code>null</code>, and skip
   the remaining steps.</p>
        <li data-md="">
-        <p>Let <var>choice</var> be the result of <a data-link-type="abstract-op" href="#abstract-opdef-ask-the-user-to-choose-a-credential" id="ref-for-abstract-opdef-ask-the-user-to-choose-a-credential-1">asking the user to
+        <p>Let <var>choice</var> be the result of <a data-link-type="abstract-op" href="#abstract-opdef-ask-the-user-to-choose-a-credential" id="ref-for-abstract-opdef-ask-the-user-to-choose-a-credential">asking the user to
   choose a <code>Credential</code></a>, given <var>options</var> and <var>credentials</var>.</p>
        <li data-md="">
-        <p>If <var>choice</var> is <code>null</code> or a <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-29">Credential</a></code>, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#resolve-promise">resolve</a> <var>p</var> with <var>choice</var> and skip the
+        <p>If <var>choice</var> is <code>null</code> or a <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential②⑧">Credential</a></code>, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#resolve-promise" id="ref-for-resolve-promise①">resolve</a> <var>p</var> with <var>choice</var> and skip the
   remaining steps.</p>
        <li data-md="">
-        <p class="assertion">Assert: <var>choice</var> is an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object">interface object</a>.</p>
+        <p class="assertion">Assert: <var>choice</var> is an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object⑧">interface object</a>.</p>
        <li data-md="">
-        <p>Let <var>result</var> be the result of executing <var>choice</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credential-discoverfromexternalsource-slot" id="ref-for-dom-credential-discoverfromexternalsource-slot-1">[[DiscoverFromExternalSource]](options)</a></code>, given <var>options</var>.</p>
+        <p>Let <var>result</var> be the result of executing <var>choice</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credential-discoverfromexternalsource-slot" id="ref-for-dom-credential-discoverfromexternalsource-slot②">[[DiscoverFromExternalSource]](options)</a></code>, given <var>options</var>.</p>
        <li data-md="">
-        <p>If <var>result</var> is a <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-30">Credential</a></code> or <code>null</code>, resolve <var>p</var> with <var>result</var>.</p>
-        <p>Otherwise, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#reject-promise">reject</a> <var>p</var> with <var>result</var>.</p>
+        <p>If <var>result</var> is a <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential②⑨">Credential</a></code> or <code>null</code>, resolve <var>p</var> with <var>result</var>.</p>
+        <p>Otherwise, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#reject-promise" id="ref-for-reject-promise①">reject</a> <var>p</var> with <var>result</var>.</p>
       </ol>
      <li data-md="">
       <p>Return <var>p</var>.</p>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Collect Credentials from the credential store" data-level="2.5.2" id="algorithm-collect-known"><span class="secno">2.5.2. </span><span class="content">Collect <code>Credential</code>s from the credential store</span><a class="self-link" href="#algorithm-collect-known"></a></h4>
-    <p>Given a <code class="idl"><a data-link-type="idl" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions-10">CredentialRequestOptions</a></code> (<var>options</var>), the user agent may <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export="" data-local-lt="collect local" id="abstract-opdef-collect-credentials-from-the-credential-store">collect <code>Credential</code>s from the credential store</dfn>,
-  returning a set of <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-31">Credential</a></code> objects stored by the user agent locally that match <var>options</var>’
-  filter. If no such <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-32">Credential</a></code> objects are known, the returned set will be empty:</p>
+    <p>Given a <code class="idl"><a data-link-type="idl" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions⑨">CredentialRequestOptions</a></code> (<var>options</var>), the user agent may <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export="" data-local-lt="collect local" id="abstract-opdef-collect-credentials-from-the-credential-store">collect <code>Credential</code>s from the credential store</dfn>,
+  returning a set of <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential③⓪">Credential</a></code> objects stored by the user agent locally that match <var>options</var>’
+  filter. If no such <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential③①">Credential</a></code> objects are known, the returned set will be empty:</p>
     <ol class="algorithm">
      <li data-md="">
       <p>Let <var>possible matches</var> be an empty set.</p>
      <li data-md="">
-      <p>For each <var>interface</var> in <var>options</var>’ <a data-link-type="dfn" href="#credentialrequestoptions-relevant-credential-interface-objects" id="ref-for-credentialrequestoptions-relevant-credential-interface-objects-2">relevant credential interface objects</a>:</p>
+      <p>For each <var>interface</var> in <var>options</var>’ <a data-link-type="dfn" href="#credentialrequestoptions-relevant-credential-interface-objects" id="ref-for-credentialrequestoptions-relevant-credential-interface-objects①">relevant credential interface objects</a>:</p>
       <ol>
        <li data-md="">
-        <p>Let <var>r</var> be the result of executing <var>interface</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credential-collectfromcredentialstore-slot" id="ref-for-dom-credential-collectfromcredentialstore-slot-1">[[CollectFromCredentialStore]](options)</a></code> internal method on <var>options</var>.</p>
+        <p>Let <var>r</var> be the result of executing <var>interface</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credential-collectfromcredentialstore-slot" id="ref-for-dom-credential-collectfromcredentialstore-slot">[[CollectFromCredentialStore]](options)</a></code> internal method on <var>options</var>.</p>
        <li data-md="">
-        <p>If <var>r</var> is an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception">exception</a>, return <var>r</var>.</p>
+        <p>If <var>r</var> is an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception" id="ref-for-dfn-exception①">exception</a>, return <var>r</var>.</p>
        <li data-md="">
-        <p class="assertion">Assert: <var>r</var> is a list of <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object">interface objects</a>.</p>
+        <p class="assertion">Assert: <var>r</var> is a list of <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object⑨">interface objects</a>.</p>
        <li data-md="">
         <p>For each <var>c</var> in <var>r</var>:</p>
         <ol>
          <li data-md="">
-          <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append">Append</a> <var>c</var> to <var>possible matches</var>.</p>
+          <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append" id="ref-for-set-append①">Append</a> <var>c</var> to <var>possible matches</var>.</p>
         </ol>
       </ol>
      <li data-md="">
       <p>Return <var>possible matches</var>.</p>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Store a Credential" data-level="2.5.3" id="algorithm-store"><span class="secno">2.5.3. </span><span class="content">Store a <code>Credential</code></span><a class="self-link" href="#algorithm-store"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export="" id="abstract-opdef-store-a-credential">Store a <code>Credential</code></dfn> algorithm accepts a <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-33">Credential</a></code> (<var>credential</var>), and returns a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-promise">Promise</a></code> which resolves once the object is persisted to the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store-10">credential store</a>.</p>
+    <p>The <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export="" id="abstract-opdef-store-a-credential">Store a <code>Credential</code></dfn> algorithm accepts a <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential③②">Credential</a></code> (<var>credential</var>), and returns a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-promise" id="ref-for-idl-promise①">Promise</a></code> which resolves once the object is persisted to the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store⑨">credential store</a>.</p>
     <ol class="algorithm">
      <li data-md="">
-      <p>Let <var>settings</var> be the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">current settings object</a></p>
+      <p>Let <var>settings</var> be the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object" id="ref-for-current-settings-object③">current settings object</a></p>
      <li data-md="">
-      <p class="assertion">Assert: <var>settings</var> is a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure context</a>.</p>
+      <p class="assertion">Assert: <var>settings</var> is a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context" id="ref-for-secure-context②">secure context</a>.</p>
      <li data-md="">
-      <p>Return <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#a-promise-rejected-with">a promise rejected with</a> <code>NotSupportedError</code> if any of the following statements
+      <p>Return <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#a-promise-rejected-with" id="ref-for-a-promise-rejected-with①">a promise rejected with</a> <code>NotSupportedError</code> if any of the following statements
   are true:</p>
       <ol>
        <li data-md="">
-        <p><var>settings</var> does not have a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document">responsible document</a>.</p>
+        <p><var>settings</var> does not have a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document" id="ref-for-responsible-document②">responsible document</a>.</p>
        <li data-md="">
-        <p><var>settings</var>’ <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document">responsible document</a> is not the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document">active document</a> in a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">top-level browsing context</a>.</p>
+        <p><var>settings</var>’ <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document" id="ref-for-responsible-document③">responsible document</a> is not the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document①">active document</a> in a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context" id="ref-for-top-level-browsing-context①">top-level browsing context</a>.</p>
       </ol>
      <li data-md="">
-      <p>Let <var>p</var> be <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#a-new-promise">a new promise</a>.</p>
+      <p>Let <var>p</var> be <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#a-new-promise" id="ref-for-a-new-promise①">a new promise</a>.</p>
      <li data-md="">
-      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
+      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel①">in parallel</a>:</p>
       <ol>
        <li data-md="">
-        <p>Let <var>r</var> be the result of executing <var>credential</var>’s <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object">interface object</a>'s <code class="idl"><a data-link-type="idl" href="#dom-credential-store-slot" id="ref-for-dom-credential-store-slot-1">[[Store]](credential)</a></code> internal method on <var>credential</var>.</p>
+        <p>Let <var>r</var> be the result of executing <var>credential</var>’s <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object①⓪">interface object</a>'s <code class="idl"><a data-link-type="idl" href="#dom-credential-store-slot" id="ref-for-dom-credential-store-slot">[[Store]](credential)</a></code> internal method on <var>credential</var>.</p>
        <li data-md="">
-        <p><a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#resolve-promise">Resolve</a> <var>p</var> with <var>r</var>.</p>
+        <p><a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#resolve-promise" id="ref-for-resolve-promise②">Resolve</a> <var>p</var> with <var>r</var>.</p>
       </ol>
      <li data-md="">
       <p>Return <var>p</var>.</p>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Create a Credential" data-level="2.5.4" id="algorithm-create"><span class="secno">2.5.4. </span><span class="content">Create a <code>Credential</code></span><a class="self-link" href="#algorithm-create"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export="" id="abstract-opdef-create-a-credential">Create a <code>Credential</code></dfn> algorithm accepts a <code class="idl"><a data-link-type="idl" href="#dictdef-credentialcreationoptions" id="ref-for-dictdef-credentialcreationoptions-5">CredentialCreationOptions</a></code> (<var>options</var>), and returns a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-promise">Promise</a></code> which resolves with a <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-34">Credential</a></code> if one can be created
-  using the options provided, or <code>null</code> if no <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-35">Credential</a></code> can be created. In exceptional
-  circumstances, the <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-promise">Promise</a></code> may reject with an appropriate exception:</p>
+    <p>The <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export="" id="abstract-opdef-create-a-credential">Create a <code>Credential</code></dfn> algorithm accepts a <code class="idl"><a data-link-type="idl" href="#dictdef-credentialcreationoptions" id="ref-for-dictdef-credentialcreationoptions④">CredentialCreationOptions</a></code> (<var>options</var>), and returns a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-promise" id="ref-for-idl-promise②">Promise</a></code> which resolves with a <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential③③">Credential</a></code> if one can be created
+  using the options provided, or <code>null</code> if no <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential③④">Credential</a></code> can be created. In exceptional
+  circumstances, the <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-promise" id="ref-for-idl-promise③">Promise</a></code> may reject with an appropriate exception:</p>
     <ol class="algorithm">
      <li data-md="">
-      <p>Let <var>settings</var> be the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">current settings object</a></p>
+      <p>Let <var>settings</var> be the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object" id="ref-for-current-settings-object④">current settings object</a></p>
      <li data-md="">
-      <p class="assertion">Assert: <var>settings</var> is a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure context</a>.</p>
+      <p class="assertion">Assert: <var>settings</var> is a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context" id="ref-for-secure-context③">secure context</a>.</p>
      <li data-md="">
-      <p>Let <var>interfaces</var> be the set of <var>options</var>’ <a data-link-type="dfn" href="#credentialrequestoptions-relevant-credential-interface-objects" id="ref-for-credentialrequestoptions-relevant-credential-interface-objects-3">relevant credential interface objects</a>.</p>
+      <p>Let <var>interfaces</var> be the set of <var>options</var>’ <a data-link-type="dfn" href="#credentialrequestoptions-relevant-credential-interface-objects" id="ref-for-credentialrequestoptions-relevant-credential-interface-objects②">relevant credential interface objects</a>.</p>
      <li data-md="">
-      <p>Return <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#a-promise-rejected-with">a promise rejected with</a> <code>NotSupportedError</code> if any of the following statements
+      <p>Return <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#a-promise-rejected-with" id="ref-for-a-promise-rejected-with②">a promise rejected with</a> <code>NotSupportedError</code> if any of the following statements
   are true:</p>
       <ol>
        <li data-md="">
-        <p><var>settings</var> does not have a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document">responsible document</a>.</p>
+        <p><var>settings</var> does not have a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document" id="ref-for-responsible-document④">responsible document</a>.</p>
        <li data-md="">
-        <p><var>settings</var>’ <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document">responsible document</a> is not the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document">active document</a> in a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">top-level browsing context</a>.</p>
+        <p><var>settings</var>’ <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document" id="ref-for-responsible-document⑤">responsible document</a> is not the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document②">active document</a> in a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context" id="ref-for-top-level-browsing-context②">top-level browsing context</a>.</p>
        <li data-md="">
-        <p><var>interfaces</var>’ <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-size">size</a> is greater than 1.</p>
+        <p><var>interfaces</var>’ <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-size" id="ref-for-list-size①">size</a> is greater than 1.</p>
         <p class="note" role="note"><span>Note:</span> It may be reasonable at some point in the future to loosen this restriction, and
   allow the user agent to help the user choose among one of many potential credential
   types in order to support a "sign-up" use case. For the moment, though, we’re punting
   on that by restricting the dictionary to a single entry.</p>
       </ol>
      <li data-md="">
-      <p>Let <var>p</var> be <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#a-new-promise">a new promise</a>.</p>
+      <p>Let <var>p</var> be <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#a-new-promise" id="ref-for-a-new-promise②">a new promise</a>.</p>
      <li data-md="">
-      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
+      <p>Run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel②">in parallel</a> but abort if the execution is <a data-link-type="dfn" href="#concept-credman-terminated" id="ref-for-concept-credman-terminated②">terminated</a>:</p>
       <ol>
        <li data-md="">
-        <p>Let <var>r</var> be the result of executing <var>interfaces</var>[0] <code class="idl"><a data-link-type="idl" href="#dom-credential-create-slot" id="ref-for-dom-credential-create-slot-1">[[Create]](options)</a></code> internal method on <var>options</var>.</p>
+        <p>Let <var>r</var> be the result of executing <var>interfaces</var>[0] <code class="idl"><a data-link-type="idl" href="#dom-credential-create-slot" id="ref-for-dom-credential-create-slot①">[[Create]](options)</a></code> internal method on <var>options</var>.</p>
        <li data-md="">
-        <p>If <var>r</var> is an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception">exception</a>, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#reject-promise">reject</a> <var>p</var> with <var>r</var>.</p>
-        <p>Otherwise, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#resolve-promise">resolve</a> <var>p</var> with <var>r</var>.</p>
+        <p>If <var>r</var> is an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception" id="ref-for-dfn-exception②">exception</a>, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#reject-promise" id="ref-for-reject-promise②">reject</a> <var>p</var> with <var>r</var>.</p>
+        <p>Otherwise, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#resolve-promise" id="ref-for-resolve-promise③">resolve</a> <var>p</var> with <var>r</var>.</p>
       </ol>
      <li data-md="">
       <p>Return <var>p</var>.</p>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Prevent Silent Access" data-level="2.5.5" id="algorithm-prevent-silent-access"><span class="secno">2.5.5. </span><span class="content">Prevent Silent Access</span><a class="self-link" href="#algorithm-prevent-silent-access"></a></h4>
-    <p>The <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export="" id="abstract-opdef-prevent-silent-access">Prevent Silent Access</dfn> algorithm accepts an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings
-  object</a> (<var>settings</var>), and returns a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-promise">Promise</a></code> which resolves once the <code>prevent silent access</code> flag is persisted to the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store-11">credential store</a>.</p>
+    <p>The <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export="" id="abstract-opdef-prevent-silent-access">Prevent Silent Access</dfn> algorithm accepts an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object" id="ref-for-environment-settings-object">environment settings
+  object</a> (<var>settings</var>), and returns a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-promise" id="ref-for-idl-promise④">Promise</a></code> which resolves once the <code>prevent silent access</code> flag is persisted to the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store①⓪">credential store</a>.</p>
     <ol class="algorithm">
      <li data-md="">
-      <p>Let <var>origin</var> be <var>settings</var>’ <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>.</p>
+      <p>Let <var>origin</var> be <var>settings</var>’ <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin①">origin</a>.</p>
      <li data-md="">
-      <p>Let <var>p</var> be <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#a-new-promise">a new promise</a></p>
+      <p>Let <var>p</var> be <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#a-new-promise" id="ref-for-a-new-promise③">a new promise</a></p>
      <li data-md="">
-      <p>Run the following seps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
+      <p>Run the following seps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel③">in parallel</a>:</p>
       <ol>
        <li data-md="">
-        <p>Set <var>origin</var>’s <a data-link-type="dfn" href="#origin-prevent-silent-access-flag" id="ref-for-origin-prevent-silent-access-flag-4"><code>prevent silent access</code> flag</a> in the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store-12">credential store</a>.</p>
+        <p>Set <var>origin</var>’s <a data-link-type="dfn" href="#origin-prevent-silent-access-flag" id="ref-for-origin-prevent-silent-access-flag③"><code>prevent silent access</code> flag</a> in the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store①①">credential store</a>.</p>
        <li data-md="">
-        <p><a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#resolve-promise">Resolve</a> <var>p</var> with <code>undefined</code>.</p>
+        <p><a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#resolve-promise" id="ref-for-resolve-promise④">Resolve</a> <var>p</var> with <code>undefined</code>.</p>
       </ol>
      <li data-md="">
       <p>Retun <var>p</var>.</p>
@@ -2304,16 +2310,16 @@ store user credentials for future use.</p>
    <section>
     <h2 class="heading settled" data-level="3" id="passwords"><span class="secno">3. </span><span class="content">Password Credentials</span><a class="self-link" href="#passwords"></a></h2>
     <p>For good or for ill, many websites rely on username/password pairs as an authentication mechanism.
-  The <code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential-2">PasswordCredential</a></code> interface is a <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential-16">credential</a> meant to enable this use case, storing
+  The <code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential①">PasswordCredential</a></code> interface is a <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential①⑤">credential</a> meant to enable this use case, storing
   both a username and password, as well as metadata that can help a user choose the right account
-  from within a <a data-link-type="dfn" href="#credential-chooser" id="ref-for-credential-chooser-7">credential chooser</a>.</p>
+  from within a <a data-link-type="dfn" href="#credential-chooser" id="ref-for-credential-chooser⑥">credential chooser</a>.</p>
     <h3 class="heading settled" data-level="3.1" id="password-examples"><span class="secno">3.1. </span><span class="content">Examples</span><a class="self-link" href="#password-examples"></a></h3>
     <h4 class="heading settled" data-level="3.1.1" id="examples-password-signin"><span class="secno">3.1.1. </span><span class="content">Password-based Sign-in</span><a class="self-link" href="#examples-password-signin"></a></h4>
     <div class="example" id="example-9d459b26">
-     <a class="self-link" href="#example-9d459b26"></a> MegaCorp, Inc. supports passwords, and can use <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get-15">navigator.credentials.get()</a></code> to obtain
-    username/password pairs from a user’s <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store-13">credential store</a>: 
-<pre>navigator.<a class="idl-code" data-link-type="attribute" href="#dom-navigator-credentials" id="ref-for-dom-navigator-credentials-7">credentials</a>
-  .<a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get-16">get</a>({ '<a class="idl-code" data-link-type="dict-member" href="#dom-credentialrequestoptions-password" id="ref-for-dom-credentialrequestoptions-password-1">password</a>': true })
+     <a class="self-link" href="#example-9d459b26"></a> MegaCorp, Inc. supports passwords, and can use <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get①④">navigator.credentials.get()</a></code> to obtain
+    username/password pairs from a user’s <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store①②">credential store</a>: 
+<pre>navigator.<a class="idl-code" data-link-type="attribute" href="#dom-navigator-credentials" id="ref-for-dom-navigator-credentials⑥">credentials</a>
+  .<a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get①⑤">get</a>({ '<a class="idl-code" data-link-type="dict-member" href="#dom-credentialrequestoptions-password" id="ref-for-dom-credentialrequestoptions-password">password</a>': true })
   .then(credential => {
     if (!credential) {
       // The user either doesn’t have credentials for this site, or
@@ -2321,7 +2327,7 @@ store user credentials for future use.</p>
       // a basic login form.
       return;
     }
-    if (credential.<a class="idl-code" data-link-type="attribute" href="#dom-credential-type" id="ref-for-dom-credential-type-2">type</a> == '<a class="idl-code" data-link-type="const" href="#dom-credential-type-password" id="ref-for-dom-credential-type-password-1">password</a>') {
+    if (credential.<a class="idl-code" data-link-type="attribute" href="#dom-credential-type" id="ref-for-dom-credential-type①">type</a> == '<a class="idl-code" data-link-type="const" href="#dom-credential-type-password" id="ref-for-dom-credential-type-password">password</a>') {
       var form = new FormData();
       form.append('username_field', credential.id);
       form.append('password_field', credential.password);
@@ -2334,7 +2340,7 @@ store user credentials for future use.</p>
         .then(function (response) {
           if (/* |response| indicates a successful login */) {
             // Record that the credential was effective. See note below.
-            navigator.<a class="idl-code" data-link-type="attribute" href="#dom-navigator-credentials" id="ref-for-dom-navigator-credentials-8">credentials</a>.<a data-link-type="idl" href="#dom-credentialscontainer-store" id="ref-for-dom-credentialscontainer-store-5">store</a>(credential);
+            navigator.<a class="idl-code" data-link-type="attribute" href="#dom-navigator-credentials" id="ref-for-dom-navigator-credentials⑦">credentials</a>.<a data-link-type="idl" href="#dom-credentialscontainer-store" id="ref-for-dom-credentialscontainer-store④">store</a>(credential);
             // Notify the user that sign-in succeeded! Do amazing, signed-in things!
             // Maybe navigate to a landing page via location.href =
             // '/signed-in-experience'?
@@ -2345,14 +2351,14 @@ store user credentials for future use.</p>
     }
   });
 </pre>
-     <p>Alternatively, the website could just copy the credential data into a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/forms.html#the-form-element">form</a></code> and call <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/forms.html#dom-form-submit">submit()</a></code> on the form:</p>
-<pre>navigator.<a class="idl-code" data-link-type="attribute" href="#dom-navigator-credentials" id="ref-for-dom-navigator-credentials-9">credentials</a>
-  .<a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get-17">get</a>({ '<a class="idl-code" data-link-type="dict-member" href="#dom-credentialrequestoptions-password" id="ref-for-dom-credentialrequestoptions-password-2">password</a>': true })
+     <p>Alternatively, the website could just copy the credential data into a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/forms.html#the-form-element" id="ref-for-the-form-element">form</a></code> and call <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/forms.html#dom-form-submit-2" id="ref-for-dom-form-submit-2">submit()</a></code> on the form:</p>
+<pre>navigator.<a class="idl-code" data-link-type="attribute" href="#dom-navigator-credentials" id="ref-for-dom-navigator-credentials⑧">credentials</a>
+  .<a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get①⑥">get</a>({ '<a class="idl-code" data-link-type="dict-member" href="#dom-credentialrequestoptions-password" id="ref-for-dom-credentialrequestoptions-password①">password</a>': true })
   .then(credential => {
     if (!credential) {
       return; // as above...
     }
-    if (credential.<a class="idl-code" data-link-type="attribute" href="#dom-credential-type" id="ref-for-dom-credential-type-3">type</a> == '<a class="idl-code" data-link-type="const" href="#password-literal">password</a>') {
+    if (credential.<a class="idl-code" data-link-type="attribute" href="#dom-credential-type" id="ref-for-dom-credential-type②">type</a> == '<a class="idl-code" data-link-type="const" href="#password-literal">password</a>') {
       document.getQuerySelector('input[name=username_field]').value =
           credential.id;
       document.getQuerySelector('input[name=password_field]').value =
@@ -2362,44 +2368,44 @@ store user credentials for future use.</p>
   });
 </pre>
      <p>Note that the former method is much preferred, as it contains an explicit call
-    to <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-store" id="ref-for-dom-credentialscontainer-store-6">store()</a></code> and saves the credentials. The <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/forms.html#the-form-element">form</a></code> based mechanism
+    to <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-store" id="ref-for-dom-credentialscontainer-store⑤">store()</a></code> and saves the credentials. The <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/forms.html#the-form-element" id="ref-for-the-form-element①">form</a></code> based mechanism
     relies on form submission, which navigates the browsing context, making it difficult to
-    ensure that <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-store" id="ref-for-dom-credentialscontainer-store-7">store()</a></code> is called after successful sign-in.</p>
+    ensure that <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-store" id="ref-for-dom-credentialscontainer-store⑥">store()</a></code> is called after successful sign-in.</p>
     </div>
-    <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#credential-chooser" id="ref-for-credential-chooser-8">credential chooser</a> presented by the user agent could allow the user to choose
+    <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#credential-chooser" id="ref-for-credential-chooser⑦">credential chooser</a> presented by the user agent could allow the user to choose
   credentials that aren’t actually stored for the current origin. For instance, it might offer up
   credentials from <code>https://m.example.com</code> when signing into <code>https://www.example.com</code> (as
   described in <a href="#security-credential-access">§6.1 Cross-domain credential access</a>), or it might allow a user to create a new
-  credential on the fly. Developers can deal gracefully with this uncertainty by calling <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-store" id="ref-for-dom-credentialscontainer-store-8">store()</a></code> every time credentials are successfully used, even right after
-  credentials have been retrieved from <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get-18">get()</a></code>: if the credentials aren’t
+  credential on the fly. Developers can deal gracefully with this uncertainty by calling <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-store" id="ref-for-dom-credentialscontainer-store⑦">store()</a></code> every time credentials are successfully used, even right after
+  credentials have been retrieved from <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get①⑦">get()</a></code>: if the credentials aren’t
   yet stored for the origin, the user will be given the opportunity to do so. If they are stored,
   the user won’t be prompted.</p>
     <h4 class="heading settled" data-level="3.1.2" id="examples-post-signin"><span class="secno">3.1.2. </span><span class="content">Post-sign-in Confirmation</span><a class="self-link" href="#examples-post-signin"></a></h4>
     <p>To ensure that users are offered to store new credentials after a successful sign-in, they can
-  to be passed to <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-store" id="ref-for-dom-credentialscontainer-store-9">store()</a></code>.</p>
+  to be passed to <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-store" id="ref-for-dom-credentialscontainer-store⑧">store()</a></code>.</p>
     <div class="example" id="example-c5fa5c32">
-     <a class="self-link" href="#example-c5fa5c32"></a> If a user is signed in by submitting the credentials to a sign-in endpoint via <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-global-fetch">fetch()</a></code>,
+     <a class="self-link" href="#example-c5fa5c32"></a> If a user is signed in by submitting the credentials to a sign-in endpoint via <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-global-fetch" id="ref-for-dom-global-fetch">fetch()</a></code>,
     we can check the response to determine whether the user
     was signed in successfully, and notify the user agent accordingly. Given a sign-in form like the
     following: 
 <pre>&lt;form action="https://example.com/login" method="POST" id="theForm">
   &lt;label for="username">Username&lt;/label>
-  &lt;input type="text" id="username" name="username" <a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete">autocomplete</a>="<a data-link-type="attr-value" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-username">username</a>">
+  &lt;input type="text" id="username" name="username" <a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete" id="ref-for-attr-fe-autocomplete①">autocomplete</a>="<a data-link-type="attr-value" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-username" id="ref-for-attr-fe-autocomplete-username">username</a>">
   &lt;label for="password">Password&lt;/label>
-  &lt;input type="password" id="password" name="password" <a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete">autocomplete</a>="<a data-link-type="attr-value" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-current-password">current-password</a>">
+  &lt;input type="password" id="password" name="password" <a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete" id="ref-for-attr-fe-autocomplete②">autocomplete</a>="<a data-link-type="attr-value" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-current-password" id="ref-for-attr-fe-autocomplete-current-password">current-password</a>">
   &lt;input type="submit">
 &lt;/form>
 </pre>
      <p>Then the developer can handle the form submission with something like the following handler:</p>
 <pre>document.querySelector('#theForm').addEventListener('submit', e => {
-    if (<a class="idl-code" data-link-type="attribute" href="#dom-navigator-credentials" id="ref-for-dom-navigator-credentials-10">navigator.credentials</a>) {
+    if (<a class="idl-code" data-link-type="attribute" href="#dom-navigator-credentials" id="ref-for-dom-navigator-credentials⑨">navigator.credentials</a>) {
       e.preventDefault();
 
-      // Construct a new <a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential-3">PasswordCredential</a> from the <a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/forms.html#htmlformelement">HTMLFormElement</a>
+      // Construct a new <a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential②">PasswordCredential</a> from the <a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/forms.html#htmlformelement" id="ref-for-htmlformelement">HTMLFormElement</a>
       // that fired the "submit" event: this will suck up the values of the fields
-      // labeled with "username" and "current-password" <a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete">autocomplete</a>
+      // labeled with "username" and "current-password" <a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete" id="ref-for-attr-fe-autocomplete③">autocomplete</a>
       // attributes:
-      var c = new <a data-link-type="idl" href="#dom-passwordcredential-passwordcredential" id="ref-for-dom-passwordcredential-passwordcredential-1">PasswordCredential</a>(e.target);
+      var c = new <a data-link-type="idl" href="#dom-passwordcredential-passwordcredential" id="ref-for-dom-passwordcredential-passwordcredential">PasswordCredential</a>(e.target);
 
       // Fetch the form’s action URL, passing that new credential object in
       // as a FormData object. If the response indicates success, tell the user agent
@@ -2410,8 +2416,8 @@ store user credentials for future use.</p>
         credentials: 'include'  // Send cookies.
       };
       fetch(e.target.action, opt).then(r => {
-        if (/* |r| is a "successful" <a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a> */)
-          <a data-link-type="idl" href="#dom-credentialscontainer-store" id="ref-for-dom-credentialscontainer-store-10">navigator.credentials.store</a>(c);
+        if (/* |r| is a "successful" <a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response" id="ref-for-response">Response</a> */)
+          <a data-link-type="idl" href="#dom-credentialscontainer-store" id="ref-for-dom-credentialscontainer-store⑨">navigator.credentials.store</a>(c);
       });
     }
 });
@@ -2424,25 +2430,25 @@ store user credentials for future use.</p>
     <div class="example" id="example-e8298f0b">
      <a class="self-link" href="#example-e8298f0b"></a> MegaCorp Inc. allows users to change their passwords by POSTing data to
     a backend server asynchronously. After doing so successfully, they can
-    update the user’s credentials by calling <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-store" id="ref-for-dom-credentialscontainer-store-11">store()</a></code> with the new information. 
+    update the user’s credentials by calling <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-store" id="ref-for-dom-credentialscontainer-store①⓪">store()</a></code> with the new information. 
      <p>Given a password change form like the following:</p>
 <pre>&lt;form action="https://example.com/changePassword" method="POST" id="theForm">
-  &lt;input type="hidden" name="username" <a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete">autocomplete</a>="<a data-link-type="attr-value" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-username">username</a>" value="user">
+  &lt;input type="hidden" name="username" <a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete" id="ref-for-attr-fe-autocomplete④">autocomplete</a>="<a data-link-type="attr-value" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-username" id="ref-for-attr-fe-autocomplete-username①">username</a>" value="user">
   &lt;label for="password">New Password&lt;/label>
-  &lt;input type="password" id="password" name="password" <a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete">autocomplete</a>="<a data-link-type="attr-value" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-new-password">new-password</a>">
+  &lt;input type="password" id="password" name="password" <a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete" id="ref-for-attr-fe-autocomplete⑤">autocomplete</a>="<a data-link-type="attr-value" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-new-password" id="ref-for-attr-fe-autocomplete-new-password">new-password</a>">
   &lt;input type="submit">
 &lt;/form>
 </pre>
      <p>The developer can handle the form submission with something like the following:</p>
 <pre>document.querySelector('#theForm').addEventListener('submit', e => {
-  if (<a class="idl-code" data-link-type="attribute" href="#dom-navigator-credentials" id="ref-for-dom-navigator-credentials-11">navigator.credentials</a>) {
+  if (<a class="idl-code" data-link-type="attribute" href="#dom-navigator-credentials" id="ref-for-dom-navigator-credentials①⓪">navigator.credentials</a>) {
     e.preventDefault();
 
-    // Construct a new <a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential-4">PasswordCredential</a> from the <a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/forms.html#htmlformelement">HTMLFormElement</a>
+    // Construct a new <a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential③">PasswordCredential</a> from the <a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/forms.html#htmlformelement" id="ref-for-htmlformelement①">HTMLFormElement</a>
     // that fired the "submit" event: this will suck up the values of the fields
-    // labeled with "username" and "new-password" <a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete">autocomplete</a>
+    // labeled with "username" and "new-password" <a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete" id="ref-for-attr-fe-autocomplete⑥">autocomplete</a>
     // attributes:
-    var c = new <a data-link-type="idl" href="#dom-passwordcredential-passwordcredential" id="ref-for-dom-passwordcredential-passwordcredential-2">PasswordCredential</a>(e.target);
+    var c = new <a data-link-type="idl" href="#dom-passwordcredential-passwordcredential" id="ref-for-dom-passwordcredential-passwordcredential①">PasswordCredential</a>(e.target);
 
     // Fetch the form’s action URL, passing that new credential object in
     // as a FormData object. If the response indicates success, tell the user agent
@@ -2453,273 +2459,273 @@ store user credentials for future use.</p>
       credentials: 'include'  // Send cookies.
     };
     fetch(e.target.action, opt).then(r => {
-      if (/* |r| is a "successful" <a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a> */)
-        <a data-link-type="idl" href="#dom-credentialscontainer-store" id="ref-for-dom-credentialscontainer-store-12">navigator.credentials.store</a>(c);
+      if (/* |r| is a "successful" <a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response" id="ref-for-response①">Response</a> */)
+        <a data-link-type="idl" href="#dom-credentialscontainer-store" id="ref-for-dom-credentialscontainer-store①①">navigator.credentials.store</a>(c);
     });
   }
 });
 </pre>
     </div>
     <h3 class="heading settled" data-level="3.2" id="passwordcredential-interface"><span class="secno">3.2. </span><span class="content">The <code>PasswordCredential</code> Interface</span><a class="self-link" href="#passwordcredential-interface"></a></h3>
-<pre class="idl highlight def"><span class="kt">typedef</span> (<a class="n" data-link-type="idl-name" href="https://xhr.spec.whatwg.org/#interface-formdata">FormData</a> <span class="kt">or</span> <a class="n" data-link-type="idl-name" href="https://url.spec.whatwg.org/#urlsearchparams">URLSearchParams</a>) <dfn class="nv idl-code" data-dfn-type="typedef" data-export="" id="typedefdef-credentialbodytype"><code>CredentialBodyType</code><a class="self-link" href="#typedefdef-credentialbodytype"></a></dfn>;
+<pre class="idl highlight def"><span class="kt">typedef</span> (<a class="n" data-link-type="idl-name" href="https://xhr.spec.whatwg.org/#interface-formdata" id="ref-for-interface-formdata">FormData</a> <span class="kt">or</span> <a class="n" data-link-type="idl-name" href="https://url.spec.whatwg.org/#urlsearchparams" id="ref-for-urlsearchparams">URLSearchParams</a>) <dfn class="nv idl-code" data-dfn-type="typedef" data-export="" id="typedefdef-credentialbodytype"><code>CredentialBodyType</code><a class="self-link" href="#typedefdef-credentialbodytype"></a></dfn>;
 
-[<a class="nv idl-code" data-link-type="constructor" href="#dom-passwordcredential-passwordcredential" id="ref-for-dom-passwordcredential-passwordcredential-3">Constructor</a>(<a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/forms.html#htmlformelement">HTMLFormElement</a> <dfn class="nv idl-code" data-dfn-for="PasswordCredential/PasswordCredential(form)" data-dfn-type="argument" data-export="" id="dom-passwordcredential-passwordcredential-form-form"><code>form</code><a class="self-link" href="#dom-passwordcredential-passwordcredential-form-form"></a></dfn>),
- <a class="nv idl-code" data-link-type="constructor" href="#dom-passwordcredential-passwordcredential-data" id="ref-for-dom-passwordcredential-passwordcredential-data-1">Constructor</a>(<a class="n" data-link-type="idl-name" href="#dictdef-passwordcredentialdata" id="ref-for-dictdef-passwordcredentialdata-1">PasswordCredentialData</a> <dfn class="nv idl-code" data-dfn-for="PasswordCredential/PasswordCredential(data)" data-dfn-type="argument" data-export="" id="dom-passwordcredential-passwordcredential-data-data"><code>data</code><a class="self-link" href="#dom-passwordcredential-passwordcredential-data-data"></a></dfn>),
- <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">Window</span>,
- <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext">SecureContext</a>]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="passwordcredential"><code>PasswordCredential</code></dfn> : <a class="n" data-link-type="idl-name" href="#credential" id="ref-for-credential-36">Credential</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString"><span class="kt">USVString</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-passwordcredential-password" id="ref-for-dom-passwordcredential-password-1">password</a>;
+[<a class="nv idl-code" data-link-type="constructor" href="#dom-passwordcredential-passwordcredential" id="ref-for-dom-passwordcredential-passwordcredential②">Constructor</a>(<a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/forms.html#htmlformelement" id="ref-for-htmlformelement②">HTMLFormElement</a> <dfn class="nv idl-code" data-dfn-for="PasswordCredential/PasswordCredential(form)" data-dfn-type="argument" data-export="" id="dom-passwordcredential-passwordcredential-form-form"><code>form</code><a class="self-link" href="#dom-passwordcredential-passwordcredential-form-form"></a></dfn>),
+ <a class="nv idl-code" data-link-type="constructor" href="#dom-passwordcredential-passwordcredential-data" id="ref-for-dom-passwordcredential-passwordcredential-data">Constructor</a>(<a class="n" data-link-type="idl-name" href="#dictdef-passwordcredentialdata" id="ref-for-dictdef-passwordcredentialdata">PasswordCredentialData</a> <dfn class="nv idl-code" data-dfn-for="PasswordCredential/PasswordCredential(data)" data-dfn-type="argument" data-export="" id="dom-passwordcredential-passwordcredential-data-data"><code>data</code><a class="self-link" href="#dom-passwordcredential-passwordcredential-data-data"></a></dfn>),
+ <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed②">Exposed</a>=<span class="n">Window</span>,
+ <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext④">SecureContext</a>]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="passwordcredential"><code>PasswordCredential</code></dfn> : <a class="n" data-link-type="idl-name" href="#credential" id="ref-for-credential③⑤">Credential</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑦"><span class="kt">USVString</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-passwordcredential-password" id="ref-for-dom-passwordcredential-password">password</a>;
 };
-<a class="n" data-link-type="idl-name" href="#passwordcredential" id="ref-for-passwordcredential-5">PasswordCredential</a> <span class="kt">implements</span> <a class="n" data-link-type="idl-name" href="#credentialuserdata" id="ref-for-credentialuserdata-1">CredentialUserData</a>;
+<a class="n" data-link-type="idl-name" href="#passwordcredential" id="ref-for-passwordcredential④">PasswordCredential</a> <span class="kt">implements</span> <a class="n" data-link-type="idl-name" href="#credentialuserdata" id="ref-for-credentialuserdata">CredentialUserData</a>;
 
-<span class="kt">partial</span> <span class="kt">dictionary</span> <a class="nv idl-code" data-link-type="dictionary" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions-11">CredentialRequestOptions</a> {
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <dfn class="nv dfn-paneled idl-code" data-default="false" data-dfn-for="CredentialRequestOptions" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-credentialrequestoptions-password"><code>password</code></dfn> = <span class="kt">false</span>;
+<span class="kt">partial</span> <span class="kt">dictionary</span> <a class="nv idl-code" data-link-type="dictionary" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions①⓪">CredentialRequestOptions</a> {
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean"><span class="kt">boolean</span></a> <dfn class="nv dfn-paneled idl-code" data-default="false" data-dfn-for="CredentialRequestOptions" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-credentialrequestoptions-password"><code>password</code></dfn> = <span class="kt">false</span>;
 };
 </pre>
     <div>
      <dl>
-      <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="PasswordCredential" data-dfn-type="attribute" data-export="" id="dom-passwordcredential-password"><code>password</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-USVString">USVString</a>, readonly</span>
+      <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="PasswordCredential" data-dfn-type="attribute" data-export="" id="dom-passwordcredential-password"><code>password</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑧">USVString</a>, readonly</span>
       <dd data-md="">
        <p>This attribute represents the password of the credential.</p>
-      <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-credential-type-slot" id="ref-for-dom-credential-type-slot-4">[[type]]</a></code>
+      <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-credential-type-slot" id="ref-for-dom-credential-type-slot③">[[type]]</a></code>
       <dd data-md="">
-       <p>The <code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential-6">PasswordCredential</a></code> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object">interface object</a> has an internal slot named <code>[[type]]</code> whose
+       <p>The <code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential⑤">PasswordCredential</a></code> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object①①">interface object</a> has an internal slot named <code>[[type]]</code> whose
   value is "<dfn class="dfn-paneled idl-code" data-dfn-for="Credential/[[type]]" data-dfn-type="const" data-export="" id="dom-credential-type-password"><code><code>password</code></code></dfn>".</p>
-      <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-credential-discovery-slot" id="ref-for-dom-credential-discovery-slot-2">[[discovery]]</a></code>
+      <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-credential-discovery-slot" id="ref-for-dom-credential-discovery-slot①">[[discovery]]</a></code>
       <dd data-md="">
-       <p>The <code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential-7">PasswordCredential</a></code> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object">interface object</a> has an internal slot named <code>[[discovery]]</code> whose value is "<code class="idl"><a data-link-type="idl" href="#dom-credential-discovery-credential-store" id="ref-for-dom-credential-discovery-credential-store-2">credential store</a></code>".</p>
+       <p>The <code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential⑥">PasswordCredential</a></code> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object①②">interface object</a> has an internal slot named <code>[[discovery]]</code> whose value is "<code class="idl"><a data-link-type="idl" href="#dom-credential-discovery-credential-store" id="ref-for-dom-credential-discovery-credential-store①">credential store</a></code>".</p>
       <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="PasswordCredential" data-dfn-type="constructor" data-export="" id="dom-passwordcredential-passwordcredential"><code>PasswordCredential(form)</code></dfn>
       <dd data-md="">
-       <p>This constructor accepts an <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/forms.html#htmlformelement">HTMLFormElement</a></code> (<var>form</var>), and runs the following steps:</p>
+       <p>This constructor accepts an <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/forms.html#htmlformelement" id="ref-for-htmlformelement③">HTMLFormElement</a></code> (<var>form</var>), and runs the following steps:</p>
        <ol>
         <li data-md="">
-         <p>Let <var>r</var> be the result of executing <a data-link-type="abstract-op" href="#abstract-opdef-create-a-passwordcredential-from-an-htmlformelement" id="ref-for-abstract-opdef-create-a-passwordcredential-from-an-htmlformelement-1">Create a <code>PasswordCredential</code> from
+         <p>Let <var>r</var> be the result of executing <a data-link-type="abstract-op" href="#abstract-opdef-create-a-passwordcredential-from-an-htmlformelement" id="ref-for-abstract-opdef-create-a-passwordcredential-from-an-htmlformelement">Create a <code>PasswordCredential</code> from
   an <code>HTMLFormElement</code></a> on <var>form</var>.</p>
         <li data-md="">
-         <p>If <var>r</var> is an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception">exception</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> <var>r</var>.</p>
+         <p>If <var>r</var> is an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception" id="ref-for-dfn-exception③">exception</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw" id="ref-for-dfn-throw">throw</a> <var>r</var>.</p>
          <p>Otherwise, return <var>r</var>.</p>
        </ol>
       <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="PasswordCredential" data-dfn-type="constructor" data-export="" id="dom-passwordcredential-passwordcredential-data"><code>PasswordCredential(data)</code></dfn>
       <dd data-md="">
-       <p>This constructor accepts a <code class="idl"><a data-link-type="idl" href="#dictdef-passwordcredentialdata" id="ref-for-dictdef-passwordcredentialdata-2">PasswordCredentialData</a></code> (<var>data</var>), and runs the following steps:</p>
+       <p>This constructor accepts a <code class="idl"><a data-link-type="idl" href="#dictdef-passwordcredentialdata" id="ref-for-dictdef-passwordcredentialdata①">PasswordCredentialData</a></code> (<var>data</var>), and runs the following steps:</p>
        <ol>
         <li data-md="">
-         <p>Let <var>r</var> be the result of executing <a data-link-type="abstract-op" href="#abstract-opdef-create-a-passwordcredential-from-passwordcredentialdata" id="ref-for-abstract-opdef-create-a-passwordcredential-from-passwordcredentialdata-1">Create a <code>PasswordCredential</code> from <code>PasswordCredentialData</code></a> on <var>data</var>.</p>
+         <p>Let <var>r</var> be the result of executing <a data-link-type="abstract-op" href="#abstract-opdef-create-a-passwordcredential-from-passwordcredentialdata" id="ref-for-abstract-opdef-create-a-passwordcredential-from-passwordcredentialdata">Create a <code>PasswordCredential</code> from <code>PasswordCredentialData</code></a> on <var>data</var>.</p>
         <li data-md="">
-         <p>If <var>r</var> is an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception">exception</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> <var>r</var>.</p>
+         <p>If <var>r</var> is an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception" id="ref-for-dfn-exception④">exception</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw" id="ref-for-dfn-throw①">throw</a> <var>r</var>.</p>
          <p>Otherwise, return <var>r</var>.</p>
        </ol>
      </dl>
     </div>
-    <p><code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential-8">PasswordCredential</a></code> objects can be created via <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-create" id="ref-for-dom-credentialscontainer-create-5">navigator.credentials.create()</a></code> either explicitly by passing in a <code class="idl"><a data-link-type="idl" href="#dictdef-passwordcredentialdata" id="ref-for-dictdef-passwordcredentialdata-3">PasswordCredentialData</a></code> dictionary, or based on the contents
-  of an <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/forms.html#htmlformelement">HTMLFormElement</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/forms.html#category-submit">submittable elements</a>.</p>
-<pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-passwordcredentialdata"><code>PasswordCredentialData</code></dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-credentialdata" id="ref-for-dictdef-credentialdata-1">CredentialData</a> {
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString"><span class="kt">USVString</span></a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="PasswordCredentialData" data-dfn-type="dict-member" data-export="" data-type="USVString " id="dom-passwordcredentialdata-name"><code>name</code></dfn>;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString"><span class="kt">USVString</span></a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="PasswordCredentialData" data-dfn-type="dict-member" data-export="" data-type="USVString " id="dom-passwordcredentialdata-iconurl"><code>iconURL</code></dfn>;
-  <span class="kt">required</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString"><span class="kt">USVString</span></a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="PasswordCredentialData" data-dfn-type="dict-member" data-export="" data-type="USVString " id="dom-passwordcredentialdata-password"><code>password</code></dfn>;
+    <p><code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential⑦">PasswordCredential</a></code> objects can be created via <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-create" id="ref-for-dom-credentialscontainer-create④">navigator.credentials.create()</a></code> either explicitly by passing in a <code class="idl"><a data-link-type="idl" href="#dictdef-passwordcredentialdata" id="ref-for-dictdef-passwordcredentialdata②">PasswordCredentialData</a></code> dictionary, or based on the contents
+  of an <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/forms.html#htmlformelement" id="ref-for-htmlformelement④">HTMLFormElement</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/forms.html#category-submit" id="ref-for-category-submit">submittable elements</a>.</p>
+<pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-passwordcredentialdata"><code>PasswordCredentialData</code></dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-credentialdata" id="ref-for-dictdef-credentialdata">CredentialData</a> {
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑨"><span class="kt">USVString</span></a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="PasswordCredentialData" data-dfn-type="dict-member" data-export="" data-type="USVString " id="dom-passwordcredentialdata-name"><code>name</code></dfn>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①⓪"><span class="kt">USVString</span></a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="PasswordCredentialData" data-dfn-type="dict-member" data-export="" data-type="USVString " id="dom-passwordcredentialdata-iconurl"><code>iconURL</code></dfn>;
+  <span class="kt">required</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①①"><span class="kt">USVString</span></a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="PasswordCredentialData" data-dfn-type="dict-member" data-export="" data-type="USVString " id="dom-passwordcredentialdata-password"><code>password</code></dfn>;
 };
 
-<span class="kt">typedef</span> (<a class="n" data-link-type="idl-name" href="#dictdef-passwordcredentialdata" id="ref-for-dictdef-passwordcredentialdata-4">PasswordCredentialData</a> <span class="kt">or</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/forms.html#htmlformelement">HTMLFormElement</a>) <dfn class="nv dfn-paneled idl-code" data-dfn-type="typedef" data-export="" id="typedefdef-passwordcredentialinit"><code>PasswordCredentialInit</code></dfn>;
+<span class="kt">typedef</span> (<a class="n" data-link-type="idl-name" href="#dictdef-passwordcredentialdata" id="ref-for-dictdef-passwordcredentialdata③">PasswordCredentialData</a> <span class="kt">or</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/forms.html#htmlformelement" id="ref-for-htmlformelement⑤">HTMLFormElement</a>) <dfn class="nv dfn-paneled idl-code" data-dfn-type="typedef" data-export="" id="typedefdef-passwordcredentialinit"><code>PasswordCredentialInit</code></dfn>;
 
-<span class="kt">partial</span> <span class="kt">dictionary</span> <a class="nv idl-code" data-link-type="dictionary" href="#dictdef-credentialcreationoptions" id="ref-for-dictdef-credentialcreationoptions-6">CredentialCreationOptions</a> {
-  <a class="n" data-link-type="idl-name" href="#typedefdef-passwordcredentialinit" id="ref-for-typedefdef-passwordcredentialinit-1">PasswordCredentialInit</a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="CredentialCreationOptions" data-dfn-type="dict-member" data-export="" data-type="PasswordCredentialInit " id="dom-credentialcreationoptions-password"><code>password</code></dfn>;
+<span class="kt">partial</span> <span class="kt">dictionary</span> <a class="nv idl-code" data-link-type="dictionary" href="#dictdef-credentialcreationoptions" id="ref-for-dictdef-credentialcreationoptions⑤">CredentialCreationOptions</a> {
+  <a class="n" data-link-type="idl-name" href="#typedefdef-passwordcredentialinit" id="ref-for-typedefdef-passwordcredentialinit">PasswordCredentialInit</a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="CredentialCreationOptions" data-dfn-type="dict-member" data-export="" data-type="PasswordCredentialInit " id="dom-credentialcreationoptions-password"><code>password</code></dfn>;
 };
 </pre>
-    <p><code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential-9">PasswordCredential</a></code> objects are <a data-link-type="dfn" href="#credential-origin-bound" id="ref-for-credential-origin-bound-1">origin bound</a>.</p>
-    <p><code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential-10">PasswordCredential</a></code>'s <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object">interface object</a> inherits <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-37">Credential</a></code>'s implementation of <code class="idl"><a data-link-type="idl" href="#dom-credential-discoverfromexternalsource-slot" id="ref-for-dom-credential-discoverfromexternalsource-slot-2">[[DiscoverFromExternalSource]](options)</a></code>, and defines its own implementation of <code class="idl"><a data-link-type="idl" href="#dom-passwordcredential-collectfromcredentialstore-slot" id="ref-for-dom-passwordcredential-collectfromcredentialstore-slot-1">[[CollectFromCredentialStore]](options)</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-passwordcredential-create-slot" id="ref-for-dom-passwordcredential-create-slot-1">[[Create]](options)</a></code>, and <code class="idl"><a data-link-type="idl" href="#dom-passwordcredential-store-slot" id="ref-for-dom-passwordcredential-store-slot-1">[[Store]](credential)</a></code>.</p>
+    <p><code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential⑧">PasswordCredential</a></code> objects are <a data-link-type="dfn" href="#credential-origin-bound" id="ref-for-credential-origin-bound">origin bound</a>.</p>
+    <p><code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential⑨">PasswordCredential</a></code>'s <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object①③">interface object</a> inherits <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential③⑥">Credential</a></code>'s implementation of <code class="idl"><a data-link-type="idl" href="#dom-credential-discoverfromexternalsource-slot" id="ref-for-dom-credential-discoverfromexternalsource-slot③">[[DiscoverFromExternalSource]](options)</a></code>, and defines its own implementation of <code class="idl"><a data-link-type="idl" href="#dom-passwordcredential-collectfromcredentialstore-slot" id="ref-for-dom-passwordcredential-collectfromcredentialstore-slot">[[CollectFromCredentialStore]](options)</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-passwordcredential-create-slot" id="ref-for-dom-passwordcredential-create-slot①">[[Create]](options)</a></code>, and <code class="idl"><a data-link-type="idl" href="#dom-passwordcredential-store-slot" id="ref-for-dom-passwordcredential-store-slot">[[Store]](credential)</a></code>.</p>
     <h3 class="heading settled" data-level="3.3" id="passwordcredential-algorithms"><span class="secno">3.3. </span><span class="content">Algorithms</span><a class="self-link" href="#passwordcredential-algorithms"></a></h3>
     <h4 class="heading settled algorithm" data-algorithm="PasswordCredential&apos;s [[CollectFromCredentialStore]](options)" data-level="3.3.1" id="collectfromcredentialstore-passwordcredential"><span class="secno">3.3.1. </span><span class="content"> <code>PasswordCredential</code>'s <code>[[CollectFromCredentialStore]](options)</code> </span><a class="self-link" href="#collectfromcredentialstore-passwordcredential"></a></h4>
     <p><dfn class="dfn-paneled idl-code" data-dfn-for="PasswordCredential" data-dfn-type="method" data-export="" id="dom-passwordcredential-collectfromcredentialstore-slot"><code>[[CollectFromCredentialStore]](options)</code></dfn> is called
-  with a <code class="idl"><a data-link-type="idl" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions-12">CredentialRequestOptions</a></code> (<var>options</var>), and returns a set of <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-38">Credential</a></code> objects from
-  the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store-14">credential store</a>. If no matching <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-39">Credential</a></code> objects are available, the returned set
+  with a <code class="idl"><a data-link-type="idl" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions①①">CredentialRequestOptions</a></code> (<var>options</var>), and returns a set of <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential③⑦">Credential</a></code> objects from
+  the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store①③">credential store</a>. If no matching <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential③⑧">Credential</a></code> objects are available, the returned set
   will be empty.</p>
     <ol class="algorithm">
      <li data-md="">
-      <p class="assertion">Assert: <var>options</var>["<code class="idl"><a data-link-type="idl" href="#dom-credentialrequestoptions-password" id="ref-for-dom-credentialrequestoptions-password-3">password</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists">exists</a>.</p>
+      <p class="assertion">Assert: <var>options</var>["<code class="idl"><a data-link-type="idl" href="#dom-credentialrequestoptions-password" id="ref-for-dom-credentialrequestoptions-password②">password</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists①">exists</a>.</p>
      <li data-md="">
-      <p>If <var>options</var>["<code class="idl"><a data-link-type="idl" href="#dom-credentialrequestoptions-password" id="ref-for-dom-credentialrequestoptions-password-4">password</a></code>"] is not <code>true</code>, return the empty set.</p>
+      <p>If <var>options</var>["<code class="idl"><a data-link-type="idl" href="#dom-credentialrequestoptions-password" id="ref-for-dom-credentialrequestoptions-password③">password</a></code>"] is not <code>true</code>, return the empty set.</p>
      <li data-md="">
-      <p>Return the result of <a data-link-type="abstract-op" href="#abstract-opdef-credential-store-retrieve-a-list-of-credentials" id="ref-for-abstract-opdef-credential-store-retrieve-a-list-of-credentials-1">retrieving</a> credentials from the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store-15">credential store</a> that match the following filter:</p>
+      <p>Return the result of <a data-link-type="abstract-op" href="#abstract-opdef-credential-store-retrieve-a-list-of-credentials" id="ref-for-abstract-opdef-credential-store-retrieve-a-list-of-credentials">retrieving</a> credentials from the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store①④">credential store</a> that match the following filter:</p>
       <ol>
        <li data-md="">
-        <p>The credential is a <code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential-11">PasswordCredential</a></code></p>
+        <p>The credential is a <code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential①⓪">PasswordCredential</a></code></p>
        <li data-md="">
-        <p>The credential’s <code class="idl"><a data-link-type="idl" href="#dom-credential-origin-slot" id="ref-for-dom-credential-origin-slot-1">[[origin]]</a></code> is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">same origin</a> as the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">current settings object</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>.</p>
+        <p>The credential’s <code class="idl"><a data-link-type="idl" href="#dom-credential-origin-slot" id="ref-for-dom-credential-origin-slot">[[origin]]</a></code> is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#same-origin" id="ref-for-same-origin">same origin</a> as the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object" id="ref-for-current-settings-object⑤">current settings object</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin②">origin</a>.</p>
       </ol>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="PasswordCredential&apos;s [[Create]](options)" data-level="3.3.2" id="create-passwordcredential"><span class="secno">3.3.2. </span><span class="content"> <code>PasswordCredential</code>'s <code>[[Create]](options)</code> </span><a class="self-link" href="#create-passwordcredential"></a></h4>
-    <p><dfn class="dfn-paneled idl-code" data-dfn-for="PasswordCredential" data-dfn-type="method" data-export="" id="dom-passwordcredential-create-slot"><code>[[Create]](options)</code></dfn> is called with a <code class="idl"><a data-link-type="idl" href="#dictdef-credentialcreationoptions" id="ref-for-dictdef-credentialcreationoptions-7">CredentialCreationOptions</a></code> (<var>options</var>), and returns a <code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential-12">PasswordCredential</a></code> if one can be created, <code>null</code> otherwise. The <code class="idl"><a data-link-type="idl" href="#dictdef-credentialcreationoptions" id="ref-for-dictdef-credentialcreationoptions-8">CredentialCreationOptions</a></code> dictionary must have a <code>password</code> member which
-  holds either an <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/forms.html#htmlformelement">HTMLFormElement</a></code> or a <code class="idl"><a data-link-type="idl" href="#dictdef-passwordcredentialdata" id="ref-for-dictdef-passwordcredentialdata-5">PasswordCredentialData</a></code>. If that member’s value cannot be
-  used to create a <code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential-13">PasswordCredential</a></code>, this algorithm will return a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#exceptiondef-typeerror">TypeError</a></code> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception">exception</a>.</p>
+    <p><dfn class="dfn-paneled idl-code" data-dfn-for="PasswordCredential" data-dfn-type="method" data-export="" id="dom-passwordcredential-create-slot"><code>[[Create]](options)</code></dfn> is called with a <code class="idl"><a data-link-type="idl" href="#dictdef-credentialcreationoptions" id="ref-for-dictdef-credentialcreationoptions⑥">CredentialCreationOptions</a></code> (<var>options</var>), and returns a <code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential①①">PasswordCredential</a></code> if one can be created, <code>null</code> otherwise. The <code class="idl"><a data-link-type="idl" href="#dictdef-credentialcreationoptions" id="ref-for-dictdef-credentialcreationoptions⑦">CredentialCreationOptions</a></code> dictionary must have a <code>password</code> member which
+  holds either an <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/forms.html#htmlformelement" id="ref-for-htmlformelement⑥">HTMLFormElement</a></code> or a <code class="idl"><a data-link-type="idl" href="#dictdef-passwordcredentialdata" id="ref-for-dictdef-passwordcredentialdata④">PasswordCredentialData</a></code>. If that member’s value cannot be
+  used to create a <code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential①②">PasswordCredential</a></code>, this algorithm will return a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror②">TypeError</a></code> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception" id="ref-for-dfn-exception⑤">exception</a>.</p>
     <ol class="algorithm">
      <li data-md="">
-      <p class="assertion">Assert: <var>options</var>["<code class="idl"><a data-link-type="idl" href="#dom-credentialcreationoptions-password" id="ref-for-dom-credentialcreationoptions-password-1">password</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists">exists</a>.</p>
+      <p class="assertion">Assert: <var>options</var>["<code class="idl"><a data-link-type="idl" href="#dom-credentialcreationoptions-password" id="ref-for-dom-credentialcreationoptions-password">password</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists②">exists</a>.</p>
      <li data-md="">
-      <p>If <var>options</var>["<code class="idl"><a data-link-type="idl" href="#dom-credentialcreationoptions-password" id="ref-for-dom-credentialcreationoptions-password-2">password</a></code>"] is an <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/forms.html#htmlformelement">HTMLFormElement</a></code>, return the
-  result of executing <a data-link-type="abstract-op" href="#abstract-opdef-create-a-passwordcredential-from-an-htmlformelement" id="ref-for-abstract-opdef-create-a-passwordcredential-from-an-htmlformelement-2">Create a <code>PasswordCredential</code> from an <code>HTMLFormElement</code></a> on <var>options</var>["<code class="idl"><a data-link-type="idl" href="#dom-credentialcreationoptions-password" id="ref-for-dom-credentialcreationoptions-password-3">password</a></code>"].</p>
+      <p>If <var>options</var>["<code class="idl"><a data-link-type="idl" href="#dom-credentialcreationoptions-password" id="ref-for-dom-credentialcreationoptions-password①">password</a></code>"] is an <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/forms.html#htmlformelement" id="ref-for-htmlformelement⑦">HTMLFormElement</a></code>, return the
+  result of executing <a data-link-type="abstract-op" href="#abstract-opdef-create-a-passwordcredential-from-an-htmlformelement" id="ref-for-abstract-opdef-create-a-passwordcredential-from-an-htmlformelement①">Create a <code>PasswordCredential</code> from an <code>HTMLFormElement</code></a> on <var>options</var>["<code class="idl"><a data-link-type="idl" href="#dom-credentialcreationoptions-password" id="ref-for-dom-credentialcreationoptions-password②">password</a></code>"].</p>
      <li data-md="">
-      <p>If <var>options</var>["<code class="idl"><a data-link-type="idl" href="#dom-credentialcreationoptions-password" id="ref-for-dom-credentialcreationoptions-password-4">password</a></code>"] is a <code class="idl"><a data-link-type="idl" href="#dictdef-passwordcredentialdata" id="ref-for-dictdef-passwordcredentialdata-6">PasswordCredentialData</a></code>, return
-  the result of executing <a data-link-type="abstract-op" href="#abstract-opdef-create-a-passwordcredential-from-passwordcredentialdata" id="ref-for-abstract-opdef-create-a-passwordcredential-from-passwordcredentialdata-2">Create a <code>PasswordCredential</code> from <code>PasswordCredentialData</code></a> on <var>options</var>["<code class="idl"><a data-link-type="idl" href="#dom-credentialcreationoptions-password" id="ref-for-dom-credentialcreationoptions-password-5">password</a></code>"].</p>
+      <p>If <var>options</var>["<code class="idl"><a data-link-type="idl" href="#dom-credentialcreationoptions-password" id="ref-for-dom-credentialcreationoptions-password③">password</a></code>"] is a <code class="idl"><a data-link-type="idl" href="#dictdef-passwordcredentialdata" id="ref-for-dictdef-passwordcredentialdata⑤">PasswordCredentialData</a></code>, return
+  the result of executing <a data-link-type="abstract-op" href="#abstract-opdef-create-a-passwordcredential-from-passwordcredentialdata" id="ref-for-abstract-opdef-create-a-passwordcredential-from-passwordcredentialdata①">Create a <code>PasswordCredential</code> from <code>PasswordCredentialData</code></a> on <var>options</var>["<code class="idl"><a data-link-type="idl" href="#dom-credentialcreationoptions-password" id="ref-for-dom-credentialcreationoptions-password④">password</a></code>"].</p>
      <li data-md="">
-      <p>Return a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#exceptiondef-typeerror">TypeError</a></code> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception">exception</a>.</p>
+      <p>Return a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror③">TypeError</a></code> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception" id="ref-for-dfn-exception⑥">exception</a>.</p>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="PasswordCredential&apos;s [[Store]](credential)" data-level="3.3.3" id="store-passwordcredential"><span class="secno">3.3.3. </span><span class="content"> <code>PasswordCredential</code>'s <code>[[Store]](credential)</code> </span><a class="self-link" href="#store-passwordcredential"></a></h4>
-    <p><dfn class="dfn-paneled idl-code" data-dfn-for="PasswordCredential" data-dfn-type="method" data-export="" id="dom-passwordcredential-store-slot"><code>[[Store]](credential)</code></dfn> is called with a <code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential-14">PasswordCredential</a></code> (<var>credential</var>), and returns once <var>credential</var> is persisted to the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store-16">credential store</a>.</p>
+    <p><dfn class="dfn-paneled idl-code" data-dfn-for="PasswordCredential" data-dfn-type="method" data-export="" id="dom-passwordcredential-store-slot"><code>[[Store]](credential)</code></dfn> is called with a <code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential①③">PasswordCredential</a></code> (<var>credential</var>), and returns once <var>credential</var> is persisted to the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store①⑤">credential store</a>.</p>
     <ol class="algorithm">
      <li data-md="">
-      <p>If the user agent’s <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store-17">credential store</a> contains a <code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential-15">PasswordCredential</a></code> (<var>stored</var>)
-  whose <code class="idl"><a data-link-type="idl" href="#dom-credential-id" id="ref-for-dom-credential-id-2">id</a></code> attribute is <var>credential</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credential-id" id="ref-for-dom-credential-id-3">id</a></code> and whose <code class="idl"><a data-link-type="idl" href="#dom-credential-origin-slot" id="ref-for-dom-credential-origin-slot-2">[[origin]]</a></code> slot is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">same origin</a> as <var>credential</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credential-origin-slot" id="ref-for-dom-credential-origin-slot-3">[[origin]]</a></code>,
+      <p>If the user agent’s <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store①⑥">credential store</a> contains a <code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential①④">PasswordCredential</a></code> (<var>stored</var>)
+  whose <code class="idl"><a data-link-type="idl" href="#dom-credential-id" id="ref-for-dom-credential-id①">id</a></code> attribute is <var>credential</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credential-id" id="ref-for-dom-credential-id②">id</a></code> and whose <code class="idl"><a data-link-type="idl" href="#dom-credential-origin-slot" id="ref-for-dom-credential-origin-slot①">[[origin]]</a></code> slot is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#same-origin" id="ref-for-same-origin①">same origin</a> as <var>credential</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credential-origin-slot" id="ref-for-dom-credential-origin-slot②">[[origin]]</a></code>,
   then:</p>
       <ol>
        <li data-md="">
-        <p>If the user grants permission to update credentials (as discussed when defining <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated-7">user mediation</a>), then:</p>
+        <p>If the user grants permission to update credentials (as discussed when defining <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated⑥">user mediation</a>), then:</p>
         <ol>
          <li data-md="">
-          <p>Set <var>stored</var>’s <a class="idl-code" data-link-type="attribute" href="#dom-passwordcredential-password" id="ref-for-dom-passwordcredential-password-2"><code>password</code></a> to <var>credential</var>’s <a class="idl-code" data-link-type="attribute" href="#dom-passwordcredential-password" id="ref-for-dom-passwordcredential-password-3"><code>password</code></a>.</p>
+          <p>Set <var>stored</var>’s <a class="idl-code" data-link-type="attribute" href="#dom-passwordcredential-password" id="ref-for-dom-passwordcredential-password①"><code>password</code></a> to <var>credential</var>’s <a class="idl-code" data-link-type="attribute" href="#dom-passwordcredential-password" id="ref-for-dom-passwordcredential-password②"><code>password</code></a>.</p>
          <li data-md="">
-          <p>Set <var>stored</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credentialuserdata-name" id="ref-for-dom-credentialuserdata-name-2">name</a></code> to <var>credential</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credentialuserdata-name" id="ref-for-dom-credentialuserdata-name-3">name</a></code>.</p>
+          <p>Set <var>stored</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credentialuserdata-name" id="ref-for-dom-credentialuserdata-name①">name</a></code> to <var>credential</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credentialuserdata-name" id="ref-for-dom-credentialuserdata-name②">name</a></code>.</p>
          <li data-md="">
-          <p>Set <var>stored</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credentialuserdata-iconurl" id="ref-for-dom-credentialuserdata-iconurl-2">iconURL</a></code> to <var>credential</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credentialuserdata-iconurl" id="ref-for-dom-credentialuserdata-iconurl-3">iconURL</a></code>.</p>
+          <p>Set <var>stored</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credentialuserdata-iconurl" id="ref-for-dom-credentialuserdata-iconurl①">iconURL</a></code> to <var>credential</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credentialuserdata-iconurl" id="ref-for-dom-credentialuserdata-iconurl②">iconURL</a></code>.</p>
         </ol>
       </ol>
       <p>Otherwise, if the user grants permission to store credentials (as discussed when
-  defining <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated-8">user mediation</a>, then:</p>
+  defining <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated⑦">user mediation</a>, then:</p>
       <ol>
        <li data-md="">
-        <p>Store a <code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential-16">PasswordCredential</a></code> in the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store-18">credential store</a> with the following
+        <p>Store a <code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential①⑤">PasswordCredential</a></code> in the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store①⑦">credential store</a> with the following
   properties:</p>
         <dl>
-         <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-credential-id" id="ref-for-dom-credential-id-4">id</a></code>
+         <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-credential-id" id="ref-for-dom-credential-id③">id</a></code>
          <dd data-md="">
-          <p><var>credential</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credential-id" id="ref-for-dom-credential-id-5">id</a></code></p>
-         <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-credentialuserdata-name" id="ref-for-dom-credentialuserdata-name-4">name</a></code>,
+          <p><var>credential</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credential-id" id="ref-for-dom-credential-id④">id</a></code></p>
+         <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-credentialuserdata-name" id="ref-for-dom-credentialuserdata-name③">name</a></code>,
          <dd data-md="">
-          <p><var>credential</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credentialuserdata-name" id="ref-for-dom-credentialuserdata-name-5">name</a></code></p>
-         <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-credentialuserdata-iconurl" id="ref-for-dom-credentialuserdata-iconurl-4">iconURL</a></code>
+          <p><var>credential</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credentialuserdata-name" id="ref-for-dom-credentialuserdata-name④">name</a></code></p>
+         <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-credentialuserdata-iconurl" id="ref-for-dom-credentialuserdata-iconurl③">iconURL</a></code>
          <dd data-md="">
-          <p><var>credential</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credentialuserdata-iconurl" id="ref-for-dom-credentialuserdata-iconurl-5">iconURL</a></code></p>
-         <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-credential-origin-slot" id="ref-for-dom-credential-origin-slot-4">[[origin]]</a></code>
+          <p><var>credential</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credentialuserdata-iconurl" id="ref-for-dom-credentialuserdata-iconurl④">iconURL</a></code></p>
+         <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-credential-origin-slot" id="ref-for-dom-credential-origin-slot③">[[origin]]</a></code>
          <dd data-md="">
-          <p><var>credential</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credential-origin-slot" id="ref-for-dom-credential-origin-slot-5">[[origin]]</a></code></p>
-         <dt data-md=""><a class="idl-code" data-link-type="attribute" href="#dom-passwordcredential-password" id="ref-for-dom-passwordcredential-password-4"><code>password</code></a>
+          <p><var>credential</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credential-origin-slot" id="ref-for-dom-credential-origin-slot④">[[origin]]</a></code></p>
+         <dt data-md=""><a class="idl-code" data-link-type="attribute" href="#dom-passwordcredential-password" id="ref-for-dom-passwordcredential-password③"><code>password</code></a>
          <dd data-md="">
-          <p><var>credential</var>’s <a class="idl-code" data-link-type="attribute" href="#dom-passwordcredential-password" id="ref-for-dom-passwordcredential-password-5"><code>password</code></a></p>
+          <p><var>credential</var>’s <a class="idl-code" data-link-type="attribute" href="#dom-passwordcredential-password" id="ref-for-dom-passwordcredential-password④"><code>password</code></a></p>
         </dl>
       </ol>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Create a PasswordCredential from an HTMLFormElement" data-level="3.3.4" id="construct-passwordcredential-form"><span class="secno">3.3.4. </span><span class="content"> Create a <code>PasswordCredential</code> from an <code>HTMLFormElement</code> </span><a class="self-link" href="#construct-passwordcredential-form"></a></h4>
-    <p>To <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export="" id="abstract-opdef-create-a-passwordcredential-from-an-htmlformelement">Create a <code>PasswordCredential</code> from an <code>HTMLFormElement</code></dfn>, given an <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/forms.html#htmlformelement">HTMLFormElement</a></code> (<var>form</var>), run these steps.</p>
+    <p>To <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export="" id="abstract-opdef-create-a-passwordcredential-from-an-htmlformelement">Create a <code>PasswordCredential</code> from an <code>HTMLFormElement</code></dfn>, given an <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/forms.html#htmlformelement" id="ref-for-htmlformelement⑧">HTMLFormElement</a></code> (<var>form</var>), run these steps.</p>
     <p class="note" role="note"><span>Note:</span> <a href="#examples-post-signin">§3.1.2 Post-sign-in Confirmation</a> and <a href="#examples-change-password">§3.1.3 Change Password</a> provide examples of the intended
   usage.</p>
     <ol class="algorithm">
      <li data-md="">
-      <p>Let <var>data</var> be a new <code class="idl"><a data-link-type="idl" href="#dictdef-passwordcredentialdata" id="ref-for-dictdef-passwordcredentialdata-7">PasswordCredentialData</a></code> dictionary.</p>
+      <p>Let <var>data</var> be a new <code class="idl"><a data-link-type="idl" href="#dictdef-passwordcredentialdata" id="ref-for-dictdef-passwordcredentialdata⑥">PasswordCredentialData</a></code> dictionary.</p>
      <li data-md="">
-      <p>Let <var>formData</var> be the result of executing the <code class="idl"><a data-link-type="idl" href="https://xhr.spec.whatwg.org/#interface-formdata">FormData</a></code> constructor
+      <p>Let <var>formData</var> be the result of executing the <code class="idl"><a data-link-type="idl" href="https://xhr.spec.whatwg.org/#interface-formdata" id="ref-for-interface-formdata①">FormData</a></code> constructor
   on <var>form</var>.</p>
      <li data-md="">
-      <p>Let <var>elements</var> be a list of all the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/forms.html#category-submit">submittable elements</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/forms.html#form-owner">form owner</a> is <var>form</var>, in <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-tree-order">tree order</a>.</p>
+      <p>Let <var>elements</var> be a list of all the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/forms.html#category-submit" id="ref-for-category-submit①">submittable elements</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#form-owner" id="ref-for-form-owner">form owner</a> is <var>form</var>, in <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-tree-order" id="ref-for-concept-tree-order">tree order</a>.</p>
      <li data-md="">
       <p>Let <var>newPasswordObserved</var> be <code>false</code>.</p>
      <li data-md="">
       <p>For each <var>field</var> in <var>elements</var>, run the following steps:</p>
       <ol>
        <li data-md="">
-        <p>If <var>field</var> does not have an <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete">autocomplete</a></code> attribute, then skip to the next <var>field</var>.</p>
+        <p>If <var>field</var> does not have an <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete" id="ref-for-attr-fe-autocomplete⑦">autocomplete</a></code> attribute, then skip to the next <var>field</var>.</p>
        <li data-md="">
-        <p>Let <var>name</var> be the value of <var>field</var>’s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-name">name</a></code> attribute.</p>
+        <p>Let <var>name</var> be the value of <var>field</var>’s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-name" id="ref-for-attr-fe-name">name</a></code> attribute.</p>
        <li data-md="">
-        <p>If <var>formData</var>’s <code class="idl"><a data-link-type="idl" href="https://xhr.spec.whatwg.org/#dom-formdata-has">has()</a></code> method returns <code>false</code> when executed on <var>name</var>, then
+        <p>If <var>formData</var>’s <code class="idl"><a data-link-type="idl" href="https://xhr.spec.whatwg.org/#dom-formdata-has" id="ref-for-dom-formdata-has">has()</a></code> method returns <code>false</code> when executed on <var>name</var>, then
   skip to the next <var>field</var>.</p>
        <li data-md="">
-        <p>If <var>field</var>’s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete">autocomplete</a></code> attribute’s value contains one or more <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/forms.html#autofill-detail-tokens">autofill
+        <p>If <var>field</var>’s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete" id="ref-for-attr-fe-autocomplete⑧">autocomplete</a></code> attribute’s value contains one or more <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens" id="ref-for-autofill-detail-tokens">autofill
   detail tokens</a> (<var>tokens</var>), then:</p>
         <ol>
          <li data-md="">
           <p>For each <var>token</var> in <var>tokens</var>:</p>
           <ol>
            <li data-md="">
-            <p>If <var>token</var> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive">ASCII case-insensitive</a> match for one
+            <p>If <var>token</var> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive">ASCII case-insensitive</a> match for one
   of the following strings, run the associated steps:</p>
             <dl>
-             <dt data-md="">"<a data-link-type="attr-value" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-new-password"><code>new-password</code></a>"
+             <dt data-md="">"<a data-link-type="attr-value" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-new-password" id="ref-for-attr-fe-autocomplete-new-password①"><code>new-password</code></a>"
              <dd data-md="">
-              <p>Set <var>data</var>’s <code class="idl"><a data-link-type="idl" href="#dom-passwordcredentialdata-password" id="ref-for-dom-passwordcredentialdata-password-1">password</a></code> member’s
-  value to the result of executing <var>formData</var>’s <code class="idl"><a data-link-type="idl" href="https://xhr.spec.whatwg.org/#dom-formdata-get">get()</a></code> method on <var>name</var>, and <var>newPasswordObserved</var> to <code>true</code>.</p>
-             <dt data-md="">"<a data-link-type="attr-value" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-current-password"><code>current-password</code></a>"
+              <p>Set <var>data</var>’s <code class="idl"><a data-link-type="idl" href="#dom-passwordcredentialdata-password" id="ref-for-dom-passwordcredentialdata-password">password</a></code> member’s
+  value to the result of executing <var>formData</var>’s <code class="idl"><a data-link-type="idl" href="https://xhr.spec.whatwg.org/#dom-formdata-get" id="ref-for-dom-formdata-get">get()</a></code> method on <var>name</var>, and <var>newPasswordObserved</var> to <code>true</code>.</p>
+             <dt data-md="">"<a data-link-type="attr-value" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-current-password" id="ref-for-attr-fe-autocomplete-current-password①"><code>current-password</code></a>"
              <dd data-md="">
               <p>If <var>newPasswordObserved</var> is <code>false</code>,
-  set <var>data</var>’s <code class="idl"><a data-link-type="idl" href="#dom-passwordcredentialdata-password" id="ref-for-dom-passwordcredentialdata-password-2">password</a></code> member’s
-  value to the result of executing <var>formData</var>’s <code class="idl"><a data-link-type="idl" href="https://xhr.spec.whatwg.org/#dom-formdata-get">get()</a></code> method on <var>name</var>.</p>
+  set <var>data</var>’s <code class="idl"><a data-link-type="idl" href="#dom-passwordcredentialdata-password" id="ref-for-dom-passwordcredentialdata-password①">password</a></code> member’s
+  value to the result of executing <var>formData</var>’s <code class="idl"><a data-link-type="idl" href="https://xhr.spec.whatwg.org/#dom-formdata-get" id="ref-for-dom-formdata-get①">get()</a></code> method on <var>name</var>.</p>
               <p class="note" role="note"><span>Note:</span> By checking that <var>newPasswordObserved</var> is <code>false</code>, <code>new-password</code> fields take precedence over <code>current-password</code> fields.</p>
-             <dt data-md="">"<a data-link-type="attr-value" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-photo"><code>photo</code></a>"
+             <dt data-md="">"<a data-link-type="attr-value" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-photo" id="ref-for-attr-fe-autocomplete-photo"><code>photo</code></a>"
              <dd data-md="">
-              <p>Set <var>data</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credentialuserdata-iconurl" id="ref-for-dom-credentialuserdata-iconurl-6">iconURL</a></code> member’s
-  value to the result of executing <var>formData</var>’s <code class="idl"><a data-link-type="idl" href="https://xhr.spec.whatwg.org/#dom-formdata-get">get()</a></code> method on <var>name</var>.</p>
-             <dt data-md="">"<a data-link-type="attr-value" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-name"><code>name</code></a>"
-             <dt data-md="">"<a data-link-type="attr-value" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-nickname"><code>nickname</code></a>"
+              <p>Set <var>data</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credentialuserdata-iconurl" id="ref-for-dom-credentialuserdata-iconurl⑤">iconURL</a></code> member’s
+  value to the result of executing <var>formData</var>’s <code class="idl"><a data-link-type="idl" href="https://xhr.spec.whatwg.org/#dom-formdata-get" id="ref-for-dom-formdata-get②">get()</a></code> method on <var>name</var>.</p>
+             <dt data-md="">"<a data-link-type="attr-value" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-name" id="ref-for-attr-fe-autocomplete-name"><code>name</code></a>"
+             <dt data-md="">"<a data-link-type="attr-value" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-nickname" id="ref-for-attr-fe-autocomplete-nickname"><code>nickname</code></a>"
              <dd data-md="">
-              <p>Set <var>data</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credentialuserdata-name" id="ref-for-dom-credentialuserdata-name-6">name</a></code> member’s
-  value to the result of executing <var>formData</var>’s <code class="idl"><a data-link-type="idl" href="https://xhr.spec.whatwg.org/#dom-formdata-get">get()</a></code> method on <var>name</var>.</p>
-             <dt data-md="">"<a data-link-type="attr-value" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-username"><code>username</code></a>"
+              <p>Set <var>data</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credentialuserdata-name" id="ref-for-dom-credentialuserdata-name⑤">name</a></code> member’s
+  value to the result of executing <var>formData</var>’s <code class="idl"><a data-link-type="idl" href="https://xhr.spec.whatwg.org/#dom-formdata-get" id="ref-for-dom-formdata-get③">get()</a></code> method on <var>name</var>.</p>
+             <dt data-md="">"<a data-link-type="attr-value" href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-username" id="ref-for-attr-fe-autocomplete-username②"><code>username</code></a>"
              <dd data-md="">
-              <p>Set <var>data</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credentialdata-id" id="ref-for-dom-credentialdata-id-1">id</a></code> member’s value to the
-  result of executing <var>formData</var>’s <code class="idl"><a data-link-type="idl" href="https://xhr.spec.whatwg.org/#dom-formdata-get">get()</a></code> method
+              <p>Set <var>data</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credentialdata-id" id="ref-for-dom-credentialdata-id">id</a></code> member’s value to the
+  result of executing <var>formData</var>’s <code class="idl"><a data-link-type="idl" href="https://xhr.spec.whatwg.org/#dom-formdata-get" id="ref-for-dom-formdata-get④">get()</a></code> method
   on <var>name</var>.</p>
             </dl>
           </ol>
         </ol>
       </ol>
      <li data-md="">
-      <p>Let <var>c</var> be the result of executing <a data-link-type="abstract-op" href="#abstract-opdef-create-a-passwordcredential-from-passwordcredentialdata" id="ref-for-abstract-opdef-create-a-passwordcredential-from-passwordcredentialdata-3">Create a <code>PasswordCredential</code> from <code>PasswordCredentialData</code></a> on <var>data</var>.</p>
+      <p>Let <var>c</var> be the result of executing <a data-link-type="abstract-op" href="#abstract-opdef-create-a-passwordcredential-from-passwordcredentialdata" id="ref-for-abstract-opdef-create-a-passwordcredential-from-passwordcredentialdata②">Create a <code>PasswordCredential</code> from <code>PasswordCredentialData</code></a> on <var>data</var>.</p>
      <li data-md="">
-      <p>If <var>c</var> is an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception">exception</a>, return <var>c</var>.</p>
+      <p>If <var>c</var> is an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception" id="ref-for-dfn-exception⑦">exception</a>, return <var>c</var>.</p>
      <li data-md="">
-      <p class="assertion">Assert: <var>c</var> is a <code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential-17">PasswordCredential</a></code>.</p>
+      <p class="assertion">Assert: <var>c</var> is a <code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential①⑥">PasswordCredential</a></code>.</p>
      <li data-md="">
       <p>Return <var>c</var>.</p>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Create a PasswordCredential from PasswordCredentialData" data-level="3.3.5" id="construct-passwordcredential-data"><span class="secno">3.3.5. </span><span class="content"> Create a <code>PasswordCredential</code> from <code>PasswordCredentialData</code> </span><a class="self-link" href="#construct-passwordcredential-data"></a></h4>
-    <p>To <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export="" id="abstract-opdef-create-a-passwordcredential-from-passwordcredentialdata">Create a <code>PasswordCredential</code> from <code>PasswordCredentialData</code></dfn>, given an <code class="idl"><a data-link-type="idl" href="#dictdef-passwordcredentialdata" id="ref-for-dictdef-passwordcredentialdata-8">PasswordCredentialData</a></code> (<var>data</var>), run these steps.</p>
+    <p>To <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export="" id="abstract-opdef-create-a-passwordcredential-from-passwordcredentialdata">Create a <code>PasswordCredential</code> from <code>PasswordCredentialData</code></dfn>, given an <code class="idl"><a data-link-type="idl" href="#dictdef-passwordcredentialdata" id="ref-for-dictdef-passwordcredentialdata⑦">PasswordCredentialData</a></code> (<var>data</var>), run these steps.</p>
     <ol class="algorithm">
      <li data-md="">
-      <p>Let <var>c</var> be a new <code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential-18">PasswordCredential</a></code> object.</p>
+      <p>Let <var>c</var> be a new <code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential①⑦">PasswordCredential</a></code> object.</p>
      <li data-md="">
-      <p>If any of the following are the empty string, return a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#exceptiondef-typeerror">TypeError</a></code> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception">exception</a>:</p>
+      <p>If any of the following are the empty string, return a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror④">TypeError</a></code> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception" id="ref-for-dfn-exception⑧">exception</a>:</p>
       <ul>
        <li data-md="">
-        <p><var>data</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credentialdata-id" id="ref-for-dom-credentialdata-id-2">id</a></code> member’s value</p>
+        <p><var>data</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credentialdata-id" id="ref-for-dom-credentialdata-id①">id</a></code> member’s value</p>
        <li data-md="">
-        <p><var>data</var>’s <code class="idl"><a data-link-type="idl" href="#dom-passwordcredentialdata-password" id="ref-for-dom-passwordcredentialdata-password-3">password</a></code> member’s value</p>
+        <p><var>data</var>’s <code class="idl"><a data-link-type="idl" href="#dom-passwordcredentialdata-password" id="ref-for-dom-passwordcredentialdata-password②">password</a></code> member’s value</p>
       </ul>
      <li data-md="">
       <p>Set <var>c</var>’s properties as follows:</p>
       <dl>
-       <dt data-md=""><a class="idl-code" data-link-type="attribute" href="#dom-passwordcredential-password" id="ref-for-dom-passwordcredential-password-6"><code>password</code></a>
+       <dt data-md=""><a class="idl-code" data-link-type="attribute" href="#dom-passwordcredential-password" id="ref-for-dom-passwordcredential-password⑤"><code>password</code></a>
        <dd data-md="">
-        <p><var>data</var>’s <code class="idl"><a data-link-type="idl" href="#dom-passwordcredentialdata-password" id="ref-for-dom-passwordcredentialdata-password-4">password</a></code> member’s value</p>
-       <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-credential-id" id="ref-for-dom-credential-id-6">id</a></code>
+        <p><var>data</var>’s <code class="idl"><a data-link-type="idl" href="#dom-passwordcredentialdata-password" id="ref-for-dom-passwordcredentialdata-password③">password</a></code> member’s value</p>
+       <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-credential-id" id="ref-for-dom-credential-id⑤">id</a></code>
        <dd data-md="">
-        <p><var>data</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credentialdata-id" id="ref-for-dom-credentialdata-id-3">id</a></code> member’s value</p>
-       <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-credentialuserdata-iconurl" id="ref-for-dom-credentialuserdata-iconurl-7">iconURL</a></code>
+        <p><var>data</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credentialdata-id" id="ref-for-dom-credentialdata-id②">id</a></code> member’s value</p>
+       <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-credentialuserdata-iconurl" id="ref-for-dom-credentialuserdata-iconurl⑥">iconURL</a></code>
        <dd data-md="">
-        <p><var>data</var>’s <code class="idl"><a data-link-type="idl" href="#dom-passwordcredentialdata-iconurl" id="ref-for-dom-passwordcredentialdata-iconurl-1">iconURL</a></code> member’s value</p>
-       <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-credentialuserdata-name" id="ref-for-dom-credentialuserdata-name-7">name</a></code>
+        <p><var>data</var>’s <code class="idl"><a data-link-type="idl" href="#dom-passwordcredentialdata-iconurl" id="ref-for-dom-passwordcredentialdata-iconurl">iconURL</a></code> member’s value</p>
+       <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-credentialuserdata-name" id="ref-for-dom-credentialuserdata-name⑥">name</a></code>
        <dd data-md="">
-        <p><var>data</var>’s <code class="idl"><a data-link-type="idl" href="#dom-passwordcredentialdata-name" id="ref-for-dom-passwordcredentialdata-name-1">name</a></code> member’s value</p>
-       <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-credential-origin-slot" id="ref-for-dom-credential-origin-slot-6">[[origin]]</a></code>
+        <p><var>data</var>’s <code class="idl"><a data-link-type="idl" href="#dom-passwordcredentialdata-name" id="ref-for-dom-passwordcredentialdata-name">name</a></code> member’s value</p>
+       <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-credential-origin-slot" id="ref-for-dom-credential-origin-slot⑤">[[origin]]</a></code>
        <dd data-md="">
-        <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">current settings object</a>.</p>
+        <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin③">origin</a> of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object" id="ref-for-current-settings-object⑥">current settings object</a>.</p>
       </dl>
      <li data-md="">
       <p>Return <var>c</var>.</p>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="CredentialRequestOptions Matching for PasswordCredential" data-level="3.3.6" id="passwordcredential-matching"><span class="secno">3.3.6. </span><span class="content"> <code>CredentialRequestOptions</code> Matching for <code>PasswordCredential</code> </span><a class="self-link" href="#passwordcredential-matching"></a></h4>
-    <p>Given a <code class="idl"><a data-link-type="idl" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions-13">CredentialRequestOptions</a></code> (<var>options</var>), the following algorithm returns "<code>Matches</code>" if
-  the <code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential-19">PasswordCredential</a></code> should be available as a response to a <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get-19">get()</a></code> request, and "<code>Does Not Match</code>" otherwise.</p>
+    <p>Given a <code class="idl"><a data-link-type="idl" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions①②">CredentialRequestOptions</a></code> (<var>options</var>), the following algorithm returns "<code>Matches</code>" if
+  the <code class="idl"><a data-link-type="idl" href="#passwordcredential" id="ref-for-passwordcredential①⑧">PasswordCredential</a></code> should be available as a response to a <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get①⑧">get()</a></code> request, and "<code>Does Not Match</code>" otherwise.</p>
     <ol>
      <li data-md="">
-      <p>If <var>options</var> has a <code class="idl"><a data-link-type="idl" href="#dom-credentialrequestoptions-password" id="ref-for-dom-credentialrequestoptions-password-5">password</a></code> member whose value is <code>true</code>, then
+      <p>If <var>options</var> has a <code class="idl"><a data-link-type="idl" href="#dom-credentialrequestoptions-password" id="ref-for-dom-credentialrequestoptions-password④">password</a></code> member whose value is <code>true</code>, then
   return "<code>Matches</code>".</p>
      <li data-md="">
       <p>Return "<code>Does Not Match</code>".</p>
@@ -2728,68 +2734,68 @@ store user credentials for future use.</p>
    <section>
     <h2 class="heading settled" data-level="4" id="federated"><span class="secno">4. </span><span class="content">Federated Credentials</span><a class="self-link" href="#federated"></a></h2>
     <h3 class="heading settled" data-level="4.1" id="federatedcredential-interface"><span class="secno">4.1. </span><span class="content">The <code>FederatedCredential</code> Interface</span><a class="self-link" href="#federatedcredential-interface"></a></h3>
-<pre class="idl highlight def">[<a class="nv idl-code" data-link-type="constructor" href="#dom-federatedcredential-federatedcredential" id="ref-for-dom-federatedcredential-federatedcredential-1">Constructor</a>(<a class="n" data-link-type="idl-name" href="#dictdef-federatedcredentialinit" id="ref-for-dictdef-federatedcredentialinit-1">FederatedCredentialInit</a> <dfn class="nv idl-code" data-dfn-for="FederatedCredential/FederatedCredential(data)" data-dfn-type="argument" data-export="" id="dom-federatedcredential-federatedcredential-data-data"><code>data</code><a class="self-link" href="#dom-federatedcredential-federatedcredential-data-data"></a></dfn>),
- <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">Window</span>,
- <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext">SecureContext</a>]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="federatedcredential"><code>FederatedCredential</code></dfn> : <a class="n" data-link-type="idl-name" href="#credential" id="ref-for-credential-40">Credential</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString"><span class="kt">USVString</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-federatedcredential-provider" id="ref-for-dom-federatedcredential-provider-1">provider</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a>? <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString?" href="#dom-federatedcredential-protocol" id="ref-for-dom-federatedcredential-protocol-1">protocol</a>;
+<pre class="idl highlight def">[<a class="nv idl-code" data-link-type="constructor" href="#dom-federatedcredential-federatedcredential" id="ref-for-dom-federatedcredential-federatedcredential">Constructor</a>(<a class="n" data-link-type="idl-name" href="#dictdef-federatedcredentialinit" id="ref-for-dictdef-federatedcredentialinit">FederatedCredentialInit</a> <dfn class="nv idl-code" data-dfn-for="FederatedCredential/FederatedCredential(data)" data-dfn-type="argument" data-export="" id="dom-federatedcredential-federatedcredential-data-data"><code>data</code><a class="self-link" href="#dom-federatedcredential-federatedcredential-data-data"></a></dfn>),
+ <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed③">Exposed</a>=<span class="n">Window</span>,
+ <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext⑤">SecureContext</a>]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="federatedcredential"><code>FederatedCredential</code></dfn> : <a class="n" data-link-type="idl-name" href="#credential" id="ref-for-credential③⑨">Credential</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①②"><span class="kt">USVString</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-federatedcredential-provider" id="ref-for-dom-federatedcredential-provider">provider</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②"><span class="kt">DOMString</span></a>? <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString?" href="#dom-federatedcredential-protocol" id="ref-for-dom-federatedcredential-protocol">protocol</a>;
 };
-<a class="n" data-link-type="idl-name" href="#federatedcredential" id="ref-for-federatedcredential-2">FederatedCredential</a> <span class="kt">implements</span> <a class="n" data-link-type="idl-name" href="#credentialuserdata" id="ref-for-credentialuserdata-2">CredentialUserData</a>;
+<a class="n" data-link-type="idl-name" href="#federatedcredential" id="ref-for-federatedcredential①">FederatedCredential</a> <span class="kt">implements</span> <a class="n" data-link-type="idl-name" href="#credentialuserdata" id="ref-for-credentialuserdata①">CredentialUserData</a>;
 
 <span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-federatedcredentialrequestoptions"><code>FederatedCredentialRequestOptions</code></dfn> {
-  <span class="kt">sequence</span>&lt;<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString"><span class="kt">USVString</span></a>> <dfn class="nv dfn-paneled idl-code" data-dfn-for="FederatedCredentialRequestOptions" data-dfn-type="dict-member" data-export="" data-type="sequence<USVString> " id="dom-federatedcredentialrequestoptions-providers"><code>providers</code></dfn>;
-  <span class="kt">sequence</span>&lt;<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a>> <dfn class="nv dfn-paneled idl-code" data-dfn-for="FederatedCredentialRequestOptions" data-dfn-type="dict-member" data-export="" data-type="sequence<DOMString> " id="dom-federatedcredentialrequestoptions-protocols"><code>protocols</code></dfn>;
+  <span class="kt">sequence</span>&lt;<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①③"><span class="kt">USVString</span></a>> <dfn class="nv dfn-paneled idl-code" data-dfn-for="FederatedCredentialRequestOptions" data-dfn-type="dict-member" data-export="" data-type="sequence<USVString> " id="dom-federatedcredentialrequestoptions-providers"><code>providers</code></dfn>;
+  <span class="kt">sequence</span>&lt;<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString③"><span class="kt">DOMString</span></a>> <dfn class="nv dfn-paneled idl-code" data-dfn-for="FederatedCredentialRequestOptions" data-dfn-type="dict-member" data-export="" data-type="sequence<DOMString> " id="dom-federatedcredentialrequestoptions-protocols"><code>protocols</code></dfn>;
 };
 
-<span class="kt">partial</span> <span class="kt">dictionary</span> <a class="nv idl-code" data-link-type="dictionary" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions-14">CredentialRequestOptions</a> {
-  <a class="n" data-link-type="idl-name" href="#dictdef-federatedcredentialrequestoptions" id="ref-for-dictdef-federatedcredentialrequestoptions-1">FederatedCredentialRequestOptions</a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="CredentialRequestOptions" data-dfn-type="dict-member" data-export="" data-type="FederatedCredentialRequestOptions " id="dom-credentialrequestoptions-federated"><code>federated</code></dfn>;
+<span class="kt">partial</span> <span class="kt">dictionary</span> <a class="nv idl-code" data-link-type="dictionary" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions①③">CredentialRequestOptions</a> {
+  <a class="n" data-link-type="idl-name" href="#dictdef-federatedcredentialrequestoptions" id="ref-for-dictdef-federatedcredentialrequestoptions">FederatedCredentialRequestOptions</a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="CredentialRequestOptions" data-dfn-type="dict-member" data-export="" data-type="FederatedCredentialRequestOptions " id="dom-credentialrequestoptions-federated"><code>federated</code></dfn>;
 };
 </pre>
     <div>
      <dl>
-      <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="FederatedCredential" data-dfn-type="attribute" data-export="" id="dom-federatedcredential-provider"><code>provider</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-USVString">USVString</a>, readonly</span>
+      <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="FederatedCredential" data-dfn-type="attribute" data-export="" id="dom-federatedcredential-provider"><code>provider</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①④">USVString</a>, readonly</span>
       <dd data-md="">
        <p>The credential’s federated identity provider. See <a href="#provider-identification">§4.1.1 Identifying Providers</a> for
   details regarding valid formats.</p>
-      <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="FederatedCredential" data-dfn-type="attribute" data-export="" id="dom-federatedcredential-protocol"><code>protocol</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a>, readonly, nullable</span>
+      <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="FederatedCredential" data-dfn-type="attribute" data-export="" id="dom-federatedcredential-protocol"><code>protocol</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString④">DOMString</a>, readonly, nullable</span>
       <dd data-md="">
        <p>The credential’s federated identity provider’s protocol (e.g. "<code>openidconnect</code>"). If the
-  value is <code>null</code>, then the protocol can be inferred from the <code class="idl"><a data-link-type="idl" href="#dom-federatedcredential-provider" id="ref-for-dom-federatedcredential-provider-2">provider</a></code>.</p>
-      <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-credential-type-slot" id="ref-for-dom-credential-type-slot-5">[[type]]</a></code>
+  value is <code>null</code>, then the protocol can be inferred from the <code class="idl"><a data-link-type="idl" href="#dom-federatedcredential-provider" id="ref-for-dom-federatedcredential-provider①">provider</a></code>.</p>
+      <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-credential-type-slot" id="ref-for-dom-credential-type-slot④">[[type]]</a></code>
       <dd data-md="">
-       <p>The <code class="idl"><a data-link-type="idl" href="#federatedcredential" id="ref-for-federatedcredential-3">FederatedCredential</a></code> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object">interface object</a> has an internal slot named <code>[[type]]</code> whose
+       <p>The <code class="idl"><a data-link-type="idl" href="#federatedcredential" id="ref-for-federatedcredential②">FederatedCredential</a></code> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object①④">interface object</a> has an internal slot named <code>[[type]]</code> whose
   value is "<dfn class="idl-code" data-dfn-for="FederatedCredential" data-dfn-type="const" data-export="" id="dom-federatedcredential-federated"><code><code>federated</code></code><a class="self-link" href="#dom-federatedcredential-federated"></a></dfn>".</p>
-      <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-credential-discovery-slot" id="ref-for-dom-credential-discovery-slot-3">[[discovery]]</a></code>
+      <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-credential-discovery-slot" id="ref-for-dom-credential-discovery-slot②">[[discovery]]</a></code>
       <dd data-md="">
-       <p>The <code class="idl"><a data-link-type="idl" href="#federatedcredential" id="ref-for-federatedcredential-4">FederatedCredential</a></code> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object">interface object</a> has an internal slot named <code>[[discovery]]</code> whose value is "<code class="idl"><a data-link-type="idl" href="#dom-credential-discovery-credential-store" id="ref-for-dom-credential-discovery-credential-store-3">credential store</a></code>".</p>
+       <p>The <code class="idl"><a data-link-type="idl" href="#federatedcredential" id="ref-for-federatedcredential③">FederatedCredential</a></code> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object①⑤">interface object</a> has an internal slot named <code>[[discovery]]</code> whose value is "<code class="idl"><a data-link-type="idl" href="#dom-credential-discovery-credential-store" id="ref-for-dom-credential-discovery-credential-store②">credential store</a></code>".</p>
       <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="FederatedCredential" data-dfn-type="constructor" data-export="" id="dom-federatedcredential-federatedcredential"><code>FederatedCredential(data)</code></dfn>
       <dd data-md="">
-       <p>This constructor accepts a <code class="idl"><a data-link-type="idl" href="#dictdef-federatedcredentialinit" id="ref-for-dictdef-federatedcredentialinit-2">FederatedCredentialInit</a></code> (<var>data</var>), and runs the following steps:</p>
+       <p>This constructor accepts a <code class="idl"><a data-link-type="idl" href="#dictdef-federatedcredentialinit" id="ref-for-dictdef-federatedcredentialinit①">FederatedCredentialInit</a></code> (<var>data</var>), and runs the following steps:</p>
        <ol>
         <li data-md="">
-         <p>Let <var>r</var> be the result of executing <a data-link-type="abstract-op" href="#abstract-opdef-create-a-federatedcredential-from-federatedcredentialinit" id="ref-for-abstract-opdef-create-a-federatedcredential-from-federatedcredentialinit-1">Create a <code>FederatedCredential</code> from <code>FederatedCredentialInit</code></a> on <var>data</var>.</p>
+         <p>Let <var>r</var> be the result of executing <a data-link-type="abstract-op" href="#abstract-opdef-create-a-federatedcredential-from-federatedcredentialinit" id="ref-for-abstract-opdef-create-a-federatedcredential-from-federatedcredentialinit">Create a <code>FederatedCredential</code> from <code>FederatedCredentialInit</code></a> on <var>data</var>.</p>
         <li data-md="">
-         <p>If <var>r</var> is an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception">exception</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> <var>r</var>.</p>
+         <p>If <var>r</var> is an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception" id="ref-for-dfn-exception⑨">exception</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw" id="ref-for-dfn-throw②">throw</a> <var>r</var>.</p>
          <p>Otherwise, return <var>r</var>.</p>
        </ol>
      </dl>
     </div>
-    <p><code class="idl"><a data-link-type="idl" href="#federatedcredential" id="ref-for-federatedcredential-5">FederatedCredential</a></code> objects can be created by passing a <code class="idl"><a data-link-type="idl" href="#dictdef-federatedcredentialinit" id="ref-for-dictdef-federatedcredentialinit-3">FederatedCredentialInit</a></code> dictionary
-  into <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-create" id="ref-for-dom-credentialscontainer-create-6">navigator.credentials.create()</a></code>.</p>
-<pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-federatedcredentialinit"><code>FederatedCredentialInit</code></dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-credentialdata" id="ref-for-dictdef-credentialdata-2">CredentialData</a> {
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString"><span class="kt">USVString</span></a> <dfn class="nv idl-code" data-dfn-for="FederatedCredentialInit" data-dfn-type="dict-member" data-export="" data-type="USVString " id="dom-federatedcredentialinit-name"><code>name</code><a class="self-link" href="#dom-federatedcredentialinit-name"></a></dfn>;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString"><span class="kt">USVString</span></a> <dfn class="nv idl-code" data-dfn-for="FederatedCredentialInit" data-dfn-type="dict-member" data-export="" data-type="USVString " id="dom-federatedcredentialinit-iconurl"><code>iconURL</code><a class="self-link" href="#dom-federatedcredentialinit-iconurl"></a></dfn>;
-  <span class="kt">required</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString"><span class="kt">USVString</span></a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="FederatedCredentialInit" data-dfn-type="dict-member" data-export="" data-type="USVString " id="dom-federatedcredentialinit-provider"><code>provider</code></dfn>;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-dfn-for="FederatedCredentialInit" data-dfn-type="dict-member" data-export="" data-type="DOMString " id="dom-federatedcredentialinit-protocol"><code>protocol</code><a class="self-link" href="#dom-federatedcredentialinit-protocol"></a></dfn>;
+    <p><code class="idl"><a data-link-type="idl" href="#federatedcredential" id="ref-for-federatedcredential④">FederatedCredential</a></code> objects can be created by passing a <code class="idl"><a data-link-type="idl" href="#dictdef-federatedcredentialinit" id="ref-for-dictdef-federatedcredentialinit②">FederatedCredentialInit</a></code> dictionary
+  into <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-create" id="ref-for-dom-credentialscontainer-create⑤">navigator.credentials.create()</a></code>.</p>
+<pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-federatedcredentialinit"><code>FederatedCredentialInit</code></dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-credentialdata" id="ref-for-dictdef-credentialdata①">CredentialData</a> {
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①⑤"><span class="kt">USVString</span></a> <dfn class="nv idl-code" data-dfn-for="FederatedCredentialInit" data-dfn-type="dict-member" data-export="" data-type="USVString " id="dom-federatedcredentialinit-name"><code>name</code><a class="self-link" href="#dom-federatedcredentialinit-name"></a></dfn>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①⑥"><span class="kt">USVString</span></a> <dfn class="nv idl-code" data-dfn-for="FederatedCredentialInit" data-dfn-type="dict-member" data-export="" data-type="USVString " id="dom-federatedcredentialinit-iconurl"><code>iconURL</code><a class="self-link" href="#dom-federatedcredentialinit-iconurl"></a></dfn>;
+  <span class="kt">required</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①⑦"><span class="kt">USVString</span></a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="FederatedCredentialInit" data-dfn-type="dict-member" data-export="" data-type="USVString " id="dom-federatedcredentialinit-provider"><code>provider</code></dfn>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑤"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-dfn-for="FederatedCredentialInit" data-dfn-type="dict-member" data-export="" data-type="DOMString " id="dom-federatedcredentialinit-protocol"><code>protocol</code><a class="self-link" href="#dom-federatedcredentialinit-protocol"></a></dfn>;
 };
 
-<span class="kt">partial</span> <span class="kt">dictionary</span> <a class="nv idl-code" data-link-type="dictionary" href="#dictdef-credentialcreationoptions" id="ref-for-dictdef-credentialcreationoptions-9">CredentialCreationOptions</a> {
-  <a class="n" data-link-type="idl-name" href="#dictdef-federatedcredentialinit" id="ref-for-dictdef-federatedcredentialinit-4">FederatedCredentialInit</a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="CredentialCreationOptions" data-dfn-type="dict-member" data-export="" data-type="FederatedCredentialInit " id="dom-credentialcreationoptions-federated"><code>federated</code></dfn>;
+<span class="kt">partial</span> <span class="kt">dictionary</span> <a class="nv idl-code" data-link-type="dictionary" href="#dictdef-credentialcreationoptions" id="ref-for-dictdef-credentialcreationoptions⑧">CredentialCreationOptions</a> {
+  <a class="n" data-link-type="idl-name" href="#dictdef-federatedcredentialinit" id="ref-for-dictdef-federatedcredentialinit③">FederatedCredentialInit</a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="CredentialCreationOptions" data-dfn-type="dict-member" data-export="" data-type="FederatedCredentialInit " id="dom-credentialcreationoptions-federated"><code>federated</code></dfn>;
 };
 </pre>
-    <p><code class="idl"><a data-link-type="idl" href="#federatedcredential" id="ref-for-federatedcredential-6">FederatedCredential</a></code> objects are <a data-link-type="dfn" href="#credential-origin-bound" id="ref-for-credential-origin-bound-2">origin bound</a>.</p>
-    <p><code class="idl"><a data-link-type="idl" href="#federatedcredential" id="ref-for-federatedcredential-7">FederatedCredential</a></code>'s <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object">interface object</a> inherits <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-41">Credential</a></code>'s implementation of <code class="idl"><a data-link-type="idl" href="#dom-credential-discoverfromexternalsource-slot" id="ref-for-dom-credential-discoverfromexternalsource-slot-3">[[DiscoverFromExternalSource]](options)</a></code>, and defines its own implementation of <code class="idl"><a data-link-type="idl" href="#dom-federatedcredential-collectfromcredentialstore-slot" id="ref-for-dom-federatedcredential-collectfromcredentialstore-slot-1">[[CollectFromCredentialStore]](options)</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-federatedcredential-create-slot" id="ref-for-dom-federatedcredential-create-slot-1">[[Create]](options)</a></code>, and <code class="idl"><a data-link-type="idl" href="#dom-federatedcredential-store-slot" id="ref-for-dom-federatedcredential-store-slot-1">[[Store]](credential)</a></code>.</p>
+    <p><code class="idl"><a data-link-type="idl" href="#federatedcredential" id="ref-for-federatedcredential⑤">FederatedCredential</a></code> objects are <a data-link-type="dfn" href="#credential-origin-bound" id="ref-for-credential-origin-bound①">origin bound</a>.</p>
+    <p><code class="idl"><a data-link-type="idl" href="#federatedcredential" id="ref-for-federatedcredential⑥">FederatedCredential</a></code>'s <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object①⑥">interface object</a> inherits <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential④⓪">Credential</a></code>'s implementation of <code class="idl"><a data-link-type="idl" href="#dom-credential-discoverfromexternalsource-slot" id="ref-for-dom-credential-discoverfromexternalsource-slot④">[[DiscoverFromExternalSource]](options)</a></code>, and defines its own implementation of <code class="idl"><a data-link-type="idl" href="#dom-federatedcredential-collectfromcredentialstore-slot" id="ref-for-dom-federatedcredential-collectfromcredentialstore-slot">[[CollectFromCredentialStore]](options)</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-federatedcredential-create-slot" id="ref-for-dom-federatedcredential-create-slot">[[Create]](options)</a></code>, and <code class="idl"><a data-link-type="idl" href="#dom-federatedcredential-store-slot" id="ref-for-dom-federatedcredential-store-slot">[[Store]](credential)</a></code>.</p>
     <p class="note" role="note"><span>Note:</span> If, in the future, we teach the user agent to obtain authentication tokens on a user’s
   behalf, we could do so by building an implementation of <code>[[DiscoverFromExternalSource]](options)</code>.</p>
     <h4 class="heading settled" data-level="4.1.1" id="provider-identification"><span class="secno">4.1.1. </span><span class="content">Identifying Providers</span><a class="self-link" href="#provider-identification"></a></h4>
@@ -2797,102 +2803,102 @@ store user credentials for future use.</p>
   provider. For example, <a href="https://developers.facebook.com/docs/facebook-login/v2.0">Facebook Login</a> shouldn’t be referred to as "Facebook" and "Facebook Login" and "FB" and "FBL" and "Facebook.com"
   and so on. It should have a canonical identifier which everyone can make use of, as consistent
   identification makes it possible for user agents to be helpful.</p>
-    <p>For consistency, federations passed into the APIs defined in this document (e.g. <code class="idl"><a data-link-type="idl" href="#dictdef-federatedcredentialrequestoptions" id="ref-for-dictdef-federatedcredentialrequestoptions-2">FederatedCredentialRequestOptions</a></code>'s <code class="idl"><a data-link-type="idl" href="#dom-federatedcredentialrequestoptions-providers" id="ref-for-dom-federatedcredentialrequestoptions-providers-1">providers</a></code> array, or <code class="idl"><a data-link-type="idl" href="#federatedcredential" id="ref-for-federatedcredential-8">FederatedCredential</a></code>'s <code class="idl"><a data-link-type="idl" href="#dom-federatedcredential-provider" id="ref-for-dom-federatedcredential-provider-3">provider</a></code> property) MUST be identified by the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin">ASCII serialization</a> of the origin the provider uses
+    <p>For consistency, federations passed into the APIs defined in this document (e.g. <code class="idl"><a data-link-type="idl" href="#dictdef-federatedcredentialrequestoptions" id="ref-for-dictdef-federatedcredentialrequestoptions①">FederatedCredentialRequestOptions</a></code>'s <code class="idl"><a data-link-type="idl" href="#dom-federatedcredentialrequestoptions-providers" id="ref-for-dom-federatedcredentialrequestoptions-providers">providers</a></code> array, or <code class="idl"><a data-link-type="idl" href="#federatedcredential" id="ref-for-federatedcredential⑦">FederatedCredential</a></code>'s <code class="idl"><a data-link-type="idl" href="#dom-federatedcredential-provider" id="ref-for-dom-federatedcredential-provider②">provider</a></code> property) MUST be identified by the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#ascii-serialisation-of-an-origin" id="ref-for-ascii-serialisation-of-an-origin">ASCII serialization</a> of the origin the provider uses
   for sign in. That is, Facebook would be represented by <code>https://www.facebook.com</code> and Google by <code>https://accounts.google.com</code>.</p>
-    <p>This serialization of an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">origin</a> does _not_ include a trailing U+002F SOLIDUS ("<code>/</code>"), but
+    <p>This serialization of an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin③">origin</a> does _not_ include a trailing U+002F SOLIDUS ("<code>/</code>"), but
   user agents SHOULD accept them silently: <code>https://accounts.google.com/</code> is clearly
   intended to be the same as <code>https://accounts.google.com</code>.</p>
     <h3 class="heading settled" data-level="4.2" id="federatedcredential-algorithms"><span class="secno">4.2. </span><span class="content">Algorithms</span><a class="self-link" href="#federatedcredential-algorithms"></a></h3>
     <h4 class="heading settled algorithm" data-algorithm="FederatedCredential&apos;s [[CollectFromCredentialStore]](options)" data-level="4.2.1" id="collectfromcredentialstore-federatedcredential"><span class="secno">4.2.1. </span><span class="content"> <code>FederatedCredential</code>'s <code>[[CollectFromCredentialStore]](options)</code> </span><a class="self-link" href="#collectfromcredentialstore-federatedcredential"></a></h4>
     <p><dfn class="dfn-paneled idl-code" data-dfn-for="FederatedCredential" data-dfn-type="method" data-export="" id="dom-federatedcredential-collectfromcredentialstore-slot"><code>[[CollectFromCredentialStore]](options)</code></dfn> is called
-  with a <code class="idl"><a data-link-type="idl" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions-15">CredentialRequestOptions</a></code> (<var>options</var>), and returns a set of <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-42">Credential</a></code> objects from
-  the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store-19">credential store</a>. If no matching <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-43">Credential</a></code> objects are available, the returned set
+  with a <code class="idl"><a data-link-type="idl" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions①④">CredentialRequestOptions</a></code> (<var>options</var>), and returns a set of <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential④①">Credential</a></code> objects from
+  the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store①⑧">credential store</a>. If no matching <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential④②">Credential</a></code> objects are available, the returned set
   will be empty.</p>
     <ol class="algorithm">
      <li data-md="">
-      <p class="assertion">Assert: <var>options</var>["<code class="idl"><a data-link-type="idl" href="#dom-credentialrequestoptions-federated" id="ref-for-dom-credentialrequestoptions-federated-1">federated</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists">exists</a>.</p>
+      <p class="assertion">Assert: <var>options</var>["<code class="idl"><a data-link-type="idl" href="#dom-credentialrequestoptions-federated" id="ref-for-dom-credentialrequestoptions-federated">federated</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists③">exists</a>.</p>
      <li data-md="">
-      <p>Return the result of <a data-link-type="abstract-op" href="#abstract-opdef-credential-store-retrieve-a-list-of-credentials" id="ref-for-abstract-opdef-credential-store-retrieve-a-list-of-credentials-2">retrieving</a> credentials from the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store-20">credential store</a> that match the following filter:</p>
+      <p>Return the result of <a data-link-type="abstract-op" href="#abstract-opdef-credential-store-retrieve-a-list-of-credentials" id="ref-for-abstract-opdef-credential-store-retrieve-a-list-of-credentials①">retrieving</a> credentials from the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store①⑨">credential store</a> that match the following filter:</p>
       <ol>
        <li data-md="">
-        <p>The credential is a <code class="idl"><a data-link-type="idl" href="#federatedcredential" id="ref-for-federatedcredential-9">FederatedCredential</a></code></p>
+        <p>The credential is a <code class="idl"><a data-link-type="idl" href="#federatedcredential" id="ref-for-federatedcredential⑧">FederatedCredential</a></code></p>
        <li data-md="">
-        <p>The credential’s <code class="idl"><a data-link-type="idl" href="#dom-credential-origin-slot" id="ref-for-dom-credential-origin-slot-7">[[origin]]</a></code> is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">same origin</a> as the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">current settings object</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>.</p>
+        <p>The credential’s <code class="idl"><a data-link-type="idl" href="#dom-credential-origin-slot" id="ref-for-dom-credential-origin-slot⑥">[[origin]]</a></code> is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#same-origin" id="ref-for-same-origin②">same origin</a> as the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object" id="ref-for-current-settings-object⑦">current settings object</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin④">origin</a>.</p>
        <li data-md="">
-        <p>If <var>options</var>["<code class="idl"><a data-link-type="idl" href="#dom-credentialrequestoptions-federated" id="ref-for-dom-credentialrequestoptions-federated-2">federated</a></code>"]["<code class="idl"><a data-link-type="idl" href="#dom-federatedcredentialrequestoptions-providers" id="ref-for-dom-federatedcredentialrequestoptions-providers-2">providers</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists">exists</a>, its value <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain">contains</a> the credentials’s <code class="idl"><a data-link-type="idl" href="#dom-federatedcredential-provider" id="ref-for-dom-federatedcredential-provider-4">provider</a></code>.</p>
+        <p>If <var>options</var>["<code class="idl"><a data-link-type="idl" href="#dom-credentialrequestoptions-federated" id="ref-for-dom-credentialrequestoptions-federated①">federated</a></code>"]["<code class="idl"><a data-link-type="idl" href="#dom-federatedcredentialrequestoptions-providers" id="ref-for-dom-federatedcredentialrequestoptions-providers①">providers</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists④">exists</a>, its value <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain①">contains</a> the credentials’s <code class="idl"><a data-link-type="idl" href="#dom-federatedcredential-provider" id="ref-for-dom-federatedcredential-provider③">provider</a></code>.</p>
        <li data-md="">
-        <p>If <var>options</var>["<code class="idl"><a data-link-type="idl" href="#dom-credentialrequestoptions-federated" id="ref-for-dom-credentialrequestoptions-federated-3">federated</a></code>"]["<code class="idl"><a data-link-type="idl" href="#dom-federatedcredentialrequestoptions-protocols" id="ref-for-dom-federatedcredentialrequestoptions-protocols-1">protocols</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists">exists</a>, its value <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain">contains</a> the credentials’s <code class="idl"><a data-link-type="idl" href="#dom-federatedcredential-protocol" id="ref-for-dom-federatedcredential-protocol-2">protocol</a></code>.</p>
+        <p>If <var>options</var>["<code class="idl"><a data-link-type="idl" href="#dom-credentialrequestoptions-federated" id="ref-for-dom-credentialrequestoptions-federated②">federated</a></code>"]["<code class="idl"><a data-link-type="idl" href="#dom-federatedcredentialrequestoptions-protocols" id="ref-for-dom-federatedcredentialrequestoptions-protocols">protocols</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists⑤">exists</a>, its value <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain②">contains</a> the credentials’s <code class="idl"><a data-link-type="idl" href="#dom-federatedcredential-protocol" id="ref-for-dom-federatedcredential-protocol①">protocol</a></code>.</p>
       </ol>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="FederatedCredential&apos;s [[Create]](options)" data-level="4.2.2" id="create-federatedcredential"><span class="secno">4.2.2. </span><span class="content"> <code>FederatedCredential</code>'s <code>[[Create]](options)</code> </span><a class="self-link" href="#create-federatedcredential"></a></h4>
-    <p><dfn class="dfn-paneled idl-code" data-dfn-for="FederatedCredential" data-dfn-type="method" data-export="" id="dom-federatedcredential-create-slot"><code>[[Create]](options)</code></dfn> is called with a <code class="idl"><a data-link-type="idl" href="#dictdef-credentialcreationoptions" id="ref-for-dictdef-credentialcreationoptions-10">CredentialCreationOptions</a></code> (<var>options</var>), and returns a <code class="idl"><a data-link-type="idl" href="#federatedcredential" id="ref-for-federatedcredential-10">FederatedCredential</a></code> if one can be created, <code>null</code> otherwise, or an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception">exception</a> in exceptional circumstances:</p>
+    <p><dfn class="dfn-paneled idl-code" data-dfn-for="FederatedCredential" data-dfn-type="method" data-export="" id="dom-federatedcredential-create-slot"><code>[[Create]](options)</code></dfn> is called with a <code class="idl"><a data-link-type="idl" href="#dictdef-credentialcreationoptions" id="ref-for-dictdef-credentialcreationoptions⑨">CredentialCreationOptions</a></code> (<var>options</var>), and returns a <code class="idl"><a data-link-type="idl" href="#federatedcredential" id="ref-for-federatedcredential⑨">FederatedCredential</a></code> if one can be created, <code>null</code> otherwise, or an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception" id="ref-for-dfn-exception①⓪">exception</a> in exceptional circumstances:</p>
     <ol class="algorithm">
      <li data-md="">
-      <p class="assertion">Assert: <var>options</var>["<code class="idl"><a data-link-type="idl" href="#dom-credentialcreationoptions-federated" id="ref-for-dom-credentialcreationoptions-federated-1">federated</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists">exists</a>.</p>
+      <p class="assertion">Assert: <var>options</var>["<code class="idl"><a data-link-type="idl" href="#dom-credentialcreationoptions-federated" id="ref-for-dom-credentialcreationoptions-federated">federated</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists⑥">exists</a>.</p>
      <li data-md="">
-      <p>Return the result of executing <a data-link-type="abstract-op" href="#abstract-opdef-create-a-federatedcredential-from-federatedcredentialinit" id="ref-for-abstract-opdef-create-a-federatedcredential-from-federatedcredentialinit-2">Create a <code>FederatedCredential</code> from <code>FederatedCredentialInit</code></a> on <var>options</var>["<code class="idl"><a data-link-type="idl" href="#dom-credentialcreationoptions-federated" id="ref-for-dom-credentialcreationoptions-federated-2">federated</a></code>"].</p>
+      <p>Return the result of executing <a data-link-type="abstract-op" href="#abstract-opdef-create-a-federatedcredential-from-federatedcredentialinit" id="ref-for-abstract-opdef-create-a-federatedcredential-from-federatedcredentialinit①">Create a <code>FederatedCredential</code> from <code>FederatedCredentialInit</code></a> on <var>options</var>["<code class="idl"><a data-link-type="idl" href="#dom-credentialcreationoptions-federated" id="ref-for-dom-credentialcreationoptions-federated①">federated</a></code>"].</p>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="FederatedCredential&apos;s [[Store]](credential)" data-level="4.2.3" id="store-federatedcredential"><span class="secno">4.2.3. </span><span class="content"> <code>FederatedCredential</code>'s <code>[[Store]](credential)</code> </span><a class="self-link" href="#store-federatedcredential"></a></h4>
-    <p><dfn class="dfn-paneled idl-code" data-dfn-for="FederatedCredential" data-dfn-type="method" data-export="" id="dom-federatedcredential-store-slot"><code>[[Store]](credential)</code></dfn> is called with a <code class="idl"><a data-link-type="idl" href="#federatedcredential" id="ref-for-federatedcredential-11">FederatedCredential</a></code> (<var>credential</var>), and returns once <var>credential</var> is persisted to the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store-21">credential store</a>.</p>
+    <p><dfn class="dfn-paneled idl-code" data-dfn-for="FederatedCredential" data-dfn-type="method" data-export="" id="dom-federatedcredential-store-slot"><code>[[Store]](credential)</code></dfn> is called with a <code class="idl"><a data-link-type="idl" href="#federatedcredential" id="ref-for-federatedcredential①⓪">FederatedCredential</a></code> (<var>credential</var>), and returns once <var>credential</var> is persisted to the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store②⓪">credential store</a>.</p>
     <ol class="algorithm">
      <li data-md="">
-      <p>If the user agent’s <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store-22">credential store</a> contains a <code class="idl"><a data-link-type="idl" href="#federatedcredential" id="ref-for-federatedcredential-12">FederatedCredential</a></code> whose <code class="idl"><a data-link-type="idl" href="#dom-credential-id" id="ref-for-dom-credential-id-7">id</a></code> attribute is <var>credential</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credential-id" id="ref-for-dom-credential-id-8">id</a></code> and whose <code class="idl"><a data-link-type="idl" href="#dom-credential-origin-slot" id="ref-for-dom-credential-origin-slot-8">[[origin]]</a></code> slot is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">same origin</a> as <var>credential</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credential-origin-slot" id="ref-for-dom-credential-origin-slot-9">[[origin]]</a></code>, and
-  whose <code class="idl"><a data-link-type="idl" href="#dom-federatedcredential-provider" id="ref-for-dom-federatedcredential-provider-5">provider</a></code> is <var>credential</var>’s <code class="idl"><a data-link-type="idl" href="#dom-federatedcredential-provider" id="ref-for-dom-federatedcredential-provider-6">provider</a></code>, then return.</p>
+      <p>If the user agent’s <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store②①">credential store</a> contains a <code class="idl"><a data-link-type="idl" href="#federatedcredential" id="ref-for-federatedcredential①①">FederatedCredential</a></code> whose <code class="idl"><a data-link-type="idl" href="#dom-credential-id" id="ref-for-dom-credential-id⑥">id</a></code> attribute is <var>credential</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credential-id" id="ref-for-dom-credential-id⑦">id</a></code> and whose <code class="idl"><a data-link-type="idl" href="#dom-credential-origin-slot" id="ref-for-dom-credential-origin-slot⑦">[[origin]]</a></code> slot is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#same-origin" id="ref-for-same-origin③">same origin</a> as <var>credential</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credential-origin-slot" id="ref-for-dom-credential-origin-slot⑧">[[origin]]</a></code>, and
+  whose <code class="idl"><a data-link-type="idl" href="#dom-federatedcredential-provider" id="ref-for-dom-federatedcredential-provider④">provider</a></code> is <var>credential</var>’s <code class="idl"><a data-link-type="idl" href="#dom-federatedcredential-provider" id="ref-for-dom-federatedcredential-provider⑤">provider</a></code>, then return.</p>
      <li data-md="">
-      <p>Store a <code class="idl"><a data-link-type="idl" href="#federatedcredential" id="ref-for-federatedcredential-13">FederatedCredential</a></code> in the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store-23">credential store</a> with the following
+      <p>Store a <code class="idl"><a data-link-type="idl" href="#federatedcredential" id="ref-for-federatedcredential①②">FederatedCredential</a></code> in the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store②②">credential store</a> with the following
   properties:</p>
       <dl>
-       <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-credential-id" id="ref-for-dom-credential-id-9">id</a></code>
+       <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-credential-id" id="ref-for-dom-credential-id⑧">id</a></code>
        <dd data-md="">
-        <p><var>credential</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credential-id" id="ref-for-dom-credential-id-10">id</a></code></p>
-       <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-credentialuserdata-name" id="ref-for-dom-credentialuserdata-name-8">name</a></code>,
+        <p><var>credential</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credential-id" id="ref-for-dom-credential-id⑨">id</a></code></p>
+       <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-credentialuserdata-name" id="ref-for-dom-credentialuserdata-name⑦">name</a></code>,
        <dd data-md="">
-        <p><var>credential</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credentialuserdata-name" id="ref-for-dom-credentialuserdata-name-9">name</a></code></p>
-       <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-credentialuserdata-iconurl" id="ref-for-dom-credentialuserdata-iconurl-8">iconURL</a></code>
+        <p><var>credential</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credentialuserdata-name" id="ref-for-dom-credentialuserdata-name⑧">name</a></code></p>
+       <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-credentialuserdata-iconurl" id="ref-for-dom-credentialuserdata-iconurl⑦">iconURL</a></code>
        <dd data-md="">
-        <p><var>credential</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credentialuserdata-iconurl" id="ref-for-dom-credentialuserdata-iconurl-9">iconURL</a></code></p>
-       <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-credential-origin-slot" id="ref-for-dom-credential-origin-slot-10">[[origin]]</a></code>
+        <p><var>credential</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credentialuserdata-iconurl" id="ref-for-dom-credentialuserdata-iconurl⑧">iconURL</a></code></p>
+       <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-credential-origin-slot" id="ref-for-dom-credential-origin-slot⑨">[[origin]]</a></code>
        <dd data-md="">
-        <p><var>credential</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credential-origin-slot" id="ref-for-dom-credential-origin-slot-11">[[origin]]</a></code></p>
-       <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-federatedcredential-provider" id="ref-for-dom-federatedcredential-provider-7">provider</a></code>
+        <p><var>credential</var>’s <code class="idl"><a data-link-type="idl" href="#dom-credential-origin-slot" id="ref-for-dom-credential-origin-slot①⓪">[[origin]]</a></code></p>
+       <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-federatedcredential-provider" id="ref-for-dom-federatedcredential-provider⑥">provider</a></code>
        <dd data-md="">
-        <p><var>credential</var>’s <code class="idl"><a data-link-type="idl" href="#dom-federatedcredential-provider" id="ref-for-dom-federatedcredential-provider-8">provider</a></code></p>
-       <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-federatedcredential-protocol" id="ref-for-dom-federatedcredential-protocol-3">protocol</a></code>
+        <p><var>credential</var>’s <code class="idl"><a data-link-type="idl" href="#dom-federatedcredential-provider" id="ref-for-dom-federatedcredential-provider⑦">provider</a></code></p>
+       <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-federatedcredential-protocol" id="ref-for-dom-federatedcredential-protocol②">protocol</a></code>
        <dd data-md="">
-        <p><var>credential</var>’s <code class="idl"><a data-link-type="idl" href="#dom-federatedcredential-protocol" id="ref-for-dom-federatedcredential-protocol-4">protocol</a></code></p>
+        <p><var>credential</var>’s <code class="idl"><a data-link-type="idl" href="#dom-federatedcredential-protocol" id="ref-for-dom-federatedcredential-protocol③">protocol</a></code></p>
       </dl>
     </ol>
     <h4 class="heading settled algorithm" data-algorithm="Create a FederatedCredential from FederatedCredentialInit" data-level="4.2.4" id="construct-federatedcredential-data"><span class="secno">4.2.4. </span><span class="content"> Create a <code>FederatedCredential</code> from <code>FederatedCredentialInit</code> </span><a class="self-link" href="#construct-federatedcredential-data"></a></h4>
-    <p>To <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export="" id="abstract-opdef-create-a-federatedcredential-from-federatedcredentialinit">Create a <code>FederatedCredential</code> from <code>FederatedCredentialInit</code></dfn>, given a <code class="idl"><a data-link-type="idl" href="#dictdef-federatedcredentialinit" id="ref-for-dictdef-federatedcredentialinit-5">FederatedCredentialInit</a></code> (<var>init</var>), run these steps.</p>
+    <p>To <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export="" id="abstract-opdef-create-a-federatedcredential-from-federatedcredentialinit">Create a <code>FederatedCredential</code> from <code>FederatedCredentialInit</code></dfn>, given a <code class="idl"><a data-link-type="idl" href="#dictdef-federatedcredentialinit" id="ref-for-dictdef-federatedcredentialinit④">FederatedCredentialInit</a></code> (<var>init</var>), run these steps.</p>
     <ol class="algorithm">
      <li data-md="">
-      <p>Let <var>c</var> be a new <code class="idl"><a data-link-type="idl" href="#federatedcredential" id="ref-for-federatedcredential-14">FederatedCredential</a></code> object.</p>
+      <p>Let <var>c</var> be a new <code class="idl"><a data-link-type="idl" href="#federatedcredential" id="ref-for-federatedcredential①③">FederatedCredential</a></code> object.</p>
      <li data-md="">
-      <p>If any of the following are the empty string, return a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#exceptiondef-typeerror">TypeError</a></code> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception">exception</a>:</p>
+      <p>If any of the following are the empty string, return a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror⑤">TypeError</a></code> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception" id="ref-for-dfn-exception①①">exception</a>:</p>
       <ul>
        <li data-md="">
-        <p><var>init</var>.<code class="idl"><a data-link-type="idl" href="#dom-credentialdata-id" id="ref-for-dom-credentialdata-id-4">id</a></code>'s value</p>
+        <p><var>init</var>.<code class="idl"><a data-link-type="idl" href="#dom-credentialdata-id" id="ref-for-dom-credentialdata-id③">id</a></code>'s value</p>
        <li data-md="">
-        <p><var>init</var>.<code class="idl"><a data-link-type="idl" href="#dom-federatedcredentialinit-provider" id="ref-for-dom-federatedcredentialinit-provider-1">provider</a></code>'s value</p>
+        <p><var>init</var>.<code class="idl"><a data-link-type="idl" href="#dom-federatedcredentialinit-provider" id="ref-for-dom-federatedcredentialinit-provider">provider</a></code>'s value</p>
       </ul>
      <li data-md="">
       <p>Set <var>c</var>’s properties as follows:</p>
       <dl>
-       <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-credential-id" id="ref-for-dom-credential-id-11">id</a></code>
+       <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-credential-id" id="ref-for-dom-credential-id①⓪">id</a></code>
        <dd data-md="">
-        <p><var>init</var>.<code class="idl"><a data-link-type="idl" href="#dom-credentialdata-id" id="ref-for-dom-credentialdata-id-5">id</a></code>'s value</p>
-       <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-federatedcredential-provider" id="ref-for-dom-federatedcredential-provider-9">provider</a></code>
+        <p><var>init</var>.<code class="idl"><a data-link-type="idl" href="#dom-credentialdata-id" id="ref-for-dom-credentialdata-id④">id</a></code>'s value</p>
+       <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-federatedcredential-provider" id="ref-for-dom-federatedcredential-provider⑧">provider</a></code>
        <dd data-md="">
-        <p><var>init</var>.<code class="idl"><a data-link-type="idl" href="#dom-federatedcredentialinit-provider" id="ref-for-dom-federatedcredentialinit-provider-2">provider</a></code>'s value</p>
-       <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-credentialuserdata-iconurl" id="ref-for-dom-credentialuserdata-iconurl-10">iconURL</a></code>
+        <p><var>init</var>.<code class="idl"><a data-link-type="idl" href="#dom-federatedcredentialinit-provider" id="ref-for-dom-federatedcredentialinit-provider①">provider</a></code>'s value</p>
+       <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-credentialuserdata-iconurl" id="ref-for-dom-credentialuserdata-iconurl⑨">iconURL</a></code>
        <dd data-md="">
-        <p><var>init</var>.<code class="idl"><a data-link-type="idl" href="#dom-credentialuserdata-iconurl" id="ref-for-dom-credentialuserdata-iconurl-11">iconURL</a></code>'s value</p>
-       <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-credentialuserdata-name" id="ref-for-dom-credentialuserdata-name-10">name</a></code>
+        <p><var>init</var>.<code class="idl"><a data-link-type="idl" href="#dom-credentialuserdata-iconurl" id="ref-for-dom-credentialuserdata-iconurl①⓪">iconURL</a></code>'s value</p>
+       <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-credentialuserdata-name" id="ref-for-dom-credentialuserdata-name⑨">name</a></code>
        <dd data-md="">
-        <p><var>init</var>.<code class="idl"><a data-link-type="idl" href="#dom-credentialuserdata-name" id="ref-for-dom-credentialuserdata-name-11">name</a></code>'s value</p>
-       <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-credential-origin-slot" id="ref-for-dom-credential-origin-slot-12">[[origin]]</a></code>
+        <p><var>init</var>.<code class="idl"><a data-link-type="idl" href="#dom-credentialuserdata-name" id="ref-for-dom-credentialuserdata-name①⓪">name</a></code>'s value</p>
+       <dt data-md=""><code class="idl"><a data-link-type="idl" href="#dom-credential-origin-slot" id="ref-for-dom-credential-origin-slot①①">[[origin]]</a></code>
        <dd data-md="">
-        <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">current settings object</a>.</p>
+        <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin⑤">origin</a> of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object" id="ref-for-current-settings-object⑧">current settings object</a>.</p>
       </dl>
      <li data-md="">
       <p>Return <var>c</var>.</p>
@@ -2905,7 +2911,7 @@ store user credentials for future use.</p>
   that they clearly understands what’s going on, and with whom their credentials are being shared.</p>
     <p>We call a particular action <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="user mediated|user mediation" id="user-mediated">user mediated</dfn> if
   it takes place after gaining a user’s explicit consent. Consent might be expressed through a
-  user’s direct interaction with a <a data-link-type="dfn" href="#credential-chooser" id="ref-for-credential-chooser-9">credential chooser</a> interface, for example. In general, <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated-9">user
+  user’s direct interaction with a <a data-link-type="dfn" href="#credential-chooser" id="ref-for-credential-chooser⑧">credential chooser</a> interface, for example. In general, <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated⑧">user
   mediated</a> actions will involve presenting the user some sort of UI, and asking them to make a
   decision.</p>
     <p>An action is unmediated if it takes place silently, without explicit user consent. For example,
@@ -2921,9 +2927,9 @@ store user credentials for future use.</p>
   profile on a particular device to a specific online persona. To mitigate the risk of surprise:</p>
     <ol>
      <li data-md="">
-      <p>Credential information SHOULD NOT be stored or updated without <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated-10">user mediation</a>. For
+      <p>Credential information SHOULD NOT be stored or updated without <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated⑨">user mediation</a>. For
   example, the user agent could display a "Save this credential?" dialog box to the user in
-  response to each call to <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-store" id="ref-for-dom-credentialscontainer-store-13">store()</a></code>.</p>
+  response to each call to <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-store" id="ref-for-dom-credentialscontainer-store①②">store()</a></code>.</p>
       <p>User consent MAY be inferred if a user agent chooses to offer a persistant grant of consent
   in the form of an "Always save passwords" option (though we’d suggest that user agents should
   err on the side of something more narrowly scoped: perhaps "Always save _generated_
@@ -2936,8 +2942,8 @@ store user credentials for future use.</p>
   be implemented as a settings page, or via interaction with a notification as described above.</p>
     </ol>
     <h3 class="heading settled" data-level="5.2" id="user-mediation-requirement"><span class="secno">5.2. </span><span class="content">Requiring User Mediation</span><a class="self-link" href="#user-mediation-requirement"></a></h3>
-    <p>By default, <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated-11">user mediation</a> is required for all <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">origins</a>, as the relevant <a data-link-type="dfn" href="#origin-prevent-silent-access-flag" id="ref-for-origin-prevent-silent-access-flag-5">prevent silent
-  access flag</a> in the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store-24">credential store</a> is set to <code>true</code>. Users MAY choose to grant an
+    <p>By default, <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated①⓪">user mediation</a> is required for all <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin④">origins</a>, as the relevant <a data-link-type="dfn" href="#origin-prevent-silent-access-flag" id="ref-for-origin-prevent-silent-access-flag④">prevent silent
+  access flag</a> in the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store②③">credential store</a> is set to <code>true</code>. Users MAY choose to grant an
   origin persistent access to credentials (perhaps in the form of a "Stay signed into this site."
   option), which would set this flag to <code>false</code>. In this case, the user would always be signed into
   that site, which is desirable from the perspective of usability and convinience, but which
@@ -2946,12 +2952,12 @@ store user credentials for future use.</p>
     <p>To mitigate the risk of surprise:</p>
     <ol>
      <li data-md="">
-      <p>User agents MUST allow users to require <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated-12">user mediation</a> for a given origin or for all
+      <p>User agents MUST allow users to require <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated①①">user mediation</a> for a given origin or for all
   origins. This functionality might be implemented as a global toggle that overrides each
-  origin’s <a data-link-type="dfn" href="#origin-prevent-silent-access-flag" id="ref-for-origin-prevent-silent-access-flag-6"><code>prevent silent access</code> flag</a> to return <code>false</code>, or via more granular
+  origin’s <a data-link-type="dfn" href="#origin-prevent-silent-access-flag" id="ref-for-origin-prevent-silent-access-flag⑤"><code>prevent silent access</code> flag</a> to return <code>false</code>, or via more granular
   settings for specific origins (or specific credentials on specific origins).</p>
      <li data-md="">
-      <p>User agents MUST NOT set an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">origin</a>'s <a data-link-type="dfn" href="#origin-prevent-silent-access-flag" id="ref-for-origin-prevent-silent-access-flag-7"><code>prevent silent access</code> flag</a> to <code>false</code> without <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated-13">user mediation</a>. For example, the <a data-link-type="dfn" href="#credential-chooser" id="ref-for-credential-chooser-10">credential chooser</a> described in <a href="#user-mediated-selection">§5.3 Credential Selection</a> could have a checkbox which the user could toggle to mark a
+      <p>User agents MUST NOT set an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin⑤">origin</a>'s <a data-link-type="dfn" href="#origin-prevent-silent-access-flag" id="ref-for-origin-prevent-silent-access-flag⑥"><code>prevent silent access</code> flag</a> to <code>false</code> without <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated①②">user mediation</a>. For example, the <a data-link-type="dfn" href="#credential-chooser" id="ref-for-credential-chooser⑨">credential chooser</a> described in <a href="#user-mediated-selection">§5.3 Credential Selection</a> could have a checkbox which the user could toggle to mark a
   credential as available without mediation for the origin, or the user agent could have an
   onboarding process for its credential manager which asked a user for a default setting.</p>
      <li data-md="">
@@ -2959,10 +2965,10 @@ store user credentials for future use.</p>
   form of an icon in the address bar, or some similar location.</p>
      <li data-md="">
       <p>If a user clears her browsing data for an origin (cookies, localStorage, and so on), the user
-  agent MUST set the <a data-link-type="dfn" href="#origin-prevent-silent-access-flag" id="ref-for-origin-prevent-silent-access-flag-8"><code>prevent silent access</code> flag</a> to <code>true</code> for that origin.</p>
+  agent MUST set the <a data-link-type="dfn" href="#origin-prevent-silent-access-flag" id="ref-for-origin-prevent-silent-access-flag⑦"><code>prevent silent access</code> flag</a> to <code>true</code> for that origin.</p>
     </ol>
     <h3 class="heading settled" data-level="5.3" id="user-mediated-selection"><span class="secno">5.3. </span><span class="content">Credential Selection</span><a class="self-link" href="#user-mediated-selection"></a></h3>
-    <p>When responding to a call to <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get-20">get()</a></code> on an origin which requires <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated-14">user mediation</a>, user agents MUST ask the user for permission to share credential information.
+    <p>When responding to a call to <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get①⑨">get()</a></code> on an origin which requires <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated①③">user mediation</a>, user agents MUST ask the user for permission to share credential information.
   This SHOULD take the form of a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="credential-chooser">credential chooser</dfn> which presents the user with a
   list of credentials that are available for use on a site, allowing them to select one which should
   be provided to the website, or to reject the request entirely.</p>
@@ -2970,9 +2976,9 @@ store user credentials for future use.</p>
   website could produce. For example, the chooser might overlap the user agent’s UI in some
   unspoofable way.</p>
     <p>The chooser interface MUST include an indication of the origin which is requesting credentials.</p>
-    <p>The chooser interface SHOULD include all <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-44">Credential</a></code> objects associated with the origin that
+    <p>The chooser interface SHOULD include all <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential④③">Credential</a></code> objects associated with the origin that
   requested credentials.</p>
-    <p>User agents MAY internally associate information with each <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-45">Credential</a></code> object beyond the
+    <p>User agents MAY internally associate information with each <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential④④">Credential</a></code> object beyond the
   attributes specified in this document in order to enhance the utility of such a chooser. For
   example, favicons could help disambiguate identity providers, etc. Any additional information
   stored MUST not be exposed directly to the web.</p>
@@ -2981,21 +2987,21 @@ store user credentials for future use.</p>
   process of choosing a credential to present. That said, the interface to the chooser is as
   follows:</p>
     <section class="algorithm" data-algorithm="ask the user to choose">
-      The user agent can <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export="" data-local-lt="ask to choose" data-lt="ask the user to choose a Credential" id="abstract-opdef-ask-the-user-to-choose-a-credential">ask the user to choose a <code>Credential</code></dfn>, given a <code class="idl"><a data-link-type="idl" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions-16">CredentialRequestOptions</a></code> (<var>options</var>), and a set of <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-46">Credential</a></code> objects from the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store-25">credential store</a> (<var>locally discovered credentials</var>). 
+      The user agent can <dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export="" data-local-lt="ask to choose" data-lt="ask the user to choose a Credential" id="abstract-opdef-ask-the-user-to-choose-a-credential">ask the user to choose a <code>Credential</code></dfn>, given a <code class="idl"><a data-link-type="idl" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions①⑤">CredentialRequestOptions</a></code> (<var>options</var>), and a set of <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential④⑤">Credential</a></code> objects from the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store②④">credential store</a> (<var>locally discovered credentials</var>). 
      <p>This algorithm returns either <code>null</code> if the user chose not to share a credential with the site,
-    a <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-47">Credential</a></code> object if the user chose a specific credential, or a <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-48">Credential</a></code> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object">interface
+    a <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential④⑥">Credential</a></code> object if the user chose a specific credential, or a <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential④⑦">Credential</a></code> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object①⑦">interface
     object</a> if the user chose a type of credential.</p>
      <div class="note" role="note">
        It seems reasonable for the chooser interface to display the list of <var>locally discovered
       credentials</var> to the user, perhaps something like this exceptionally non-normative mock: 
       <p><img alt="A mockup of what a chooser might look like." src="./mock-chooser.png"></p>
-      <p>If the <var>options</var> provided is not <a data-link-type="dfn" href="#credentialrequestoptions-matchable-a-priori" id="ref-for-credentialrequestoptions-matchable-a-priori-3">matchable <i lang="la">a priori</i></a>, then it might
-      also make sense for the chooser interface to list the <a data-link-type="dfn" href="#credentialrequestoptions-relevant-credential-interface-objects" id="ref-for-credentialrequestoptions-relevant-credential-interface-objects-4">relevant credential interface
+      <p>If the <var>options</var> provided is not <a data-link-type="dfn" href="#credentialrequestoptions-matchable-a-priori" id="ref-for-credentialrequestoptions-matchable-a-priori②">matchable <i lang="la">a priori</i></a>, then it might
+      also make sense for the chooser interface to list the <a data-link-type="dfn" href="#credentialrequestoptions-relevant-credential-interface-objects" id="ref-for-credentialrequestoptions-relevant-credential-interface-objects③">relevant credential interface
       objects</a> for <var>options</var> that aren’t covered by the list of explicit credentials. If, for
       instance, a site accepts webauthn-style authenticators, then "Security Key" might show up
       in the chooser list with an appropriate icon.</p>
       <p>Also, note that in some cases the user agent may skip the chooser entirely. For example, if
-      the only <a data-link-type="dfn" href="#credentialrequestoptions-relevant-credential-interface-objects" id="ref-for-credentialrequestoptions-relevant-credential-interface-objects-5">relevant credential interface objects</a> is one that itself requires user
+      the only <a data-link-type="dfn" href="#credentialrequestoptions-relevant-credential-interface-objects" id="ref-for-credentialrequestoptions-relevant-credential-interface-objects④">relevant credential interface objects</a> is one that itself requires user
       interaction, the user agent may return that interface directly, and rely on its internal
       mediation flow for user consent.</p>
      </div>
@@ -3019,11 +3025,11 @@ store user credentials for future use.</p>
   secure transport), but the inverse would be dangerous.</p>
      <li data-md="">
       <p>MAY use the Public Suffix List <a data-link-type="biblio" href="#biblio-psl">[PSL]</a> to determine the effective scope of a credential by
-  comparing the <a data-link-type="dfn" href="https://publicsuffix.org/list/#">registerable domain</a> of the credential’s <code class="idl"><a data-link-type="idl" href="#dom-credential-origin-slot" id="ref-for-dom-credential-origin-slot-13">[[origin]]</a></code> with the
-  origin in which <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get-21">get()</a></code> is called. That is: credentials saved on <code>https://admin.example.com/</code> and <code>https://example.com/</code> MAY be offered to users when <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get-22">get()</a></code> is called from <code>https://www.example.com/</code>, and vice versa.</p>
+  comparing the <a data-link-type="dfn" href="https://publicsuffix.org/list/#">registerable domain</a> of the credential’s <code class="idl"><a data-link-type="idl" href="#dom-credential-origin-slot" id="ref-for-dom-credential-origin-slot①②">[[origin]]</a></code> with the
+  origin in which <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get②⓪">get()</a></code> is called. That is: credentials saved on <code>https://admin.example.com/</code> and <code>https://example.com/</code> MAY be offered to users when <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get②①">get()</a></code> is called from <code>https://www.example.com/</code>, and vice versa.</p>
      <li data-md="">
-      <p>MUST NOT offer credentials to an origin in response to <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get-23">get()</a></code> without <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated-15">user mediation</a> if the credential’s origin is not an exact match for the calling origin.
-  That is, <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-49">Credential</a></code> objects for <code>https://example.com</code> would not be returned directly to <code>https://www.example.com</code>, but could be offered to the user via the chooser.</p>
+      <p>MUST NOT offer credentials to an origin in response to <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get②②">get()</a></code> without <a data-link-type="dfn" href="#user-mediated" id="ref-for-user-mediated①④">user mediation</a> if the credential’s origin is not an exact match for the calling origin.
+  That is, <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential④⑧">Credential</a></code> objects for <code>https://example.com</code> would not be returned directly to <code>https://www.example.com</code>, but could be offered to the user via the chooser.</p>
     </ol>
     <h3 class="heading settled" data-level="6.2" id="security-leakage"><span class="secno">6.2. </span><span class="content">Credential Leakage</span><a class="self-link" href="#security-leakage"></a></h3>
     <p>Developers are well-advised to take
@@ -3032,14 +3038,14 @@ store user credentials for future use.</p>
   that the following directives are set, explicitly or implicitly, in their pages' policies:</p>
     <ul>
      <li data-md="">
-      <p><a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#script-src"><code>script-src</code></a> and <a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#object-src"><code>object-src</code></a> both restrict script execution on a page, making
+      <p><a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#script-src" id="ref-for-script-src"><code>script-src</code></a> and <a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#object-src" id="ref-for-object-src"><code>object-src</code></a> both restrict script execution on a page, making
   it less likely that a cross-site scripting attack will succeed in the first place. If sites
-  are populating <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/forms.html#the-form-element">form</a></code> elements, also <a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#form-action"><code>form-action</code></a> directives should be set.</p>
+  are populating <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/forms.html#the-form-element" id="ref-for-the-form-element②">form</a></code> elements, also <a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#form-action" id="ref-for-form-action"><code>form-action</code></a> directives should be set.</p>
      <li data-md="">
-      <p><a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#connect-src"><code>connect-src</code></a> restricts the origins to which <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-global-fetch">fetch()</a></code> may submit data (which
+      <p><a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#connect-src" id="ref-for-connect-src"><code>connect-src</code></a> restricts the origins to which <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-global-fetch" id="ref-for-dom-global-fetch①">fetch()</a></code> may submit data (which
   mitigates the risk that credentials could be exfiltrated to <code>evil.com</code>.</p>
      <li data-md="">
-      <p><a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#child-src"><code>child-src</code></a> restricts the nested browsing contexts which may be embedded in a page,
+      <p><a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#child-src" id="ref-for-child-src"><code>child-src</code></a> restricts the nested browsing contexts which may be embedded in a page,
   making it more difficult to inject a malicious <code>postMessage()</code> target. <a data-link-type="biblio" href="#biblio-webmessaging">[WEBMESSAGING]</a></p>
     </ul>
     <p>Developers should, of course, also properly escape input and output, and consider using other
@@ -3048,20 +3054,20 @@ store user credentials for future use.</p>
   to the ways in which credential data can be transmitted over the wire. It might be reasonable,
   for example, to define transmission mechanisms which are restricted to same-origin endpoints.</p>
     <h3 class="heading settled" data-level="6.3" id="insecure-sites"><span class="secno">6.3. </span><span class="content">Insecure Sites</span><a class="self-link" href="#insecure-sites"></a></h3>
-    <p>User agents MUST NOT expose the APIs defined here to environments which are not <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure
+    <p>User agents MUST NOT expose the APIs defined here to environments which are not <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context" id="ref-for-secure-context④">secure
   contexts</a>. User agents might implement autofill mechanisms which store user credentials and fill
-  sign-in forms on non-<a data-link-type="dfn" href="https://w3c.github.io/webappsec-mixed-content/#a-priori-authenticated-url"><i lang="la">a priori</i> authenticated URLs</a>, but those sites cannot
+  sign-in forms on non-<a data-link-type="dfn" href="https://w3c.github.io/webappsec-mixed-content/#a-priori-authenticated-url" id="ref-for-a-priori-authenticated-url①"><i lang="la">a priori</i> authenticated URLs</a>, but those sites cannot
   be trusted to interact directly with the credential manager in any meaningful way, and those sites
-  MUST NOT have access to credentials saved in <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure contexts</a>.</p>
+  MUST NOT have access to credentials saved in <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context" id="ref-for-secure-context⑤">secure contexts</a>.</p>
     <h3 class="heading settled" data-level="6.4" id="security-origin-confusion"><span class="secno">6.4. </span><span class="content">Origin Confusion</span><a class="self-link" href="#security-origin-confusion"></a></h3>
     <p>If framed pages have access to the APIs defined here, it might be possible to confuse a user into
-  granting access to credentials for an origin other than the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">top-level browsing context</a>,
+  granting access to credentials for an origin other than the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context" id="ref-for-top-level-browsing-context③">top-level browsing context</a>,
   which is the only security origin which users can reasonably be expected to understand.</p>
-    <p>Therefore, both <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get-24">get()</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-store" id="ref-for-dom-credentialscontainer-store-14">store()</a></code> will result in a rejected <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-promise">Promise</a></code> when called from
-  a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context">nested browsing context</a>, and the API and related interfaces are not exposed inside <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#worker">Worker</a></code> contexts.</p>
+    <p>Therefore, both <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get②③">get()</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-store" id="ref-for-dom-credentialscontainer-store①③">store()</a></code> will result in a rejected <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-promise" id="ref-for-idl-promise⑤">Promise</a></code> when called from
+  a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context">nested browsing context</a>, and the API and related interfaces are not exposed inside <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#worker-2" id="ref-for-worker-2">Worker</a></code> contexts.</p>
     <p>The algorithms in <a href="#algorithm-request">§2.5.1 Request a Credential</a> and <a href="#algorithm-store">§2.5.3 Store a Credential</a> contain more detail.</p>
     <h3 class="heading settled" data-level="6.5" id="security-timing"><span class="secno">6.5. </span><span class="content">Timing Attacks</span><a class="self-link" href="#security-timing"></a></h3>
-    <p>If the user has no credentials for an origin, a call to <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get-25">get()</a></code> will
+    <p>If the user has no credentials for an origin, a call to <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get②④">get()</a></code> will
   resolve very quickly indeed. A malicious website could distinguish between a user with no
   credentials and a user with credentials who chooses not to share them.</p>
     <p>User agents SHOULD also rate-limit credential requests. It’s almost certainly abusive for a page
@@ -3069,7 +3075,7 @@ store user credentials for future use.</p>
     <h3 class="heading settled" data-level="6.6" id="security-signout"><span class="secno">6.6. </span><span class="content">Signing-Out</span><a class="self-link" href="#security-signout"></a></h3>
     <p>If a user has chosen to automatically sign-in to websites, as discussed in <a href="#user-mediation-requirement">§5.2 Requiring User Mediation</a>, then the user agent will provide credentials to an origin
   whenever it asks for them. The website can instruct the user agent to suppress this behavior by
-  calling <code class="idl"><a data-link-type="idl" href="#credentialscontainer" id="ref-for-credentialscontainer-6">CredentialsContainer</a></code>'s <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-preventsilentaccess" id="ref-for-dom-credentialscontainer-preventsilentaccess-4">preventSilentAccess()</a></code> method, which
+  calling <code class="idl"><a data-link-type="idl" href="#credentialscontainer" id="ref-for-credentialscontainer⑤">CredentialsContainer</a></code>'s <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-preventsilentaccess" id="ref-for-dom-credentialscontainer-preventsilentaccess③">preventSilentAccess()</a></code> method, which
   will turn off automatic sign-in for a given origin.</p>
     <p>The user agent relies on the website to do the right thing; an inattentive (or malicious) website
   could simply neglect to call this method, causing the user agent to continue providing credentials
@@ -3077,20 +3083,20 @@ store user credentials for future use.</p>
   doesn’t clear user credentials when they click "Sign-out", as the user agent becomes complicit in
   the authentication.</p>
     <p>The user MUST have some control over this behavior. As noted in <a href="#user-mediation-requirement">§5.2 Requiring User Mediation</a>,
-  clearing cookies for an origin will also reset that origin’s <a data-link-type="dfn" href="#origin-prevent-silent-access-flag" id="ref-for-origin-prevent-silent-access-flag-9"><code>prevent silent access</code> flag</a> the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store-26">credential store</a> to <code>true</code>. Additionally, the user agent SHOULD provide some UI affordance
+  clearing cookies for an origin will also reset that origin’s <a data-link-type="dfn" href="#origin-prevent-silent-access-flag" id="ref-for-origin-prevent-silent-access-flag⑧"><code>prevent silent access</code> flag</a> the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store②⑤">credential store</a> to <code>true</code>. Additionally, the user agent SHOULD provide some UI affordance
   for disabling automatic sign-in for a particular origin. This could be tied to the notification
   that credentials have been provided to an origin, for example.</p>
     <h3 class="heading settled" data-level="6.7" id="security-chooser-leakage"><span class="secno">6.7. </span><span class="content">Chooser Leakage</span><a class="self-link" href="#security-chooser-leakage"></a></h3>
-    <p>If a user agent’s <a data-link-type="dfn" href="#credential-chooser" id="ref-for-credential-chooser-11">credential chooser</a> displays images supplied by an origin (for example, if a <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-50">Credential</a></code> displays a site’s favicon), then, requests for these images MUST NOT be directly
+    <p>If a user agent’s <a data-link-type="dfn" href="#credential-chooser" id="ref-for-credential-chooser①⓪">credential chooser</a> displays images supplied by an origin (for example, if a <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential④⑨">Credential</a></code> displays a site’s favicon), then, requests for these images MUST NOT be directly
   tied to instantiating the chooser in order to avoid leaking chooser usage. One option would be to
-  fetch the images in the background when saving or updating a <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-51">Credential</a></code>, and to cache them for
-  the lifetime of the <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-52">Credential</a></code>.</p>
-    <p>These images MUST be fetched with the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-credentials-mode">credentials mode</a> set to "<code>omit</code>", the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#request-service-workers-mode">service-workers mode</a> set to "<code>none</code>", the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">client</a> set to <code>null</code>, the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator">initiator</a> set to the empty string, and the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> "<code>subresource</code>".</p>
+  fetch the images in the background when saving or updating a <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential⑤⓪">Credential</a></code>, and to cache them for
+  the lifetime of the <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential⑤①">Credential</a></code>.</p>
+    <p>These images MUST be fetched with the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-credentials-mode" id="ref-for-concept-request-credentials-mode">credentials mode</a> set to "<code>omit</code>", the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#request-service-workers-mode" id="ref-for-request-service-workers-mode">service-workers mode</a> set to "<code>none</code>", the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client">client</a> set to <code>null</code>, the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-initiator" id="ref-for-concept-request-initiator">initiator</a> set to the empty string, and the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination">destination</a> "<code>subresource</code>".</p>
     <p>Moreover, if the user agent allows the user to change either the name or icon associated with the
   credential, the alterations to the data SHOULD NOT be exposed to the website (consider a user who
   names two credentials for an origin "My fake account" and "My real account", for instance).</p>
     <h3 class="heading settled" data-level="6.8" id="security-local-data"><span class="secno">6.8. </span><span class="content">Locally Stored Data</span><a class="self-link" href="#security-local-data"></a></h3>
-    <p>This API offers an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">origin</a> the ability to store data persistently along with a user’s profile.
+    <p>This API offers an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin⑥">origin</a> the ability to store data persistently along with a user’s profile.
   Since most user agents treat credential data differently than "browsing data" (cookies, etc.)
   this might have the side effect of surprising a user who might believe that all traces of an
   origin have been wiped out when they clear their cookies.</p>
@@ -3103,16 +3109,16 @@ store user credentials for future use.</p>
     <p><em>This section is non-normative.</em></p>
     <h3 class="heading settled" data-level="7.1" id="implementation-authors"><span class="secno">7.1. </span><span class="content">Website Authors</span><a class="self-link" href="#implementation-authors"></a></h3>
     <p class="issue" id="issue-8678ef20"><a class="self-link" href="#issue-8678ef20"></a> Add some thoughts here about when and how the API
-  should be used, especially with regard to <code class="idl"><a data-link-type="idl" href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation-15">mediation</a></code>. <a href="https://github.com/w3c/webappsec/issues/290">&lt;https://github.com/w3c/webappsec/issues/290></a></p>
-    <p class="issue" id="issue-1c5542f0"><a class="self-link" href="#issue-1c5542f0"></a> Describe encoding restrictions of submitting credentials by <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-global-fetch">fetch()</a></code> with
-  a <code class="idl"><a data-link-type="idl" href="https://xhr.spec.whatwg.org/#interface-formdata">FormData</a></code> body.</p>
+  should be used, especially with regard to <code class="idl"><a data-link-type="idl" href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation①④">mediation</a></code>. <a href="https://github.com/w3c/webappsec/issues/290">&lt;https://github.com/w3c/webappsec/issues/290></a></p>
+    <p class="issue" id="issue-1c5542f0"><a class="self-link" href="#issue-1c5542f0"></a> Describe encoding restrictions of submitting credentials by <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-global-fetch" id="ref-for-dom-global-fetch②">fetch()</a></code> with
+  a <code class="idl"><a data-link-type="idl" href="https://xhr.spec.whatwg.org/#interface-formdata" id="ref-for-interface-formdata②">FormData</a></code> body.</p>
     <h3 class="heading settled" data-level="7.2" id="implementation-extension"><span class="secno">7.2. </span><span class="content">Extension Points</span><a class="self-link" href="#implementation-extension"></a></h3>
     <p>This document provides a generic, high-level API that’s meant to be extended with specific types
-  of <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential-17">credentials</a> that serve specific authentication needs. Doing so is, hopefully,
+  of <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential①⑥">credentials</a> that serve specific authentication needs. Doing so is, hopefully,
   straightforward:</p>
     <ol>
      <li data-md="">
-      <p>Define a new interface that inherits from <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-53">Credential</a></code>:</p>
+      <p>Define a new interface that inherits from <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential⑤②">Credential</a></code>:</p>
       <div class="example" id="example-8cda5b28">
        <a class="self-link" href="#example-8cda5b28"></a> 
 <pre>[Exposed=Window,
@@ -3123,11 +3129,11 @@ interface ExampleCredential : Credential {
 </pre>
       </div>
      <li data-md="">
-      <p>Define appropriate <code class="idl"><a data-link-type="idl" href="#dom-credential-create-slot" id="ref-for-dom-credential-create-slot-2">[[Create]](options)</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-credential-collectfromcredentialstore-slot" id="ref-for-dom-credential-collectfromcredentialstore-slot-2">[[CollectFromCredentialStore]](options)</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-credential-discoverfromexternalsource-slot" id="ref-for-dom-credential-discoverfromexternalsource-slot-4">[[DiscoverFromExternalSource]](options)</a></code>, and <code class="idl"><a data-link-type="idl" href="#dom-credential-store-slot" id="ref-for-dom-credential-store-slot-2">[[Store]](credential)</a></code> methods on <code>ExampleCredential</code>'s <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object">interface object</a>. <code class="idl"><a data-link-type="idl" href="#dom-credential-collectfromcredentialstore-slot" id="ref-for-dom-credential-collectfromcredentialstore-slot-3">[[CollectFromCredentialStore]](options)</a></code> is appropriate for <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential-18">credentials</a> that remain <a data-link-type="dfn" href="#credential-effective" id="ref-for-credential-effective-4">effective</a> forever and
-  can therefore simply be copied out of the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store-27">credential store</a>, while <code class="idl"><a data-link-type="idl" href="#dom-credential-discoverfromexternalsource-slot" id="ref-for-dom-credential-discoverfromexternalsource-slot-5">[[DiscoverFromExternalSource]](options)</a></code> is appropriate for <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential-19">credentials</a> that need to be re-generated from a <a data-link-type="dfn" href="#credential-source" id="ref-for-credential-source-2">credential source</a>.</p>
+      <p>Define appropriate <code class="idl"><a data-link-type="idl" href="#dom-credential-create-slot" id="ref-for-dom-credential-create-slot②">[[Create]](options)</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-credential-collectfromcredentialstore-slot" id="ref-for-dom-credential-collectfromcredentialstore-slot①">[[CollectFromCredentialStore]](options)</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-credential-discoverfromexternalsource-slot" id="ref-for-dom-credential-discoverfromexternalsource-slot⑤">[[DiscoverFromExternalSource]](options)</a></code>, and <code class="idl"><a data-link-type="idl" href="#dom-credential-store-slot" id="ref-for-dom-credential-store-slot①">[[Store]](credential)</a></code> methods on <code>ExampleCredential</code>'s <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object①⑧">interface object</a>. <code class="idl"><a data-link-type="idl" href="#dom-credential-collectfromcredentialstore-slot" id="ref-for-dom-credential-collectfromcredentialstore-slot②">[[CollectFromCredentialStore]](options)</a></code> is appropriate for <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential①⑦">credentials</a> that remain <a data-link-type="dfn" href="#credential-effective" id="ref-for-credential-effective③">effective</a> forever and
+  can therefore simply be copied out of the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store②⑥">credential store</a>, while <code class="idl"><a data-link-type="idl" href="#dom-credential-discoverfromexternalsource-slot" id="ref-for-dom-credential-discoverfromexternalsource-slot⑥">[[DiscoverFromExternalSource]](options)</a></code> is appropriate for <a data-link-type="dfn" href="#concept-credential" id="ref-for-concept-credential①⑧">credentials</a> that need to be re-generated from a <a data-link-type="dfn" href="#credential-source" id="ref-for-credential-source①">credential source</a>.</p>
       <div class="example" id="example-b597dd69">
        <a class="self-link" href="#example-b597dd69"></a> <code>ExampleCredential</code>'s <code>[[CollectFromCredentialStore]](options)</code> internal method is called
-    with a CredentialRequestOptions object (<code>options</code>), and returns a set of <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-54">Credential</a></code> objects that match the options provided. If no matching <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-55">Credential</a></code> objects are
+    with a CredentialRequestOptions object (<code>options</code>), and returns a set of <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential⑤③">Credential</a></code> objects that match the options provided. If no matching <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential⑤④">Credential</a></code> objects are
     available, the returned set will be empty. 
        <ol>
         <li data-md="">
@@ -3135,7 +3141,7 @@ interface ExampleCredential : Credential {
         <li data-md="">
          <p>If <code>options</code>[<code>example</code>] is not truthy, return the empty set.</p>
         <li data-md="">
-         <p>For each <i>credential</i> in the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store-28">credential store</a>:</p>
+         <p>For each <i>credential</i> in the <a data-link-type="dfn" href="#concept-credential-store" id="ref-for-concept-credential-store②⑦">credential store</a>:</p>
          <ol>
           <li data-md="">
            <p>...</p>
@@ -3143,16 +3149,16 @@ interface ExampleCredential : Credential {
        </ol>
       </div>
      <li data-md="">
-      <p>Define the value of the <code>ExampleCredential</code> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object">interface object</a>'s <code class="idl"><a data-link-type="idl" href="#dom-credential-type-slot" id="ref-for-dom-credential-type-slot-6">[[type]]</a></code> slot:</p>
-      <div class="example" id="example-cff8c3fc"><a class="self-link" href="#example-cff8c3fc"></a> The <code>ExampleCredential</code> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object">interface object</a> has an internal slot named <code>[[type]]</code> whose
+      <p>Define the value of the <code>ExampleCredential</code> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object①⑨">interface object</a>'s <code class="idl"><a data-link-type="idl" href="#dom-credential-type-slot" id="ref-for-dom-credential-type-slot⑤">[[type]]</a></code> slot:</p>
+      <div class="example" id="example-cff8c3fc"><a class="self-link" href="#example-cff8c3fc"></a> The <code>ExampleCredential</code> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object②⓪">interface object</a> has an internal slot named <code>[[type]]</code> whose
     value is the string "<code>example</code>". </div>
      <li data-md="">
-      <p>Define the value of the <code>ExampleCredential</code> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object">interface object</a>'s <code class="idl"><a data-link-type="idl" href="#dom-credential-discovery-slot" id="ref-for-dom-credential-discovery-slot-4">[[discovery]]</a></code> slot:</p>
-      <div class="example" id="example-2f6a6ca1"><a class="self-link" href="#example-2f6a6ca1"></a> The <code>ExampleCredential</code> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object">interface object</a> has an internal slot named <code>[[type]]</code> whose
-    value is "<code class="idl"><a data-link-type="idl" href="#dom-credential-discovery-credential-store" id="ref-for-dom-credential-discovery-credential-store-4">credential store</a></code>". </div>
+      <p>Define the value of the <code>ExampleCredential</code> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object②①">interface object</a>'s <code class="idl"><a data-link-type="idl" href="#dom-credential-discovery-slot" id="ref-for-dom-credential-discovery-slot③">[[discovery]]</a></code> slot:</p>
+      <div class="example" id="example-2f6a6ca1"><a class="self-link" href="#example-2f6a6ca1"></a> The <code>ExampleCredential</code> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-interface-object" id="ref-for-dfn-interface-object②②">interface object</a> has an internal slot named <code>[[type]]</code> whose
+    value is "<code class="idl"><a data-link-type="idl" href="#dom-credential-discovery-credential-store" id="ref-for-dom-credential-discovery-credential-store③">credential store</a></code>". </div>
      <li data-md="">
-      <p>Extend <code class="idl"><a data-link-type="idl" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions-17">CredentialRequestOptions</a></code> with the options the new credential type needs to respond
-  reasonably to <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get-26">get()</a></code>:</p>
+      <p>Extend <code class="idl"><a data-link-type="idl" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions①⑥">CredentialRequestOptions</a></code> with the options the new credential type needs to respond
+  reasonably to <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get②⑤">get()</a></code>:</p>
       <div class="example" id="example-f0110d62">
        <a class="self-link" href="#example-f0110d62"></a> 
 <pre>dictionary ExampleCredentialRequestOptions {
@@ -3165,7 +3171,7 @@ partial dictionary CredentialRequestOptions {
 </pre>
       </div>
      <li data-md="">
-      <p>Extend <code class="idl"><a data-link-type="idl" href="#dictdef-credentialcreationoptions" id="ref-for-dictdef-credentialcreationoptions-11">CredentialCreationOptions</a></code> with the data the new credential type needs to create <code>Credential</code> objects in response to <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-create" id="ref-for-dom-credentialscontainer-create-7">create()</a></code>:</p>
+      <p>Extend <code class="idl"><a data-link-type="idl" href="#dictdef-credentialcreationoptions" id="ref-for-dictdef-credentialcreationoptions①⓪">CredentialCreationOptions</a></code> with the data the new credential type needs to create <code>Credential</code> objects in response to <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-create" id="ref-for-dom-credentialscontainer-create⑥">create()</a></code>:</p>
       <div class="example" id="example-17ce7fc3">
        <a class="self-link" href="#example-17ce7fc3"></a> 
 <pre>dictionary ExampleCredentialInit {
@@ -3179,8 +3185,8 @@ partial dictionary CredentialCreationOptions {
       </div>
     </ol>
     <p>You might also find that new primitives are necessary. For instance, you might want to return
-  many <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential-56">Credential</a></code> objects rather than just one in some sort of complicated, multi-factor
-  sign-in process. That might be accomplished in a generic fashion by adding a <code>getAll()</code> method to <code class="idl"><a data-link-type="idl" href="#credentialscontainer" id="ref-for-credentialscontainer-7">CredentialsContainer</a></code> which returned a <code>sequence&lt;Credential></code>, and defining a reasonable
+  many <code class="idl"><a data-link-type="idl" href="#credential" id="ref-for-credential⑤⑤">Credential</a></code> objects rather than just one in some sort of complicated, multi-factor
+  sign-in process. That might be accomplished in a generic fashion by adding a <code>getAll()</code> method to <code class="idl"><a data-link-type="idl" href="#credentialscontainer" id="ref-for-credentialscontainer⑥">CredentialsContainer</a></code> which returned a <code>sequence&lt;Credential></code>, and defining a reasonable
   mechanism for dealing with requesting credentials of distinct types.</p>
     <p>For any such extension, we recommend getting in touch with <a href="mailto:public-webappsec@w3.org">public-webappsec@</a> for consultation and review.</p>
     <h3 class="heading settled" data-level="7.3" id="browser-extensions"><span class="secno">7.3. </span><span class="content">Browser Extensions</span><a class="self-link" href="#browser-extensions"></a></h3>
@@ -3189,7 +3195,7 @@ partial dictionary CredentialCreationOptions {
   the behavior of third party credential management software in the same way
   that user agents can improve their own via this imperative approach.</p>
     <p>This could range from a complex new API that the user agent mediates, or
-  simply by allowing extensions to overwrite the <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get-27">get()</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-store" id="ref-for-dom-credentialscontainer-store-15">store()</a></code> endpoints for their own purposes.</p>
+  simply by allowing extensions to overwrite the <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get②⑥">get()</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-credentialscontainer-store" id="ref-for-dom-credentialscontainer-store①④">store()</a></code> endpoints for their own purposes.</p>
    </section>
    <section>
     <h2 class="heading settled" data-level="8" id="teh-futur"><span class="secno">8. </span><span class="content">Future Work</span><a class="self-link" href="#teh-futur"></a></h2>
@@ -3201,7 +3207,7 @@ partial dictionary CredentialCreationOptions {
   between users, identity providers, and websites. If the user agent can remove some of the risk and
   confusion associated with the typical authentication flows, users will be in a significantly
   better position than today.</p>
-    <p>A natural way to expose this information might be to extend the <code class="idl"><a data-link-type="idl" href="#federatedcredential" id="ref-for-federatedcredential-15">FederatedCredential</a></code> interface
+    <p>A natural way to expose this information might be to extend the <code class="idl"><a data-link-type="idl" href="#federatedcredential" id="ref-for-federatedcredential①④">FederatedCredential</a></code> interface
   with properties like authentication tokens, and possibly to add some form of manifest format with
   properties that declare the authentication type which the provider supports.</p>
     <p>The API described here is designed to be extensible enough to support use cases that require user
@@ -3369,6 +3375,7 @@ partial dictionary CredentialCreationOptions {
    <li><a href="#dom-credentialmediationrequirement-required">required</a><span>, in §2.3.2</span>
    <li><a href="#origin-requires-user-mediation">requires user mediation</a><span>, in §2.1</span>
    <li><a href="#abstract-opdef-credential-store-retrieve-a-list-of-credentials">Retrieve a list of credentials</a><span>, in §2.1</span>
+   <li><a href="#dom-credential-signal">signal</a><span>, in §2.2</span>
    <li><a href="#dom-credentialmediationrequirement-silent">silent</a><span>, in §2.3.2</span>
    <li><a href="#dom-credentialscontainer-store">store()</a><span>, in §2.3</span>
    <li><a href="#abstract-opdef-credential-store-store-a-credential">Store a credential</a><span>, in §2.1</span>
@@ -3381,6 +3388,7 @@ partial dictionary CredentialCreationOptions {
      <li><a href="#dom-passwordcredential-store-slot">method for PasswordCredential</a><span>, in §3.3.3</span>
      <li><a href="#dom-federatedcredential-store-slot">method for FederatedCredential</a><span>, in §4.2.3</span>
     </ul>
+   <li><a href="#concept-credman-terminated">terminated</a><span>, in §2.2.1</span>
    <li><a href="#dom-credential-type">type</a><span>, in §2.2</span>
    <li><a href="#dom-credential-type-slot">[[type]]</a><span>, in §2.2</span>
    <li><a href="#user-mediated">user mediated</a><span>, in §5</span>
@@ -3389,7 +3397,7 @@ partial dictionary CredentialCreationOptions {
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
   <ul class="index">
    <li>
-    <a data-link-type="biblio">[CSP]</a> defines the following terms:
+    <a data-link-type="biblio">[csp-3]</a> defines the following terms:
     <ul>
      <li><a href="https://w3c.github.io/webappsec-csp/#child-src">child-src</a>
      <li><a href="https://w3c.github.io/webappsec-csp/#connect-src">connect-src</a>
@@ -3400,6 +3408,8 @@ partial dictionary CredentialCreationOptions {
    <li>
     <a data-link-type="biblio">[DOM]</a> defines the following terms:
     <ul>
+     <li><a href="https://dom.spec.whatwg.org/#abortsignal">AbortSignal</a>
+     <li><a href="https://dom.spec.whatwg.org/#abortsignal-aborted-flag">aborted flag</a>
      <li><a href="https://dom.spec.whatwg.org/#context-object">context object</a>
      <li><a href="https://dom.spec.whatwg.org/#concept-tree-order">tree order</a>
     </ul>
@@ -3418,17 +3428,17 @@ partial dictionary CredentialCreationOptions {
     <a data-link-type="biblio">[HTML]</a> defines the following terms:
     <ul>
      <li><a href="https://html.spec.whatwg.org/multipage/forms.html#htmlformelement">HTMLFormElement</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#navigator">Navigator</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/workers.html#worker">Worker</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">Navigator</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/workers.html#worker-2">Worker</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#active-document">active document</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin">ascii serialization of an origin</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/origin.html#ascii-serialisation-of-an-origin">ascii serialization of an origin</a>
      <li><a href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete">autocomplete</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/forms.html#autofill-detail-tokens">autofill detail tokens</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens">autofill detail tokens</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">current settings object</a>
      <li><a href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-current-password">current-password</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a>
      <li><a href="https://html.spec.whatwg.org/multipage/forms.html#the-form-element">form</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/forms.html#form-owner">form owner</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#form-owner">form owner</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a>
      <li><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>
      <li><a href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-name">name <small>(for autocomplete)</small></a>
@@ -3436,13 +3446,13 @@ partial dictionary CredentialCreationOptions {
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context">nested browsing context</a>
      <li><a href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-new-password">new-password</a>
      <li><a href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-nickname">nickname</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">origin</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin">origin</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin <small>(for environment settings object)</small></a>
      <li><a href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-photo">photo</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">relevant realm</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document">responsible document</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">same origin</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/forms.html#dom-form-submit">submit()</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/origin.html#same-origin">same origin</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/forms.html#dom-form-submit-2">submit()</a>
      <li><a href="https://html.spec.whatwg.org/multipage/forms.html#category-submit">submittable elements</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">top-level browsing context</a>
      <li><a href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-username">username</a>
@@ -3454,7 +3464,7 @@ partial dictionary CredentialCreationOptions {
      <li><a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">ascii case-insensitive</a>
      <li><a href="https://infra.spec.whatwg.org/#list-contain">contain</a>
      <li><a href="https://infra.spec.whatwg.org/#iteration-continue">continue</a>
-     <li><a href="https://infra.spec.whatwg.org/#map-exists">exists</a>
+     <li><a href="https://infra.spec.whatwg.org/#map-exists">exist</a>
      <li><a href="https://infra.spec.whatwg.org/#list-size">size</a>
     </ul>
    <li>
@@ -3463,7 +3473,17 @@ partial dictionary CredentialCreationOptions {
      <li><a href="https://w3c.github.io/webappsec-mixed-content/#a-priori-authenticated-url">a priori authenticated url</a>
     </ul>
    <li>
+    <a data-link-type="biblio">[mixed-content-1]</a> defines the following terms:
+    <ul>
+     <li><a href="https://w3c.github.io/webappsec-mixed-content/#a-priori-authenticated-url">a priori authenticated url</a>
+    </ul>
+   <li>
     <a data-link-type="biblio">[promises-guide]</a> defines the following terms:
+    <ul>
+     <li><a href="https://www.w3.org/2001/tag/doc/promises-guide/#a-promise-rejected-with">a promise rejected with</a>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[promises-guide-1]</a> defines the following terms:
     <ul>
      <li><a href="https://www.w3.org/2001/tag/doc/promises-guide/#a-new-promise">a new promise</a>
      <li><a href="https://www.w3.org/2001/tag/doc/promises-guide/#a-promise-rejected-with">a promise rejected with</a>
@@ -3481,6 +3501,11 @@ partial dictionary CredentialCreationOptions {
      <li><a href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure context</a>
     </ul>
    <li>
+    <a data-link-type="biblio">[secure-contexts-1]</a> defines the following terms:
+    <ul>
+     <li><a href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure context</a>
+    </ul>
+   <li>
     <a data-link-type="biblio">[URL]</a> defines the following terms:
     <ul>
      <li><a href="https://url.spec.whatwg.org/#urlsearchparams">URLSearchParams</a>
@@ -3488,6 +3513,8 @@ partial dictionary CredentialCreationOptions {
    <li>
     <a data-link-type="biblio">[WebIDL]</a> defines the following terms:
     <ul>
+     <li><a href="https://heycam.github.io/webidl/#aborterror">AbortError</a>
+     <li><a href="https://heycam.github.io/webidl/#idl-DOMException">DOMException</a>
      <li><a href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a>
      <li><a href="https://heycam.github.io/webidl/#Exposed">Exposed</a>
      <li><a href="https://heycam.github.io/webidl/#NoInterfaceObject">NoInterfaceObject</a>
@@ -3535,8 +3562,6 @@ partial dictionary CredentialCreationOptions {
    <dd><cite><a href="https://publicsuffix.org/">Public Suffix List</a></cite>.    Mozilla Foundation.
    <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
-   <dt id="biblio-secure-contexts">[SECURE-CONTEXTS]
-   <dd>Mike West. <a href="https://www.w3.org/TR/secure-contexts/">Secure Contexts</a>. URL: <a href="https://www.w3.org/TR/secure-contexts/">https://www.w3.org/TR/secure-contexts/</a>
    <dt id="biblio-url">[URL]
    <dd>Anne van Kesteren. <a href="https://url.spec.whatwg.org/">URL Standard</a>. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
    <dt id="biblio-webidl">[WebIDL]
@@ -3548,113 +3573,116 @@ partial dictionary CredentialCreationOptions {
   <dl>
    <dt id="biblio-browserid">[BROWSERID]
    <dd>Ben Adida; et al. <a href="https://github.com/mozilla/id-specs/blob/prod/browserid/index.md">BrowserID</a>. 26 February 2013. URL: <a href="https://github.com/mozilla/id-specs/blob/prod/browserid/index.md">https://github.com/mozilla/id-specs/blob/prod/browserid/index.md</a>
+   <dt id="biblio-secure-contexts">[SECURE-CONTEXTS]
+   <dd>Mike West. <a href="https://www.w3.org/TR/secure-contexts/">Secure Contexts</a>. URL: <a href="https://www.w3.org/TR/secure-contexts/">https://www.w3.org/TR/secure-contexts/</a>
    <dt id="biblio-sri">[SRI]
    <dd>Devdatta Akhawe; et al. <a href="https://www.w3.org/TR/SRI/">Subresource Integrity</a>. URL: <a href="https://www.w3.org/TR/SRI/">https://www.w3.org/TR/SRI/</a>
    <dt id="biblio-web-login">[WEB-LOGIN]
    <dd>Jason Denizac; Robin Berjon; Anne van Kesteren. <a href="https://github.com/jden/web-login">web-login</a>. URL: <a href="https://github.com/jden/web-login">https://github.com/jden/web-login</a>
    <dt id="biblio-webauthn">[WEBAUTHN]
-   <dd>Vijay Bharadwaj; et al. <a href="https://www.w3.org/TR/webauthn/">Web Authentication: An API for accessing Public Key Credentials</a>. URL: <a href="https://www.w3.org/TR/webauthn/">https://www.w3.org/TR/webauthn/</a>
+   <dd>Vijay Bharadwaj; et al. <a href="https://www.w3.org/TR/webauthn/">Web Authentication: An API for accessing Public Key Credentials Level 1</a>. URL: <a href="https://www.w3.org/TR/webauthn/">https://www.w3.org/TR/webauthn/</a>
    <dt id="biblio-webmessaging">[WEBMESSAGING]
    <dd>Ian Hickson. <a href="https://www.w3.org/TR/webmessaging/">HTML5 Web Messaging</a>. URL: <a href="https://www.w3.org/TR/webmessaging/">https://www.w3.org/TR/webmessaging/</a>
    <dt id="biblio-xmlhttprequest">[XMLHTTPREQUEST]
    <dd>Anne van Kesteren; et al. <a href="https://www.w3.org/TR/XMLHttpRequest/">XMLHttpRequest Level 1</a>. URL: <a href="https://www.w3.org/TR/XMLHttpRequest/">https://www.w3.org/TR/XMLHttpRequest/</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
-<pre class="idl highlight def">[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">Window</span>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext">SecureContext</a>]
+<pre class="idl highlight def">[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed④">Exposed</a>=<span class="n">Window</span>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext⑥">SecureContext</a>]
 <span class="kt">interface</span> <a class="nv" href="#credential"><code>Credential</code></a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString"><span class="kt">USVString</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-credential-id">id</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-credential-type">type</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①⑧"><span class="kt">USVString</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-credential-id" id="ref-for-dom-credential-id①①">id</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑥"><span class="kt">DOMString</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-credential-type" id="ref-for-dom-credential-type③">type</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#abortsignal" id="ref-for-abortsignal④">AbortSignal</a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="AbortSignal" href="#dom-credential-signal" id="ref-for-dom-credential-signal①">signal</a>;
 };
 
-[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#NoInterfaceObject">NoInterfaceObject</a>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext">SecureContext</a>]
+[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#NoInterfaceObject" id="ref-for-NoInterfaceObject①">NoInterfaceObject</a>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext①①">SecureContext</a>]
 <span class="kt">interface</span> <a class="nv" href="#credentialuserdata"><code>CredentialUserData</code></a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString"><span class="kt">USVString</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-credentialuserdata-name">name</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString"><span class="kt">USVString</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-credentialuserdata-iconurl">iconURL</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString②①"><span class="kt">USVString</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-credentialuserdata-name" id="ref-for-dom-credentialuserdata-name①①">name</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString③①"><span class="kt">USVString</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-credentialuserdata-iconurl" id="ref-for-dom-credentialuserdata-iconurl①①">iconURL</a>;
 };
 
-<span class="kt">partial</span> <span class="kt">interface</span> <a class="nv idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/webappapis.html#navigator">Navigator</a> {
-  [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext">SecureContext</a>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SameObject">SameObject</a>] <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#credentialscontainer">CredentialsContainer</a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="CredentialsContainer" href="#dom-navigator-credentials">credentials</a>;
+<span class="kt">partial</span> <span class="kt">interface</span> <a class="nv idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/system-state.html#navigator" id="ref-for-navigator①①">Navigator</a> {
+  [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext②①">SecureContext</a>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SameObject" id="ref-for-SameObject①">SameObject</a>] <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#credentialscontainer" id="ref-for-credentialscontainer②①">CredentialsContainer</a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="CredentialsContainer" href="#dom-navigator-credentials" id="ref-for-dom-navigator-credentials①①">credentials</a>;
 };
 
-[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">Window</span>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext">SecureContext</a>]
+[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①①">Exposed</a>=<span class="n">Window</span>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext③①">SecureContext</a>]
 <span class="kt">interface</span> <a class="nv" href="#credentialscontainer"><code>CredentialsContainer</code></a> {
-  <span class="kt">Promise</span>&lt;<a class="n" data-link-type="idl-name" href="#credential">Credential</a>?> <a class="nv idl-code" data-link-type="method" href="#dom-credentialscontainer-get">get</a>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-credentialrequestoptions">CredentialRequestOptions</a> <a class="nv idl-code" data-link-type="argument" href="#dom-credentialscontainer-get-options-options">options</a>);
-  <span class="kt">Promise</span>&lt;<a class="n" data-link-type="idl-name" href="#credential">Credential</a>> <a class="nv idl-code" data-link-type="method" href="#dom-credentialscontainer-store">store</a>(<a class="n" data-link-type="idl-name" href="#credential">Credential</a> <a class="nv idl-code" data-link-type="argument" href="#dom-credentialscontainer-store-credential-credential">credential</a>);
-  <span class="kt">Promise</span>&lt;<a class="n" data-link-type="idl-name" href="#credential">Credential</a>?> <a class="nv idl-code" data-link-type="method" href="#dom-credentialscontainer-create">create</a>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-credentialcreationoptions">CredentialCreationOptions</a> <a class="nv idl-code" data-link-type="argument" href="#dom-credentialscontainer-create-options-options">options</a>);
-  <span class="kt">Promise</span>&lt;<span class="kt">void</span>> <a class="nv idl-code" data-link-type="method" href="#dom-credentialscontainer-preventsilentaccess">preventSilentAccess</a>();
+  <span class="kt">Promise</span>&lt;<a class="n" data-link-type="idl-name" href="#credential" id="ref-for-credential②⓪①">Credential</a>?> <a class="nv idl-code" data-link-type="method" href="#dom-credentialscontainer-get" id="ref-for-dom-credentialscontainer-get②⑦">get</a>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions②①">CredentialRequestOptions</a> <a class="nv idl-code" data-link-type="argument" href="#dom-credentialscontainer-get-options-options" id="ref-for-dom-credentialscontainer-get-options-options②">options</a>);
+  <span class="kt">Promise</span>&lt;<a class="n" data-link-type="idl-name" href="#credential" id="ref-for-credential②①①">Credential</a>> <a class="nv idl-code" data-link-type="method" href="#dom-credentialscontainer-store" id="ref-for-dom-credentialscontainer-store①⑤">store</a>(<a class="n" data-link-type="idl-name" href="#credential" id="ref-for-credential②②①">Credential</a> <a class="nv idl-code" data-link-type="argument" href="#dom-credentialscontainer-store-credential-credential" id="ref-for-dom-credentialscontainer-store-credential-credential②">credential</a>);
+  <span class="kt">Promise</span>&lt;<a class="n" data-link-type="idl-name" href="#credential" id="ref-for-credential②③①">Credential</a>?> <a class="nv idl-code" data-link-type="method" href="#dom-credentialscontainer-create" id="ref-for-dom-credentialscontainer-create⑦">create</a>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-credentialcreationoptions" id="ref-for-dictdef-credentialcreationoptions①①">CredentialCreationOptions</a> <a class="nv idl-code" data-link-type="argument" href="#dom-credentialscontainer-create-options-options" id="ref-for-dom-credentialscontainer-create-options-options②">options</a>);
+  <span class="kt">Promise</span>&lt;<span class="kt">void</span>> <a class="nv idl-code" data-link-type="method" href="#dom-credentialscontainer-preventsilentaccess" id="ref-for-dom-credentialscontainer-preventsilentaccess④">preventSilentAccess</a>();
 };
 
 <span class="kt">dictionary</span> <a class="nv" href="#dictdef-credentialdata"><code>CredentialData</code></a> {
-  <span class="kt">required</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString"><span class="kt">USVString</span></a> <a class="nv" data-type="USVString " href="#dom-credentialdata-id"><code>id</code></a>;
+  <span class="kt">required</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑥①"><span class="kt">USVString</span></a> <a class="nv" data-type="USVString " href="#dom-credentialdata-id"><code>id</code></a>;
 };
 
 <span class="kt">dictionary</span> <a class="nv" href="#dictdef-credentialrequestoptions"><code>CredentialRequestOptions</code></a> {
-  <a class="n" data-link-type="idl-name" href="#enumdef-credentialmediationrequirement">CredentialMediationRequirement</a> <a class="nv idl-code" data-default="&quot;optional&quot;" data-link-type="dict-member" data-type="CredentialMediationRequirement " href="#dom-credentialrequestoptions-mediation">mediation</a> = "optional";
+  <a class="n" data-link-type="idl-name" href="#enumdef-credentialmediationrequirement" id="ref-for-enumdef-credentialmediationrequirement④">CredentialMediationRequirement</a> <a class="nv idl-code" data-default="&quot;optional&quot;" data-link-type="dict-member" data-type="CredentialMediationRequirement " href="#dom-credentialrequestoptions-mediation" id="ref-for-dom-credentialrequestoptions-mediation①⑤">mediation</a> = "optional";
 };
 
 <span class="kt">enum</span> <a class="nv" href="#enumdef-credentialmediationrequirement"><code>CredentialMediationRequirement</code></a> {
-  <a class="s idl-code" data-link-type="enum-value" href="#dom-credentialmediationrequirement-silent">"silent"</a>,
-  <a class="s idl-code" data-link-type="enum-value" href="#dom-credentialmediationrequirement-optional">"optional"</a>,
-  <a class="s idl-code" data-link-type="enum-value" href="#dom-credentialmediationrequirement-required">"required"</a>
+  <a class="s idl-code" data-link-type="enum-value" href="#dom-credentialmediationrequirement-silent" id="ref-for-dom-credentialmediationrequirement-silent①①">"silent"</a>,
+  <a class="s idl-code" data-link-type="enum-value" href="#dom-credentialmediationrequirement-optional" id="ref-for-dom-credentialmediationrequirement-optional①①">"optional"</a>,
+  <a class="s idl-code" data-link-type="enum-value" href="#dom-credentialmediationrequirement-required" id="ref-for-dom-credentialmediationrequirement-required⑥">"required"</a>
 };
 
 <span class="kt">dictionary</span> <a class="nv" href="#dictdef-credentialcreationoptions"><code>CredentialCreationOptions</code></a> {
 };
 
-<span class="kt">typedef</span> (<a class="n" data-link-type="idl-name" href="https://xhr.spec.whatwg.org/#interface-formdata">FormData</a> <span class="kt">or</span> <a class="n" data-link-type="idl-name" href="https://url.spec.whatwg.org/#urlsearchparams">URLSearchParams</a>) <a class="nv" href="#typedefdef-credentialbodytype"><code>CredentialBodyType</code></a>;
+<span class="kt">typedef</span> (<a class="n" data-link-type="idl-name" href="https://xhr.spec.whatwg.org/#interface-formdata" id="ref-for-interface-formdata③">FormData</a> <span class="kt">or</span> <a class="n" data-link-type="idl-name" href="https://url.spec.whatwg.org/#urlsearchparams" id="ref-for-urlsearchparams①">URLSearchParams</a>) <a class="nv" href="#typedefdef-credentialbodytype"><code>CredentialBodyType</code></a>;
 
-[<a class="nv idl-code" data-link-type="constructor" href="#dom-passwordcredential-passwordcredential">Constructor</a>(<a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/forms.html#htmlformelement">HTMLFormElement</a> <a class="nv" href="#dom-passwordcredential-passwordcredential-form-form"><code>form</code></a>),
- <a class="nv idl-code" data-link-type="constructor" href="#dom-passwordcredential-passwordcredential-data">Constructor</a>(<a class="n" data-link-type="idl-name" href="#dictdef-passwordcredentialdata">PasswordCredentialData</a> <a class="nv" href="#dom-passwordcredential-passwordcredential-data-data"><code>data</code></a>),
- <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">Window</span>,
- <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext">SecureContext</a>]
-<span class="kt">interface</span> <a class="nv" href="#passwordcredential"><code>PasswordCredential</code></a> : <a class="n" data-link-type="idl-name" href="#credential">Credential</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString"><span class="kt">USVString</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-passwordcredential-password">password</a>;
+[<a class="nv idl-code" data-link-type="constructor" href="#dom-passwordcredential-passwordcredential" id="ref-for-dom-passwordcredential-passwordcredential②①">Constructor</a>(<a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/forms.html#htmlformelement" id="ref-for-htmlformelement②①">HTMLFormElement</a> <a class="nv" href="#dom-passwordcredential-passwordcredential-form-form"><code>form</code></a>),
+ <a class="nv idl-code" data-link-type="constructor" href="#dom-passwordcredential-passwordcredential-data" id="ref-for-dom-passwordcredential-passwordcredential-data①">Constructor</a>(<a class="n" data-link-type="idl-name" href="#dictdef-passwordcredentialdata" id="ref-for-dictdef-passwordcredentialdata⑧">PasswordCredentialData</a> <a class="nv" href="#dom-passwordcredential-passwordcredential-data-data"><code>data</code></a>),
+ <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed②①">Exposed</a>=<span class="n">Window</span>,
+ <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext④①">SecureContext</a>]
+<span class="kt">interface</span> <a class="nv" href="#passwordcredential"><code>PasswordCredential</code></a> : <a class="n" data-link-type="idl-name" href="#credential" id="ref-for-credential③⑤①">Credential</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑦①"><span class="kt">USVString</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-passwordcredential-password" id="ref-for-dom-passwordcredential-password⑥">password</a>;
 };
-<a class="n" data-link-type="idl-name" href="#passwordcredential">PasswordCredential</a> <span class="kt">implements</span> <a class="n" data-link-type="idl-name" href="#credentialuserdata">CredentialUserData</a>;
+<a class="n" data-link-type="idl-name" href="#passwordcredential" id="ref-for-passwordcredential④①">PasswordCredential</a> <span class="kt">implements</span> <a class="n" data-link-type="idl-name" href="#credentialuserdata" id="ref-for-credentialuserdata②">CredentialUserData</a>;
 
-<span class="kt">partial</span> <span class="kt">dictionary</span> <a class="nv idl-code" data-link-type="dictionary" href="#dictdef-credentialrequestoptions">CredentialRequestOptions</a> {
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv" data-default="false" data-type="boolean " href="#dom-credentialrequestoptions-password"><code>password</code></a> = <span class="kt">false</span>;
-};
-
-<span class="kt">dictionary</span> <a class="nv" href="#dictdef-passwordcredentialdata"><code>PasswordCredentialData</code></a> : <a class="n" data-link-type="idl-name" href="#dictdef-credentialdata">CredentialData</a> {
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString"><span class="kt">USVString</span></a> <a class="nv" data-type="USVString " href="#dom-passwordcredentialdata-name"><code>name</code></a>;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString"><span class="kt">USVString</span></a> <a class="nv" data-type="USVString " href="#dom-passwordcredentialdata-iconurl"><code>iconURL</code></a>;
-  <span class="kt">required</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString"><span class="kt">USVString</span></a> <a class="nv" data-type="USVString " href="#dom-passwordcredentialdata-password"><code>password</code></a>;
+<span class="kt">partial</span> <span class="kt">dictionary</span> <a class="nv idl-code" data-link-type="dictionary" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions①⓪①">CredentialRequestOptions</a> {
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①"><span class="kt">boolean</span></a> <a class="nv" data-default="false" data-type="boolean " href="#dom-credentialrequestoptions-password"><code>password</code></a> = <span class="kt">false</span>;
 };
 
-<span class="kt">typedef</span> (<a class="n" data-link-type="idl-name" href="#dictdef-passwordcredentialdata">PasswordCredentialData</a> <span class="kt">or</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/forms.html#htmlformelement">HTMLFormElement</a>) <a class="nv" href="#typedefdef-passwordcredentialinit"><code>PasswordCredentialInit</code></a>;
-
-<span class="kt">partial</span> <span class="kt">dictionary</span> <a class="nv idl-code" data-link-type="dictionary" href="#dictdef-credentialcreationoptions">CredentialCreationOptions</a> {
-  <a class="n" data-link-type="idl-name" href="#typedefdef-passwordcredentialinit">PasswordCredentialInit</a> <a class="nv" data-type="PasswordCredentialInit " href="#dom-credentialcreationoptions-password"><code>password</code></a>;
+<span class="kt">dictionary</span> <a class="nv" href="#dictdef-passwordcredentialdata"><code>PasswordCredentialData</code></a> : <a class="n" data-link-type="idl-name" href="#dictdef-credentialdata" id="ref-for-dictdef-credentialdata②">CredentialData</a> {
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑨①"><span class="kt">USVString</span></a> <a class="nv" data-type="USVString " href="#dom-passwordcredentialdata-name"><code>name</code></a>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①⓪①"><span class="kt">USVString</span></a> <a class="nv" data-type="USVString " href="#dom-passwordcredentialdata-iconurl"><code>iconURL</code></a>;
+  <span class="kt">required</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①①①"><span class="kt">USVString</span></a> <a class="nv" data-type="USVString " href="#dom-passwordcredentialdata-password"><code>password</code></a>;
 };
 
-[<a class="nv idl-code" data-link-type="constructor" href="#dom-federatedcredential-federatedcredential">Constructor</a>(<a class="n" data-link-type="idl-name" href="#dictdef-federatedcredentialinit">FederatedCredentialInit</a> <a class="nv" href="#dom-federatedcredential-federatedcredential-data-data"><code>data</code></a>),
- <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">Window</span>,
- <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext">SecureContext</a>]
-<span class="kt">interface</span> <a class="nv" href="#federatedcredential"><code>FederatedCredential</code></a> : <a class="n" data-link-type="idl-name" href="#credential">Credential</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString"><span class="kt">USVString</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-federatedcredential-provider">provider</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a>? <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString?" href="#dom-federatedcredential-protocol">protocol</a>;
+<span class="kt">typedef</span> (<a class="n" data-link-type="idl-name" href="#dictdef-passwordcredentialdata" id="ref-for-dictdef-passwordcredentialdata③①">PasswordCredentialData</a> <span class="kt">or</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/forms.html#htmlformelement" id="ref-for-htmlformelement⑤①">HTMLFormElement</a>) <a class="nv" href="#typedefdef-passwordcredentialinit"><code>PasswordCredentialInit</code></a>;
+
+<span class="kt">partial</span> <span class="kt">dictionary</span> <a class="nv idl-code" data-link-type="dictionary" href="#dictdef-credentialcreationoptions" id="ref-for-dictdef-credentialcreationoptions⑤①">CredentialCreationOptions</a> {
+  <a class="n" data-link-type="idl-name" href="#typedefdef-passwordcredentialinit" id="ref-for-typedefdef-passwordcredentialinit①">PasswordCredentialInit</a> <a class="nv" data-type="PasswordCredentialInit " href="#dom-credentialcreationoptions-password"><code>password</code></a>;
 };
-<a class="n" data-link-type="idl-name" href="#federatedcredential">FederatedCredential</a> <span class="kt">implements</span> <a class="n" data-link-type="idl-name" href="#credentialuserdata">CredentialUserData</a>;
+
+[<a class="nv idl-code" data-link-type="constructor" href="#dom-federatedcredential-federatedcredential" id="ref-for-dom-federatedcredential-federatedcredential①">Constructor</a>(<a class="n" data-link-type="idl-name" href="#dictdef-federatedcredentialinit" id="ref-for-dictdef-federatedcredentialinit⑤">FederatedCredentialInit</a> <a class="nv" href="#dom-federatedcredential-federatedcredential-data-data"><code>data</code></a>),
+ <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed③①">Exposed</a>=<span class="n">Window</span>,
+ <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext⑤①">SecureContext</a>]
+<span class="kt">interface</span> <a class="nv" href="#federatedcredential"><code>FederatedCredential</code></a> : <a class="n" data-link-type="idl-name" href="#credential" id="ref-for-credential③⑨①">Credential</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①②①"><span class="kt">USVString</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-federatedcredential-provider" id="ref-for-dom-federatedcredential-provider⑨">provider</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②①"><span class="kt">DOMString</span></a>? <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString?" href="#dom-federatedcredential-protocol" id="ref-for-dom-federatedcredential-protocol④">protocol</a>;
+};
+<a class="n" data-link-type="idl-name" href="#federatedcredential" id="ref-for-federatedcredential①⑤">FederatedCredential</a> <span class="kt">implements</span> <a class="n" data-link-type="idl-name" href="#credentialuserdata" id="ref-for-credentialuserdata①①">CredentialUserData</a>;
 
 <span class="kt">dictionary</span> <a class="nv" href="#dictdef-federatedcredentialrequestoptions"><code>FederatedCredentialRequestOptions</code></a> {
-  <span class="kt">sequence</span>&lt;<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString"><span class="kt">USVString</span></a>> <a class="nv" data-type="sequence<USVString> " href="#dom-federatedcredentialrequestoptions-providers"><code>providers</code></a>;
-  <span class="kt">sequence</span>&lt;<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a>> <a class="nv" data-type="sequence<DOMString> " href="#dom-federatedcredentialrequestoptions-protocols"><code>protocols</code></a>;
+  <span class="kt">sequence</span>&lt;<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①③①"><span class="kt">USVString</span></a>> <a class="nv" data-type="sequence<USVString> " href="#dom-federatedcredentialrequestoptions-providers"><code>providers</code></a>;
+  <span class="kt">sequence</span>&lt;<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString③①"><span class="kt">DOMString</span></a>> <a class="nv" data-type="sequence<DOMString> " href="#dom-federatedcredentialrequestoptions-protocols"><code>protocols</code></a>;
 };
 
-<span class="kt">partial</span> <span class="kt">dictionary</span> <a class="nv idl-code" data-link-type="dictionary" href="#dictdef-credentialrequestoptions">CredentialRequestOptions</a> {
-  <a class="n" data-link-type="idl-name" href="#dictdef-federatedcredentialrequestoptions">FederatedCredentialRequestOptions</a> <a class="nv" data-type="FederatedCredentialRequestOptions " href="#dom-credentialrequestoptions-federated"><code>federated</code></a>;
+<span class="kt">partial</span> <span class="kt">dictionary</span> <a class="nv idl-code" data-link-type="dictionary" href="#dictdef-credentialrequestoptions" id="ref-for-dictdef-credentialrequestoptions①③①">CredentialRequestOptions</a> {
+  <a class="n" data-link-type="idl-name" href="#dictdef-federatedcredentialrequestoptions" id="ref-for-dictdef-federatedcredentialrequestoptions②">FederatedCredentialRequestOptions</a> <a class="nv" data-type="FederatedCredentialRequestOptions " href="#dom-credentialrequestoptions-federated"><code>federated</code></a>;
 };
 
-<span class="kt">dictionary</span> <a class="nv" href="#dictdef-federatedcredentialinit"><code>FederatedCredentialInit</code></a> : <a class="n" data-link-type="idl-name" href="#dictdef-credentialdata">CredentialData</a> {
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString"><span class="kt">USVString</span></a> <a class="nv" data-type="USVString " href="#dom-federatedcredentialinit-name"><code>name</code></a>;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString"><span class="kt">USVString</span></a> <a class="nv" data-type="USVString " href="#dom-federatedcredentialinit-iconurl"><code>iconURL</code></a>;
-  <span class="kt">required</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString"><span class="kt">USVString</span></a> <a class="nv" data-type="USVString " href="#dom-federatedcredentialinit-provider"><code>provider</code></a>;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <a class="nv" data-type="DOMString " href="#dom-federatedcredentialinit-protocol"><code>protocol</code></a>;
+<span class="kt">dictionary</span> <a class="nv" href="#dictdef-federatedcredentialinit"><code>FederatedCredentialInit</code></a> : <a class="n" data-link-type="idl-name" href="#dictdef-credentialdata" id="ref-for-dictdef-credentialdata①①">CredentialData</a> {
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①⑤①"><span class="kt">USVString</span></a> <a class="nv" data-type="USVString " href="#dom-federatedcredentialinit-name"><code>name</code></a>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①⑥①"><span class="kt">USVString</span></a> <a class="nv" data-type="USVString " href="#dom-federatedcredentialinit-iconurl"><code>iconURL</code></a>;
+  <span class="kt">required</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①⑦①"><span class="kt">USVString</span></a> <a class="nv" data-type="USVString " href="#dom-federatedcredentialinit-provider"><code>provider</code></a>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑤①"><span class="kt">DOMString</span></a> <a class="nv" data-type="DOMString " href="#dom-federatedcredentialinit-protocol"><code>protocol</code></a>;
 };
 
-<span class="kt">partial</span> <span class="kt">dictionary</span> <a class="nv idl-code" data-link-type="dictionary" href="#dictdef-credentialcreationoptions">CredentialCreationOptions</a> {
-  <a class="n" data-link-type="idl-name" href="#dictdef-federatedcredentialinit">FederatedCredentialInit</a> <a class="nv" data-type="FederatedCredentialInit " href="#dom-credentialcreationoptions-federated"><code>federated</code></a>;
+<span class="kt">partial</span> <span class="kt">dictionary</span> <a class="nv idl-code" data-link-type="dictionary" href="#dictdef-credentialcreationoptions" id="ref-for-dictdef-credentialcreationoptions⑧①">CredentialCreationOptions</a> {
+  <a class="n" data-link-type="idl-name" href="#dictdef-federatedcredentialinit" id="ref-for-dictdef-federatedcredentialinit③①">FederatedCredentialInit</a> <a class="nv" data-type="FederatedCredentialInit " href="#dom-credentialcreationoptions-federated"><code>federated</code></a>;
 };
 
 </pre>
@@ -3676,779 +3704,797 @@ partial dictionary CredentialCreationOptions {
   <aside class="dfn-panel" data-for="concept-credential">
    <b><a href="#concept-credential">#concept-credential</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-credential-1">1. Introduction</a> <a href="#ref-for-concept-credential-2">(2)</a>
-    <li><a href="#ref-for-concept-credential-3">2. Core API</a> <a href="#ref-for-concept-credential-4">(2)</a> <a href="#ref-for-concept-credential-5">(3)</a> <a href="#ref-for-concept-credential-6">(4)</a>
-    <li><a href="#ref-for-concept-credential-7">2.1. Infrastructure</a> <a href="#ref-for-concept-credential-8">(2)</a> <a href="#ref-for-concept-credential-9">(3)</a> <a href="#ref-for-concept-credential-10">(4)</a> <a href="#ref-for-concept-credential-11">(5)</a> <a href="#ref-for-concept-credential-12">(6)</a> <a href="#ref-for-concept-credential-13">(7)</a>
-    <li><a href="#ref-for-concept-credential-14">2.2. The Credential Interface</a>
-    <li><a href="#ref-for-concept-credential-15">2.2.1. Credential Internal Methods</a>
-    <li><a href="#ref-for-concept-credential-16">3. Password Credentials</a>
-    <li><a href="#ref-for-concept-credential-17">7.2. Extension Points</a> <a href="#ref-for-concept-credential-18">(2)</a> <a href="#ref-for-concept-credential-19">(3)</a>
+    <li><a href="#ref-for-concept-credential">1. Introduction</a> <a href="#ref-for-concept-credential①">(2)</a>
+    <li><a href="#ref-for-concept-credential②">2. Core API</a> <a href="#ref-for-concept-credential③">(2)</a> <a href="#ref-for-concept-credential④">(3)</a> <a href="#ref-for-concept-credential⑤">(4)</a>
+    <li><a href="#ref-for-concept-credential⑥">2.1. Infrastructure</a> <a href="#ref-for-concept-credential⑦">(2)</a> <a href="#ref-for-concept-credential⑧">(3)</a> <a href="#ref-for-concept-credential⑨">(4)</a> <a href="#ref-for-concept-credential①⓪">(5)</a> <a href="#ref-for-concept-credential①①">(6)</a> <a href="#ref-for-concept-credential①②">(7)</a>
+    <li><a href="#ref-for-concept-credential①③">2.2. The Credential Interface</a>
+    <li><a href="#ref-for-concept-credential①④">2.2.1. Credential Internal Methods</a>
+    <li><a href="#ref-for-concept-credential①⑤">3. Password Credentials</a>
+    <li><a href="#ref-for-concept-credential①⑥">7.2. Extension Points</a> <a href="#ref-for-concept-credential①⑦">(2)</a> <a href="#ref-for-concept-credential①⑧">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="credential-effective">
    <b><a href="#credential-effective">#credential-effective</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-credential-effective-1">2.1. Infrastructure</a>
-    <li><a href="#ref-for-credential-effective-2">2.2. The Credential Interface</a>
-    <li><a href="#ref-for-credential-effective-3">2.2.1. Credential Internal Methods</a>
-    <li><a href="#ref-for-credential-effective-4">7.2. Extension Points</a>
+    <li><a href="#ref-for-credential-effective">2.1. Infrastructure</a>
+    <li><a href="#ref-for-credential-effective①">2.2. The Credential Interface</a>
+    <li><a href="#ref-for-credential-effective②">2.2.1. Credential Internal Methods</a>
+    <li><a href="#ref-for-credential-effective③">7.2. Extension Points</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="credential-source">
    <b><a href="#credential-source">#credential-source</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-credential-source-1">2.2.1. Credential Internal Methods</a>
-    <li><a href="#ref-for-credential-source-2">7.2. Extension Points</a>
+    <li><a href="#ref-for-credential-source">2.2.1. Credential Internal Methods</a>
+    <li><a href="#ref-for-credential-source①">7.2. Extension Points</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="concept-credential-store">
    <b><a href="#concept-credential-store">#concept-credential-store</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-credential-store-1">2.1. Infrastructure</a> <a href="#ref-for-concept-credential-store-2">(2)</a> <a href="#ref-for-concept-credential-store-3">(3)</a> <a href="#ref-for-concept-credential-store-4">(4)</a>
-    <li><a href="#ref-for-concept-credential-store-5">2.2. The Credential Interface</a> <a href="#ref-for-concept-credential-store-6">(2)</a>
-    <li><a href="#ref-for-concept-credential-store-7">2.2.1. Credential Internal Methods</a> <a href="#ref-for-concept-credential-store-8">(2)</a>
-    <li><a href="#ref-for-concept-credential-store-9">2.3. navigator.credentials</a>
-    <li><a href="#ref-for-concept-credential-store-10">2.5.3. Store a Credential</a>
-    <li><a href="#ref-for-concept-credential-store-11">2.5.5. Prevent Silent Access</a> <a href="#ref-for-concept-credential-store-12">(2)</a>
-    <li><a href="#ref-for-concept-credential-store-13">3.1.1. Password-based Sign-in</a>
-    <li><a href="#ref-for-concept-credential-store-14">3.3.1. 
-    PasswordCredential's [[CollectFromCredentialStore]](options) </a> <a href="#ref-for-concept-credential-store-15">(2)</a>
-    <li><a href="#ref-for-concept-credential-store-16">3.3.3. 
-    PasswordCredential's [[Store]](credential) </a> <a href="#ref-for-concept-credential-store-17">(2)</a> <a href="#ref-for-concept-credential-store-18">(3)</a>
-    <li><a href="#ref-for-concept-credential-store-19">4.2.1. 
-    FederatedCredential's [[CollectFromCredentialStore]](options) </a> <a href="#ref-for-concept-credential-store-20">(2)</a>
-    <li><a href="#ref-for-concept-credential-store-21">4.2.3. 
-    FederatedCredential's [[Store]](credential) </a> <a href="#ref-for-concept-credential-store-22">(2)</a> <a href="#ref-for-concept-credential-store-23">(3)</a>
-    <li><a href="#ref-for-concept-credential-store-24">5.2. Requiring User Mediation</a>
-    <li><a href="#ref-for-concept-credential-store-25">5.3. Credential Selection</a>
-    <li><a href="#ref-for-concept-credential-store-26">6.6. Signing-Out</a>
-    <li><a href="#ref-for-concept-credential-store-27">7.2. Extension Points</a> <a href="#ref-for-concept-credential-store-28">(2)</a>
+    <li><a href="#ref-for-concept-credential-store">2.1. Infrastructure</a> <a href="#ref-for-concept-credential-store①">(2)</a> <a href="#ref-for-concept-credential-store②">(3)</a> <a href="#ref-for-concept-credential-store③">(4)</a>
+    <li><a href="#ref-for-concept-credential-store④">2.2. The Credential Interface</a> <a href="#ref-for-concept-credential-store⑤">(2)</a>
+    <li><a href="#ref-for-concept-credential-store⑥">2.2.1. Credential Internal Methods</a> <a href="#ref-for-concept-credential-store⑦">(2)</a>
+    <li><a href="#ref-for-concept-credential-store⑧">2.3. navigator.credentials</a>
+    <li><a href="#ref-for-concept-credential-store⑨">2.5.3. Store a Credential</a>
+    <li><a href="#ref-for-concept-credential-store①⓪">2.5.5. Prevent Silent Access</a> <a href="#ref-for-concept-credential-store①①">(2)</a>
+    <li><a href="#ref-for-concept-credential-store①②">3.1.1. Password-based Sign-in</a>
+    <li><a href="#ref-for-concept-credential-store①③">3.3.1. 
+    PasswordCredential's [[CollectFromCredentialStore]](options) </a> <a href="#ref-for-concept-credential-store①④">(2)</a>
+    <li><a href="#ref-for-concept-credential-store①⑤">3.3.3. 
+    PasswordCredential's [[Store]](credential) </a> <a href="#ref-for-concept-credential-store①⑥">(2)</a> <a href="#ref-for-concept-credential-store①⑦">(3)</a>
+    <li><a href="#ref-for-concept-credential-store①⑧">4.2.1. 
+    FederatedCredential's [[CollectFromCredentialStore]](options) </a> <a href="#ref-for-concept-credential-store①⑨">(2)</a>
+    <li><a href="#ref-for-concept-credential-store②⓪">4.2.3. 
+    FederatedCredential's [[Store]](credential) </a> <a href="#ref-for-concept-credential-store②①">(2)</a> <a href="#ref-for-concept-credential-store②②">(3)</a>
+    <li><a href="#ref-for-concept-credential-store②③">5.2. Requiring User Mediation</a>
+    <li><a href="#ref-for-concept-credential-store②④">5.3. Credential Selection</a>
+    <li><a href="#ref-for-concept-credential-store②⑤">6.6. Signing-Out</a>
+    <li><a href="#ref-for-concept-credential-store②⑥">7.2. Extension Points</a> <a href="#ref-for-concept-credential-store②⑦">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="abstract-opdef-credential-store-retrieve-a-list-of-credentials">
    <b><a href="#abstract-opdef-credential-store-retrieve-a-list-of-credentials">#abstract-opdef-credential-store-retrieve-a-list-of-credentials</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-abstract-opdef-credential-store-retrieve-a-list-of-credentials-1">3.3.1. 
+    <li><a href="#ref-for-abstract-opdef-credential-store-retrieve-a-list-of-credentials">3.3.1. 
     PasswordCredential's [[CollectFromCredentialStore]](options) </a>
-    <li><a href="#ref-for-abstract-opdef-credential-store-retrieve-a-list-of-credentials-2">4.2.1. 
+    <li><a href="#ref-for-abstract-opdef-credential-store-retrieve-a-list-of-credentials①">4.2.1. 
     FederatedCredential's [[CollectFromCredentialStore]](options) </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="origin-prevent-silent-access-flag">
    <b><a href="#origin-prevent-silent-access-flag">#origin-prevent-silent-access-flag</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-origin-prevent-silent-access-flag-1">2.3. navigator.credentials</a>
-    <li><a href="#ref-for-origin-prevent-silent-access-flag-2">2.3.2. Mediation Requirements</a> <a href="#ref-for-origin-prevent-silent-access-flag-3">(2)</a>
-    <li><a href="#ref-for-origin-prevent-silent-access-flag-4">2.5.5. Prevent Silent Access</a>
-    <li><a href="#ref-for-origin-prevent-silent-access-flag-5">5.2. Requiring User Mediation</a> <a href="#ref-for-origin-prevent-silent-access-flag-6">(2)</a> <a href="#ref-for-origin-prevent-silent-access-flag-7">(3)</a> <a href="#ref-for-origin-prevent-silent-access-flag-8">(4)</a>
-    <li><a href="#ref-for-origin-prevent-silent-access-flag-9">6.6. Signing-Out</a>
+    <li><a href="#ref-for-origin-prevent-silent-access-flag">2.3. navigator.credentials</a>
+    <li><a href="#ref-for-origin-prevent-silent-access-flag①">2.3.2. Mediation Requirements</a> <a href="#ref-for-origin-prevent-silent-access-flag②">(2)</a>
+    <li><a href="#ref-for-origin-prevent-silent-access-flag③">2.5.5. Prevent Silent Access</a>
+    <li><a href="#ref-for-origin-prevent-silent-access-flag④">5.2. Requiring User Mediation</a> <a href="#ref-for-origin-prevent-silent-access-flag⑤">(2)</a> <a href="#ref-for-origin-prevent-silent-access-flag⑥">(3)</a> <a href="#ref-for-origin-prevent-silent-access-flag⑦">(4)</a>
+    <li><a href="#ref-for-origin-prevent-silent-access-flag⑧">6.6. Signing-Out</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="origin-requires-user-mediation">
    <b><a href="#origin-requires-user-mediation">#origin-requires-user-mediation</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-origin-requires-user-mediation-1">2.3.2. Mediation Requirements</a>
-    <li><a href="#ref-for-origin-requires-user-mediation-2">2.5.1. Request a Credential</a>
+    <li><a href="#ref-for-origin-requires-user-mediation">2.3.2. Mediation Requirements</a>
+    <li><a href="#ref-for-origin-requires-user-mediation①">2.5.1. Request a Credential</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="credential">
    <b><a href="#credential">#credential</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-credential-1">2. Core API</a> <a href="#ref-for-credential-2">(2)</a>
-    <li><a href="#ref-for-credential-3">2.2. The Credential Interface</a> <a href="#ref-for-credential-4">(2)</a> <a href="#ref-for-credential-5">(3)</a> <a href="#ref-for-credential-6">(4)</a> <a href="#ref-for-credential-7">(5)</a>
-    <li><a href="#ref-for-credential-8">2.2.1. Credential Internal Methods</a> <a href="#ref-for-credential-9">(2)</a> <a href="#ref-for-credential-10">(3)</a> <a href="#ref-for-credential-11">(4)</a> <a href="#ref-for-credential-12">(5)</a> <a href="#ref-for-credential-13">(6)</a> <a href="#ref-for-credential-14">(7)</a> <a href="#ref-for-credential-15">(8)</a> <a href="#ref-for-credential-16">(9)</a> <a href="#ref-for-credential-17">(10)</a> <a href="#ref-for-credential-18">(11)</a>
-    <li><a href="#ref-for-credential-19">2.2.2. CredentialUserData Mixin</a>
-    <li><a href="#ref-for-credential-20">2.3. navigator.credentials</a> <a href="#ref-for-credential-21">(2)</a> <a href="#ref-for-credential-22">(3)</a> <a href="#ref-for-credential-23">(4)</a> <a href="#ref-for-credential-24">(5)</a>
-    <li><a href="#ref-for-credential-25">2.3.1. The CredentialRequestOptions Dictionary</a> <a href="#ref-for-credential-26">(2)</a>
-    <li><a href="#ref-for-credential-27">2.4. The CredentialCreationOptions Dictionary</a>
-    <li><a href="#ref-for-credential-28">2.5.1. Request a Credential</a> <a href="#ref-for-credential-29">(2)</a> <a href="#ref-for-credential-30">(3)</a>
-    <li><a href="#ref-for-credential-31">2.5.2. Collect Credentials from the credential store</a> <a href="#ref-for-credential-32">(2)</a>
-    <li><a href="#ref-for-credential-33">2.5.3. Store a Credential</a>
-    <li><a href="#ref-for-credential-34">2.5.4. Create a Credential</a> <a href="#ref-for-credential-35">(2)</a>
-    <li><a href="#ref-for-credential-36">3.2. The PasswordCredential Interface</a> <a href="#ref-for-credential-37">(2)</a>
-    <li><a href="#ref-for-credential-38">3.3.1. 
-    PasswordCredential's [[CollectFromCredentialStore]](options) </a> <a href="#ref-for-credential-39">(2)</a>
-    <li><a href="#ref-for-credential-40">4.1. The FederatedCredential Interface</a> <a href="#ref-for-credential-41">(2)</a>
-    <li><a href="#ref-for-credential-42">4.2.1. 
-    FederatedCredential's [[CollectFromCredentialStore]](options) </a> <a href="#ref-for-credential-43">(2)</a>
-    <li><a href="#ref-for-credential-44">5.3. Credential Selection</a> <a href="#ref-for-credential-45">(2)</a> <a href="#ref-for-credential-46">(3)</a> <a href="#ref-for-credential-47">(4)</a> <a href="#ref-for-credential-48">(5)</a>
-    <li><a href="#ref-for-credential-49">6.1. Cross-domain credential access</a>
-    <li><a href="#ref-for-credential-50">6.7. Chooser Leakage</a> <a href="#ref-for-credential-51">(2)</a> <a href="#ref-for-credential-52">(3)</a>
-    <li><a href="#ref-for-credential-53">7.2. Extension Points</a> <a href="#ref-for-credential-54">(2)</a> <a href="#ref-for-credential-55">(3)</a> <a href="#ref-for-credential-56">(4)</a>
+    <li><a href="#ref-for-credential">2. Core API</a> <a href="#ref-for-credential①">(2)</a>
+    <li><a href="#ref-for-credential②">2.2. The Credential Interface</a> <a href="#ref-for-credential③">(2)</a> <a href="#ref-for-credential④">(3)</a> <a href="#ref-for-credential⑤">(4)</a> <a href="#ref-for-credential⑥">(5)</a>
+    <li><a href="#ref-for-credential⑦">2.2.1. Credential Internal Methods</a> <a href="#ref-for-credential⑧">(2)</a> <a href="#ref-for-credential⑨">(3)</a> <a href="#ref-for-credential①⓪">(4)</a> <a href="#ref-for-credential①①">(5)</a> <a href="#ref-for-credential①②">(6)</a> <a href="#ref-for-credential①③">(7)</a> <a href="#ref-for-credential①④">(8)</a> <a href="#ref-for-credential①⑤">(9)</a> <a href="#ref-for-credential①⑥">(10)</a> <a href="#ref-for-credential①⑦">(11)</a>
+    <li><a href="#ref-for-credential①⑧">2.2.2. CredentialUserData Mixin</a>
+    <li><a href="#ref-for-credential①⑨">2.3. navigator.credentials</a> <a href="#ref-for-credential②⓪">(2)</a> <a href="#ref-for-credential②①">(3)</a> <a href="#ref-for-credential②②">(4)</a> <a href="#ref-for-credential②③">(5)</a>
+    <li><a href="#ref-for-credential②④">2.3.1. The CredentialRequestOptions Dictionary</a> <a href="#ref-for-credential②⑤">(2)</a>
+    <li><a href="#ref-for-credential②⑥">2.4. The CredentialCreationOptions Dictionary</a>
+    <li><a href="#ref-for-credential②⑦">2.5.1. Request a Credential</a> <a href="#ref-for-credential②⑧">(2)</a> <a href="#ref-for-credential②⑨">(3)</a>
+    <li><a href="#ref-for-credential③⓪">2.5.2. Collect Credentials from the credential store</a> <a href="#ref-for-credential③①">(2)</a>
+    <li><a href="#ref-for-credential③②">2.5.3. Store a Credential</a>
+    <li><a href="#ref-for-credential③③">2.5.4. Create a Credential</a> <a href="#ref-for-credential③④">(2)</a>
+    <li><a href="#ref-for-credential③⑤">3.2. The PasswordCredential Interface</a> <a href="#ref-for-credential③⑥">(2)</a>
+    <li><a href="#ref-for-credential③⑦">3.3.1. 
+    PasswordCredential's [[CollectFromCredentialStore]](options) </a> <a href="#ref-for-credential③⑧">(2)</a>
+    <li><a href="#ref-for-credential③⑨">4.1. The FederatedCredential Interface</a> <a href="#ref-for-credential④⓪">(2)</a>
+    <li><a href="#ref-for-credential④①">4.2.1. 
+    FederatedCredential's [[CollectFromCredentialStore]](options) </a> <a href="#ref-for-credential④②">(2)</a>
+    <li><a href="#ref-for-credential④③">5.3. Credential Selection</a> <a href="#ref-for-credential④④">(2)</a> <a href="#ref-for-credential④⑤">(3)</a> <a href="#ref-for-credential④⑥">(4)</a> <a href="#ref-for-credential④⑦">(5)</a>
+    <li><a href="#ref-for-credential④⑧">6.1. Cross-domain credential access</a>
+    <li><a href="#ref-for-credential④⑨">6.7. Chooser Leakage</a> <a href="#ref-for-credential⑤⓪">(2)</a> <a href="#ref-for-credential⑤①">(3)</a>
+    <li><a href="#ref-for-credential⑤②">7.2. Extension Points</a> <a href="#ref-for-credential⑤③">(2)</a> <a href="#ref-for-credential⑤④">(3)</a> <a href="#ref-for-credential⑤⑤">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-credential-id">
    <b><a href="#dom-credential-id">#dom-credential-id</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-credential-id-1">2.2. The Credential Interface</a>
-    <li><a href="#ref-for-dom-credential-id-2">3.3.3. 
-    PasswordCredential's [[Store]](credential) </a> <a href="#ref-for-dom-credential-id-3">(2)</a> <a href="#ref-for-dom-credential-id-4">(3)</a> <a href="#ref-for-dom-credential-id-5">(4)</a>
-    <li><a href="#ref-for-dom-credential-id-6">3.3.5. 
+    <li><a href="#ref-for-dom-credential-id">2.2. The Credential Interface</a>
+    <li><a href="#ref-for-dom-credential-id①">3.3.3. 
+    PasswordCredential's [[Store]](credential) </a> <a href="#ref-for-dom-credential-id②">(2)</a> <a href="#ref-for-dom-credential-id③">(3)</a> <a href="#ref-for-dom-credential-id④">(4)</a>
+    <li><a href="#ref-for-dom-credential-id⑤">3.3.5. 
     Create a PasswordCredential from PasswordCredentialData </a>
-    <li><a href="#ref-for-dom-credential-id-7">4.2.3. 
-    FederatedCredential's [[Store]](credential) </a> <a href="#ref-for-dom-credential-id-8">(2)</a> <a href="#ref-for-dom-credential-id-9">(3)</a> <a href="#ref-for-dom-credential-id-10">(4)</a>
-    <li><a href="#ref-for-dom-credential-id-11">4.2.4. 
+    <li><a href="#ref-for-dom-credential-id⑥">4.2.3. 
+    FederatedCredential's [[Store]](credential) </a> <a href="#ref-for-dom-credential-id⑦">(2)</a> <a href="#ref-for-dom-credential-id⑧">(3)</a> <a href="#ref-for-dom-credential-id⑨">(4)</a>
+    <li><a href="#ref-for-dom-credential-id①⓪">4.2.4. 
     Create a FederatedCredential from FederatedCredentialInit </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-credential-type">
    <b><a href="#dom-credential-type">#dom-credential-type</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-credential-type-1">2.2. The Credential Interface</a>
-    <li><a href="#ref-for-dom-credential-type-2">3.1.1. Password-based Sign-in</a> <a href="#ref-for-dom-credential-type-3">(2)</a>
+    <li><a href="#ref-for-dom-credential-type">2.2. The Credential Interface</a>
+    <li><a href="#ref-for-dom-credential-type①">3.1.1. Password-based Sign-in</a> <a href="#ref-for-dom-credential-type②">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-credential-signal">
+   <b><a href="#dom-credential-signal">#dom-credential-signal</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-credential-signal">2.2. The Credential Interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-credential-type-slot">
    <b><a href="#dom-credential-type-slot">#dom-credential-type-slot</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-credential-type-slot-1">2.2. The Credential Interface</a> <a href="#ref-for-dom-credential-type-slot-2">(2)</a>
-    <li><a href="#ref-for-dom-credential-type-slot-3">2.3.1. The CredentialRequestOptions Dictionary</a>
-    <li><a href="#ref-for-dom-credential-type-slot-4">3.2. The PasswordCredential Interface</a>
-    <li><a href="#ref-for-dom-credential-type-slot-5">4.1. The FederatedCredential Interface</a>
-    <li><a href="#ref-for-dom-credential-type-slot-6">7.2. Extension Points</a>
+    <li><a href="#ref-for-dom-credential-type-slot">2.2. The Credential Interface</a> <a href="#ref-for-dom-credential-type-slot①">(2)</a>
+    <li><a href="#ref-for-dom-credential-type-slot②">2.3.1. The CredentialRequestOptions Dictionary</a>
+    <li><a href="#ref-for-dom-credential-type-slot③">3.2. The PasswordCredential Interface</a>
+    <li><a href="#ref-for-dom-credential-type-slot④">4.1. The FederatedCredential Interface</a>
+    <li><a href="#ref-for-dom-credential-type-slot⑤">7.2. Extension Points</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-credential-discovery-slot">
    <b><a href="#dom-credential-discovery-slot">#dom-credential-discovery-slot</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-credential-discovery-slot-1">2.3.1. The CredentialRequestOptions Dictionary</a>
-    <li><a href="#ref-for-dom-credential-discovery-slot-2">3.2. The PasswordCredential Interface</a>
-    <li><a href="#ref-for-dom-credential-discovery-slot-3">4.1. The FederatedCredential Interface</a>
-    <li><a href="#ref-for-dom-credential-discovery-slot-4">7.2. Extension Points</a>
+    <li><a href="#ref-for-dom-credential-discovery-slot">2.3.1. The CredentialRequestOptions Dictionary</a>
+    <li><a href="#ref-for-dom-credential-discovery-slot①">3.2. The PasswordCredential Interface</a>
+    <li><a href="#ref-for-dom-credential-discovery-slot②">4.1. The FederatedCredential Interface</a>
+    <li><a href="#ref-for-dom-credential-discovery-slot③">7.2. Extension Points</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-credential-discovery-credential-store">
    <b><a href="#dom-credential-discovery-credential-store">#dom-credential-discovery-credential-store</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-credential-discovery-credential-store-1">2.3.1. The CredentialRequestOptions Dictionary</a>
-    <li><a href="#ref-for-dom-credential-discovery-credential-store-2">3.2. The PasswordCredential Interface</a>
-    <li><a href="#ref-for-dom-credential-discovery-credential-store-3">4.1. The FederatedCredential Interface</a>
-    <li><a href="#ref-for-dom-credential-discovery-credential-store-4">7.2. Extension Points</a>
+    <li><a href="#ref-for-dom-credential-discovery-credential-store">2.3.1. The CredentialRequestOptions Dictionary</a>
+    <li><a href="#ref-for-dom-credential-discovery-credential-store①">3.2. The PasswordCredential Interface</a>
+    <li><a href="#ref-for-dom-credential-discovery-credential-store②">4.1. The FederatedCredential Interface</a>
+    <li><a href="#ref-for-dom-credential-discovery-credential-store③">7.2. Extension Points</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="credential-origin-bound">
    <b><a href="#credential-origin-bound">#credential-origin-bound</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-credential-origin-bound-1">3.2. The PasswordCredential Interface</a>
-    <li><a href="#ref-for-credential-origin-bound-2">4.1. The FederatedCredential Interface</a>
+    <li><a href="#ref-for-credential-origin-bound">3.2. The PasswordCredential Interface</a>
+    <li><a href="#ref-for-credential-origin-bound①">4.1. The FederatedCredential Interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-credential-origin-slot">
    <b><a href="#dom-credential-origin-slot">#dom-credential-origin-slot</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-credential-origin-slot-1">3.3.1. 
+    <li><a href="#ref-for-dom-credential-origin-slot">3.3.1. 
     PasswordCredential's [[CollectFromCredentialStore]](options) </a>
-    <li><a href="#ref-for-dom-credential-origin-slot-2">3.3.3. 
-    PasswordCredential's [[Store]](credential) </a> <a href="#ref-for-dom-credential-origin-slot-3">(2)</a> <a href="#ref-for-dom-credential-origin-slot-4">(3)</a> <a href="#ref-for-dom-credential-origin-slot-5">(4)</a>
-    <li><a href="#ref-for-dom-credential-origin-slot-6">3.3.5. 
+    <li><a href="#ref-for-dom-credential-origin-slot①">3.3.3. 
+    PasswordCredential's [[Store]](credential) </a> <a href="#ref-for-dom-credential-origin-slot②">(2)</a> <a href="#ref-for-dom-credential-origin-slot③">(3)</a> <a href="#ref-for-dom-credential-origin-slot④">(4)</a>
+    <li><a href="#ref-for-dom-credential-origin-slot⑤">3.3.5. 
     Create a PasswordCredential from PasswordCredentialData </a>
-    <li><a href="#ref-for-dom-credential-origin-slot-7">4.2.1. 
+    <li><a href="#ref-for-dom-credential-origin-slot⑥">4.2.1. 
     FederatedCredential's [[CollectFromCredentialStore]](options) </a>
-    <li><a href="#ref-for-dom-credential-origin-slot-8">4.2.3. 
-    FederatedCredential's [[Store]](credential) </a> <a href="#ref-for-dom-credential-origin-slot-9">(2)</a> <a href="#ref-for-dom-credential-origin-slot-10">(3)</a> <a href="#ref-for-dom-credential-origin-slot-11">(4)</a>
-    <li><a href="#ref-for-dom-credential-origin-slot-12">4.2.4. 
+    <li><a href="#ref-for-dom-credential-origin-slot⑦">4.2.3. 
+    FederatedCredential's [[Store]](credential) </a> <a href="#ref-for-dom-credential-origin-slot⑧">(2)</a> <a href="#ref-for-dom-credential-origin-slot⑨">(3)</a> <a href="#ref-for-dom-credential-origin-slot①⓪">(4)</a>
+    <li><a href="#ref-for-dom-credential-origin-slot①①">4.2.4. 
     Create a FederatedCredential from FederatedCredentialInit </a>
-    <li><a href="#ref-for-dom-credential-origin-slot-13">6.1. Cross-domain credential access</a>
+    <li><a href="#ref-for-dom-credential-origin-slot①②">6.1. Cross-domain credential access</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="concept-credman-terminated">
+   <b><a href="#concept-credman-terminated">#concept-credman-terminated</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-credman-terminated">2.2. The Credential Interface</a>
+    <li><a href="#ref-for-concept-credman-terminated①">2.2.1. Credential Internal Methods</a>
+    <li><a href="#ref-for-concept-credman-terminated②">2.5.4. Create a Credential</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-credential-collectfromcredentialstore-slot">
    <b><a href="#dom-credential-collectfromcredentialstore-slot">#dom-credential-collectfromcredentialstore-slot</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-credential-collectfromcredentialstore-slot-1">2.5.2. Collect Credentials from the credential store</a>
-    <li><a href="#ref-for-dom-credential-collectfromcredentialstore-slot-2">7.2. Extension Points</a> <a href="#ref-for-dom-credential-collectfromcredentialstore-slot-3">(2)</a>
+    <li><a href="#ref-for-dom-credential-collectfromcredentialstore-slot">2.5.2. Collect Credentials from the credential store</a>
+    <li><a href="#ref-for-dom-credential-collectfromcredentialstore-slot①">7.2. Extension Points</a> <a href="#ref-for-dom-credential-collectfromcredentialstore-slot②">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-credential-discoverfromexternalsource-slot">
    <b><a href="#dom-credential-discoverfromexternalsource-slot">#dom-credential-discoverfromexternalsource-slot</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-credential-discoverfromexternalsource-slot-1">2.5.1. Request a Credential</a>
-    <li><a href="#ref-for-dom-credential-discoverfromexternalsource-slot-2">3.2. The PasswordCredential Interface</a>
-    <li><a href="#ref-for-dom-credential-discoverfromexternalsource-slot-3">4.1. The FederatedCredential Interface</a>
-    <li><a href="#ref-for-dom-credential-discoverfromexternalsource-slot-4">7.2. Extension Points</a> <a href="#ref-for-dom-credential-discoverfromexternalsource-slot-5">(2)</a>
+    <li><a href="#ref-for-dom-credential-discoverfromexternalsource-slot">2.2. The Credential Interface</a>
+    <li><a href="#ref-for-dom-credential-discoverfromexternalsource-slot①">2.2.1. Credential Internal Methods</a>
+    <li><a href="#ref-for-dom-credential-discoverfromexternalsource-slot②">2.5.1. Request a Credential</a>
+    <li><a href="#ref-for-dom-credential-discoverfromexternalsource-slot③">3.2. The PasswordCredential Interface</a>
+    <li><a href="#ref-for-dom-credential-discoverfromexternalsource-slot④">4.1. The FederatedCredential Interface</a>
+    <li><a href="#ref-for-dom-credential-discoverfromexternalsource-slot⑤">7.2. Extension Points</a> <a href="#ref-for-dom-credential-discoverfromexternalsource-slot⑥">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-credential-store-slot">
    <b><a href="#dom-credential-store-slot">#dom-credential-store-slot</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-credential-store-slot-1">2.5.3. Store a Credential</a>
-    <li><a href="#ref-for-dom-credential-store-slot-2">7.2. Extension Points</a>
+    <li><a href="#ref-for-dom-credential-store-slot">2.5.3. Store a Credential</a>
+    <li><a href="#ref-for-dom-credential-store-slot①">7.2. Extension Points</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-credential-create-slot">
    <b><a href="#dom-credential-create-slot">#dom-credential-create-slot</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-credential-create-slot-1">2.5.4. Create a Credential</a>
-    <li><a href="#ref-for-dom-credential-create-slot-2">7.2. Extension Points</a>
+    <li><a href="#ref-for-dom-credential-create-slot">2.2.1. Credential Internal Methods</a>
+    <li><a href="#ref-for-dom-credential-create-slot①">2.5.4. Create a Credential</a>
+    <li><a href="#ref-for-dom-credential-create-slot②">7.2. Extension Points</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="credentialuserdata">
    <b><a href="#credentialuserdata">#credentialuserdata</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-credentialuserdata-1">3.2. The PasswordCredential Interface</a>
-    <li><a href="#ref-for-credentialuserdata-2">4.1. The FederatedCredential Interface</a>
+    <li><a href="#ref-for-credentialuserdata">3.2. The PasswordCredential Interface</a>
+    <li><a href="#ref-for-credentialuserdata①">4.1. The FederatedCredential Interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-credentialuserdata-name">
    <b><a href="#dom-credentialuserdata-name">#dom-credentialuserdata-name</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-credentialuserdata-name-1">2.2.2. CredentialUserData Mixin</a>
-    <li><a href="#ref-for-dom-credentialuserdata-name-2">3.3.3. 
-    PasswordCredential's [[Store]](credential) </a> <a href="#ref-for-dom-credentialuserdata-name-3">(2)</a> <a href="#ref-for-dom-credentialuserdata-name-4">(3)</a> <a href="#ref-for-dom-credentialuserdata-name-5">(4)</a>
-    <li><a href="#ref-for-dom-credentialuserdata-name-6">3.3.4. 
+    <li><a href="#ref-for-dom-credentialuserdata-name">2.2.2. CredentialUserData Mixin</a>
+    <li><a href="#ref-for-dom-credentialuserdata-name①">3.3.3. 
+    PasswordCredential's [[Store]](credential) </a> <a href="#ref-for-dom-credentialuserdata-name②">(2)</a> <a href="#ref-for-dom-credentialuserdata-name③">(3)</a> <a href="#ref-for-dom-credentialuserdata-name④">(4)</a>
+    <li><a href="#ref-for-dom-credentialuserdata-name⑤">3.3.4. 
     Create a PasswordCredential from an HTMLFormElement </a>
-    <li><a href="#ref-for-dom-credentialuserdata-name-7">3.3.5. 
+    <li><a href="#ref-for-dom-credentialuserdata-name⑥">3.3.5. 
     Create a PasswordCredential from PasswordCredentialData </a>
-    <li><a href="#ref-for-dom-credentialuserdata-name-8">4.2.3. 
-    FederatedCredential's [[Store]](credential) </a> <a href="#ref-for-dom-credentialuserdata-name-9">(2)</a>
-    <li><a href="#ref-for-dom-credentialuserdata-name-10">4.2.4. 
-    Create a FederatedCredential from FederatedCredentialInit </a> <a href="#ref-for-dom-credentialuserdata-name-11">(2)</a>
+    <li><a href="#ref-for-dom-credentialuserdata-name⑦">4.2.3. 
+    FederatedCredential's [[Store]](credential) </a> <a href="#ref-for-dom-credentialuserdata-name⑧">(2)</a>
+    <li><a href="#ref-for-dom-credentialuserdata-name⑨">4.2.4. 
+    Create a FederatedCredential from FederatedCredentialInit </a> <a href="#ref-for-dom-credentialuserdata-name①⓪">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-credentialuserdata-iconurl">
    <b><a href="#dom-credentialuserdata-iconurl">#dom-credentialuserdata-iconurl</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-credentialuserdata-iconurl-1">2.2.2. CredentialUserData Mixin</a>
-    <li><a href="#ref-for-dom-credentialuserdata-iconurl-2">3.3.3. 
-    PasswordCredential's [[Store]](credential) </a> <a href="#ref-for-dom-credentialuserdata-iconurl-3">(2)</a> <a href="#ref-for-dom-credentialuserdata-iconurl-4">(3)</a> <a href="#ref-for-dom-credentialuserdata-iconurl-5">(4)</a>
-    <li><a href="#ref-for-dom-credentialuserdata-iconurl-6">3.3.4. 
+    <li><a href="#ref-for-dom-credentialuserdata-iconurl">2.2.2. CredentialUserData Mixin</a>
+    <li><a href="#ref-for-dom-credentialuserdata-iconurl①">3.3.3. 
+    PasswordCredential's [[Store]](credential) </a> <a href="#ref-for-dom-credentialuserdata-iconurl②">(2)</a> <a href="#ref-for-dom-credentialuserdata-iconurl③">(3)</a> <a href="#ref-for-dom-credentialuserdata-iconurl④">(4)</a>
+    <li><a href="#ref-for-dom-credentialuserdata-iconurl⑤">3.3.4. 
     Create a PasswordCredential from an HTMLFormElement </a>
-    <li><a href="#ref-for-dom-credentialuserdata-iconurl-7">3.3.5. 
+    <li><a href="#ref-for-dom-credentialuserdata-iconurl⑥">3.3.5. 
     Create a PasswordCredential from PasswordCredentialData </a>
-    <li><a href="#ref-for-dom-credentialuserdata-iconurl-8">4.2.3. 
-    FederatedCredential's [[Store]](credential) </a> <a href="#ref-for-dom-credentialuserdata-iconurl-9">(2)</a>
-    <li><a href="#ref-for-dom-credentialuserdata-iconurl-10">4.2.4. 
-    Create a FederatedCredential from FederatedCredentialInit </a> <a href="#ref-for-dom-credentialuserdata-iconurl-11">(2)</a>
+    <li><a href="#ref-for-dom-credentialuserdata-iconurl⑦">4.2.3. 
+    FederatedCredential's [[Store]](credential) </a> <a href="#ref-for-dom-credentialuserdata-iconurl⑧">(2)</a>
+    <li><a href="#ref-for-dom-credentialuserdata-iconurl⑨">4.2.4. 
+    Create a FederatedCredential from FederatedCredentialInit </a> <a href="#ref-for-dom-credentialuserdata-iconurl①⓪">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-navigator-credentials">
    <b><a href="#dom-navigator-credentials">#dom-navigator-credentials</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-navigator-credentials-1">2.3. navigator.credentials</a> <a href="#ref-for-dom-navigator-credentials-2">(2)</a>
-    <li><a href="#ref-for-dom-navigator-credentials-3">2.3.2.1. Examples</a> <a href="#ref-for-dom-navigator-credentials-4">(2)</a> <a href="#ref-for-dom-navigator-credentials-5">(3)</a> <a href="#ref-for-dom-navigator-credentials-6">(4)</a>
-    <li><a href="#ref-for-dom-navigator-credentials-7">3.1.1. Password-based Sign-in</a> <a href="#ref-for-dom-navigator-credentials-8">(2)</a> <a href="#ref-for-dom-navigator-credentials-9">(3)</a>
-    <li><a href="#ref-for-dom-navigator-credentials-10">3.1.2. Post-sign-in Confirmation</a>
-    <li><a href="#ref-for-dom-navigator-credentials-11">3.1.3. Change Password</a>
+    <li><a href="#ref-for-dom-navigator-credentials">2.3. navigator.credentials</a> <a href="#ref-for-dom-navigator-credentials①">(2)</a>
+    <li><a href="#ref-for-dom-navigator-credentials②">2.3.2.1. Examples</a> <a href="#ref-for-dom-navigator-credentials③">(2)</a> <a href="#ref-for-dom-navigator-credentials④">(3)</a> <a href="#ref-for-dom-navigator-credentials⑤">(4)</a>
+    <li><a href="#ref-for-dom-navigator-credentials⑥">3.1.1. Password-based Sign-in</a> <a href="#ref-for-dom-navigator-credentials⑦">(2)</a> <a href="#ref-for-dom-navigator-credentials⑧">(3)</a>
+    <li><a href="#ref-for-dom-navigator-credentials⑨">3.1.2. Post-sign-in Confirmation</a>
+    <li><a href="#ref-for-dom-navigator-credentials①⓪">3.1.3. Change Password</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="credentialscontainer">
    <b><a href="#credentialscontainer">#credentialscontainer</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-credentialscontainer-1">2. Core API</a>
-    <li><a href="#ref-for-credentialscontainer-2">2.3. navigator.credentials</a> <a href="#ref-for-credentialscontainer-3">(2)</a> <a href="#ref-for-credentialscontainer-4">(3)</a> <a href="#ref-for-credentialscontainer-5">(4)</a>
-    <li><a href="#ref-for-credentialscontainer-6">6.6. Signing-Out</a>
-    <li><a href="#ref-for-credentialscontainer-7">7.2. Extension Points</a>
+    <li><a href="#ref-for-credentialscontainer">2. Core API</a>
+    <li><a href="#ref-for-credentialscontainer①">2.3. navigator.credentials</a> <a href="#ref-for-credentialscontainer②">(2)</a> <a href="#ref-for-credentialscontainer③">(3)</a> <a href="#ref-for-credentialscontainer④">(4)</a>
+    <li><a href="#ref-for-credentialscontainer⑤">6.6. Signing-Out</a>
+    <li><a href="#ref-for-credentialscontainer⑥">7.2. Extension Points</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dictdef-credentialdata">
    <b><a href="#dictdef-credentialdata">#dictdef-credentialdata</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dictdef-credentialdata-1">3.2. The PasswordCredential Interface</a>
-    <li><a href="#ref-for-dictdef-credentialdata-2">4.1. The FederatedCredential Interface</a>
+    <li><a href="#ref-for-dictdef-credentialdata">3.2. The PasswordCredential Interface</a>
+    <li><a href="#ref-for-dictdef-credentialdata①">4.1. The FederatedCredential Interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-credentialdata-id">
    <b><a href="#dom-credentialdata-id">#dom-credentialdata-id</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-credentialdata-id-1">3.3.4. 
+    <li><a href="#ref-for-dom-credentialdata-id">3.3.4. 
     Create a PasswordCredential from an HTMLFormElement </a>
-    <li><a href="#ref-for-dom-credentialdata-id-2">3.3.5. 
-    Create a PasswordCredential from PasswordCredentialData </a> <a href="#ref-for-dom-credentialdata-id-3">(2)</a>
-    <li><a href="#ref-for-dom-credentialdata-id-4">4.2.4. 
-    Create a FederatedCredential from FederatedCredentialInit </a> <a href="#ref-for-dom-credentialdata-id-5">(2)</a>
+    <li><a href="#ref-for-dom-credentialdata-id①">3.3.5. 
+    Create a PasswordCredential from PasswordCredentialData </a> <a href="#ref-for-dom-credentialdata-id②">(2)</a>
+    <li><a href="#ref-for-dom-credentialdata-id③">4.2.4. 
+    Create a FederatedCredential from FederatedCredentialInit </a> <a href="#ref-for-dom-credentialdata-id④">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-credentialscontainer-get">
    <b><a href="#dom-credentialscontainer-get">#dom-credentialscontainer-get</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-credentialscontainer-get-1">2.3. navigator.credentials</a> <a href="#ref-for-dom-credentialscontainer-get-2">(2)</a> <a href="#ref-for-dom-credentialscontainer-get-3">(3)</a>
-    <li><a href="#ref-for-dom-credentialscontainer-get-4">2.3.1. The CredentialRequestOptions Dictionary</a> <a href="#ref-for-dom-credentialscontainer-get-5">(2)</a>
-    <li><a href="#ref-for-dom-credentialscontainer-get-6">2.3.2. Mediation Requirements</a> <a href="#ref-for-dom-credentialscontainer-get-7">(2)</a>
-    <li><a href="#ref-for-dom-credentialscontainer-get-8">2.3.2.1. Examples</a> <a href="#ref-for-dom-credentialscontainer-get-9">(2)</a> <a href="#ref-for-dom-credentialscontainer-get-10">(3)</a> <a href="#ref-for-dom-credentialscontainer-get-11">(4)</a> <a href="#ref-for-dom-credentialscontainer-get-12">(5)</a> <a href="#ref-for-dom-credentialscontainer-get-13">(6)</a> <a href="#ref-for-dom-credentialscontainer-get-14">(7)</a>
-    <li><a href="#ref-for-dom-credentialscontainer-get-15">3.1.1. Password-based Sign-in</a> <a href="#ref-for-dom-credentialscontainer-get-16">(2)</a> <a href="#ref-for-dom-credentialscontainer-get-17">(3)</a> <a href="#ref-for-dom-credentialscontainer-get-18">(4)</a>
-    <li><a href="#ref-for-dom-credentialscontainer-get-19">3.3.6. 
+    <li><a href="#ref-for-dom-credentialscontainer-get">2.3. navigator.credentials</a> <a href="#ref-for-dom-credentialscontainer-get①">(2)</a> <a href="#ref-for-dom-credentialscontainer-get②">(3)</a>
+    <li><a href="#ref-for-dom-credentialscontainer-get③">2.3.1. The CredentialRequestOptions Dictionary</a> <a href="#ref-for-dom-credentialscontainer-get④">(2)</a>
+    <li><a href="#ref-for-dom-credentialscontainer-get⑤">2.3.2. Mediation Requirements</a> <a href="#ref-for-dom-credentialscontainer-get⑥">(2)</a>
+    <li><a href="#ref-for-dom-credentialscontainer-get⑦">2.3.2.1. Examples</a> <a href="#ref-for-dom-credentialscontainer-get⑧">(2)</a> <a href="#ref-for-dom-credentialscontainer-get⑨">(3)</a> <a href="#ref-for-dom-credentialscontainer-get①⓪">(4)</a> <a href="#ref-for-dom-credentialscontainer-get①①">(5)</a> <a href="#ref-for-dom-credentialscontainer-get①②">(6)</a> <a href="#ref-for-dom-credentialscontainer-get①③">(7)</a>
+    <li><a href="#ref-for-dom-credentialscontainer-get①④">3.1.1. Password-based Sign-in</a> <a href="#ref-for-dom-credentialscontainer-get①⑤">(2)</a> <a href="#ref-for-dom-credentialscontainer-get①⑥">(3)</a> <a href="#ref-for-dom-credentialscontainer-get①⑦">(4)</a>
+    <li><a href="#ref-for-dom-credentialscontainer-get①⑧">3.3.6. 
     CredentialRequestOptions Matching for PasswordCredential </a>
-    <li><a href="#ref-for-dom-credentialscontainer-get-20">5.3. Credential Selection</a>
-    <li><a href="#ref-for-dom-credentialscontainer-get-21">6.1. Cross-domain credential access</a> <a href="#ref-for-dom-credentialscontainer-get-22">(2)</a> <a href="#ref-for-dom-credentialscontainer-get-23">(3)</a>
-    <li><a href="#ref-for-dom-credentialscontainer-get-24">6.4. Origin Confusion</a>
-    <li><a href="#ref-for-dom-credentialscontainer-get-25">6.5. Timing Attacks</a>
-    <li><a href="#ref-for-dom-credentialscontainer-get-26">7.2. Extension Points</a>
-    <li><a href="#ref-for-dom-credentialscontainer-get-27">7.3. Browser Extensions</a>
+    <li><a href="#ref-for-dom-credentialscontainer-get①⑨">5.3. Credential Selection</a>
+    <li><a href="#ref-for-dom-credentialscontainer-get②⓪">6.1. Cross-domain credential access</a> <a href="#ref-for-dom-credentialscontainer-get②①">(2)</a> <a href="#ref-for-dom-credentialscontainer-get②②">(3)</a>
+    <li><a href="#ref-for-dom-credentialscontainer-get②③">6.4. Origin Confusion</a>
+    <li><a href="#ref-for-dom-credentialscontainer-get②④">6.5. Timing Attacks</a>
+    <li><a href="#ref-for-dom-credentialscontainer-get②⑤">7.2. Extension Points</a>
+    <li><a href="#ref-for-dom-credentialscontainer-get②⑥">7.3. Browser Extensions</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-credentialscontainer-get-options-options">
    <b><a href="#dom-credentialscontainer-get-options-options">#dom-credentialscontainer-get-options-options</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-credentialscontainer-get-options-options-1">2.3. navigator.credentials</a> <a href="#ref-for-dom-credentialscontainer-get-options-options-2">(2)</a>
+    <li><a href="#ref-for-dom-credentialscontainer-get-options-options">2.3. navigator.credentials</a> <a href="#ref-for-dom-credentialscontainer-get-options-options①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-credentialscontainer-store">
    <b><a href="#dom-credentialscontainer-store">#dom-credentialscontainer-store</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-credentialscontainer-store-1">2. Core API</a>
-    <li><a href="#ref-for-dom-credentialscontainer-store-2">2.3. navigator.credentials</a> <a href="#ref-for-dom-credentialscontainer-store-3">(2)</a> <a href="#ref-for-dom-credentialscontainer-store-4">(3)</a>
-    <li><a href="#ref-for-dom-credentialscontainer-store-5">3.1.1. Password-based Sign-in</a> <a href="#ref-for-dom-credentialscontainer-store-6">(2)</a> <a href="#ref-for-dom-credentialscontainer-store-7">(3)</a> <a href="#ref-for-dom-credentialscontainer-store-8">(4)</a>
-    <li><a href="#ref-for-dom-credentialscontainer-store-9">3.1.2. Post-sign-in Confirmation</a> <a href="#ref-for-dom-credentialscontainer-store-10">(2)</a>
-    <li><a href="#ref-for-dom-credentialscontainer-store-11">3.1.3. Change Password</a> <a href="#ref-for-dom-credentialscontainer-store-12">(2)</a>
-    <li><a href="#ref-for-dom-credentialscontainer-store-13">5.1. Storing and Updating Credentials</a>
-    <li><a href="#ref-for-dom-credentialscontainer-store-14">6.4. Origin Confusion</a>
-    <li><a href="#ref-for-dom-credentialscontainer-store-15">7.3. Browser Extensions</a>
+    <li><a href="#ref-for-dom-credentialscontainer-store">2. Core API</a>
+    <li><a href="#ref-for-dom-credentialscontainer-store①">2.3. navigator.credentials</a> <a href="#ref-for-dom-credentialscontainer-store②">(2)</a> <a href="#ref-for-dom-credentialscontainer-store③">(3)</a>
+    <li><a href="#ref-for-dom-credentialscontainer-store④">3.1.1. Password-based Sign-in</a> <a href="#ref-for-dom-credentialscontainer-store⑤">(2)</a> <a href="#ref-for-dom-credentialscontainer-store⑥">(3)</a> <a href="#ref-for-dom-credentialscontainer-store⑦">(4)</a>
+    <li><a href="#ref-for-dom-credentialscontainer-store⑧">3.1.2. Post-sign-in Confirmation</a> <a href="#ref-for-dom-credentialscontainer-store⑨">(2)</a>
+    <li><a href="#ref-for-dom-credentialscontainer-store①⓪">3.1.3. Change Password</a> <a href="#ref-for-dom-credentialscontainer-store①①">(2)</a>
+    <li><a href="#ref-for-dom-credentialscontainer-store①②">5.1. Storing and Updating Credentials</a>
+    <li><a href="#ref-for-dom-credentialscontainer-store①③">6.4. Origin Confusion</a>
+    <li><a href="#ref-for-dom-credentialscontainer-store①④">7.3. Browser Extensions</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-credentialscontainer-store-credential-credential">
    <b><a href="#dom-credentialscontainer-store-credential-credential">#dom-credentialscontainer-store-credential-credential</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-credentialscontainer-store-credential-credential-1">2.3. navigator.credentials</a> <a href="#ref-for-dom-credentialscontainer-store-credential-credential-2">(2)</a>
+    <li><a href="#ref-for-dom-credentialscontainer-store-credential-credential">2.3. navigator.credentials</a> <a href="#ref-for-dom-credentialscontainer-store-credential-credential①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-credentialscontainer-create">
    <b><a href="#dom-credentialscontainer-create">#dom-credentialscontainer-create</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-credentialscontainer-create-1">2.3. navigator.credentials</a> <a href="#ref-for-dom-credentialscontainer-create-2">(2)</a> <a href="#ref-for-dom-credentialscontainer-create-3">(3)</a>
-    <li><a href="#ref-for-dom-credentialscontainer-create-4">2.4. The CredentialCreationOptions Dictionary</a>
-    <li><a href="#ref-for-dom-credentialscontainer-create-5">3.2. The PasswordCredential Interface</a>
-    <li><a href="#ref-for-dom-credentialscontainer-create-6">4.1. The FederatedCredential Interface</a>
-    <li><a href="#ref-for-dom-credentialscontainer-create-7">7.2. Extension Points</a>
+    <li><a href="#ref-for-dom-credentialscontainer-create">2.3. navigator.credentials</a> <a href="#ref-for-dom-credentialscontainer-create①">(2)</a> <a href="#ref-for-dom-credentialscontainer-create②">(3)</a>
+    <li><a href="#ref-for-dom-credentialscontainer-create③">2.4. The CredentialCreationOptions Dictionary</a>
+    <li><a href="#ref-for-dom-credentialscontainer-create④">3.2. The PasswordCredential Interface</a>
+    <li><a href="#ref-for-dom-credentialscontainer-create⑤">4.1. The FederatedCredential Interface</a>
+    <li><a href="#ref-for-dom-credentialscontainer-create⑥">7.2. Extension Points</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-credentialscontainer-create-options-options">
    <b><a href="#dom-credentialscontainer-create-options-options">#dom-credentialscontainer-create-options-options</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-credentialscontainer-create-options-options-1">2.3. navigator.credentials</a> <a href="#ref-for-dom-credentialscontainer-create-options-options-2">(2)</a>
+    <li><a href="#ref-for-dom-credentialscontainer-create-options-options">2.3. navigator.credentials</a> <a href="#ref-for-dom-credentialscontainer-create-options-options①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-credentialscontainer-preventsilentaccess">
    <b><a href="#dom-credentialscontainer-preventsilentaccess">#dom-credentialscontainer-preventsilentaccess</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-credentialscontainer-preventsilentaccess-1">2.3. navigator.credentials</a> <a href="#ref-for-dom-credentialscontainer-preventsilentaccess-2">(2)</a>
-    <li><a href="#ref-for-dom-credentialscontainer-preventsilentaccess-3">2.3.2. Mediation Requirements</a>
-    <li><a href="#ref-for-dom-credentialscontainer-preventsilentaccess-4">6.6. Signing-Out</a>
+    <li><a href="#ref-for-dom-credentialscontainer-preventsilentaccess">2.3. navigator.credentials</a> <a href="#ref-for-dom-credentialscontainer-preventsilentaccess①">(2)</a>
+    <li><a href="#ref-for-dom-credentialscontainer-preventsilentaccess②">2.3.2. Mediation Requirements</a>
+    <li><a href="#ref-for-dom-credentialscontainer-preventsilentaccess③">6.6. Signing-Out</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dictdef-credentialrequestoptions">
    <b><a href="#dictdef-credentialrequestoptions">#dictdef-credentialrequestoptions</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dictdef-credentialrequestoptions-1">2.2.1. Credential Internal Methods</a> <a href="#ref-for-dictdef-credentialrequestoptions-2">(2)</a>
-    <li><a href="#ref-for-dictdef-credentialrequestoptions-3">2.3. navigator.credentials</a>
-    <li><a href="#ref-for-dictdef-credentialrequestoptions-4">2.3.1. The CredentialRequestOptions Dictionary</a> <a href="#ref-for-dictdef-credentialrequestoptions-5">(2)</a> <a href="#ref-for-dictdef-credentialrequestoptions-6">(3)</a> <a href="#ref-for-dictdef-credentialrequestoptions-7">(4)</a> <a href="#ref-for-dictdef-credentialrequestoptions-8">(5)</a>
-    <li><a href="#ref-for-dictdef-credentialrequestoptions-9">2.5.1. Request a Credential</a>
-    <li><a href="#ref-for-dictdef-credentialrequestoptions-10">2.5.2. Collect Credentials from the credential store</a>
-    <li><a href="#ref-for-dictdef-credentialrequestoptions-11">3.2. The PasswordCredential Interface</a>
-    <li><a href="#ref-for-dictdef-credentialrequestoptions-12">3.3.1. 
+    <li><a href="#ref-for-dictdef-credentialrequestoptions">2.2.1. Credential Internal Methods</a> <a href="#ref-for-dictdef-credentialrequestoptions①">(2)</a>
+    <li><a href="#ref-for-dictdef-credentialrequestoptions②">2.3. navigator.credentials</a>
+    <li><a href="#ref-for-dictdef-credentialrequestoptions③">2.3.1. The CredentialRequestOptions Dictionary</a> <a href="#ref-for-dictdef-credentialrequestoptions④">(2)</a> <a href="#ref-for-dictdef-credentialrequestoptions⑤">(3)</a> <a href="#ref-for-dictdef-credentialrequestoptions⑥">(4)</a> <a href="#ref-for-dictdef-credentialrequestoptions⑦">(5)</a>
+    <li><a href="#ref-for-dictdef-credentialrequestoptions⑧">2.5.1. Request a Credential</a>
+    <li><a href="#ref-for-dictdef-credentialrequestoptions⑨">2.5.2. Collect Credentials from the credential store</a>
+    <li><a href="#ref-for-dictdef-credentialrequestoptions①⓪">3.2. The PasswordCredential Interface</a>
+    <li><a href="#ref-for-dictdef-credentialrequestoptions①①">3.3.1. 
     PasswordCredential's [[CollectFromCredentialStore]](options) </a>
-    <li><a href="#ref-for-dictdef-credentialrequestoptions-13">3.3.6. 
+    <li><a href="#ref-for-dictdef-credentialrequestoptions①②">3.3.6. 
     CredentialRequestOptions Matching for PasswordCredential </a>
-    <li><a href="#ref-for-dictdef-credentialrequestoptions-14">4.1. The FederatedCredential Interface</a>
-    <li><a href="#ref-for-dictdef-credentialrequestoptions-15">4.2.1. 
+    <li><a href="#ref-for-dictdef-credentialrequestoptions①③">4.1. The FederatedCredential Interface</a>
+    <li><a href="#ref-for-dictdef-credentialrequestoptions①④">4.2.1. 
     FederatedCredential's [[CollectFromCredentialStore]](options) </a>
-    <li><a href="#ref-for-dictdef-credentialrequestoptions-16">5.3. Credential Selection</a>
-    <li><a href="#ref-for-dictdef-credentialrequestoptions-17">7.2. Extension Points</a>
+    <li><a href="#ref-for-dictdef-credentialrequestoptions①⑤">5.3. Credential Selection</a>
+    <li><a href="#ref-for-dictdef-credentialrequestoptions①⑥">7.2. Extension Points</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-credentialrequestoptions-mediation">
    <b><a href="#dom-credentialrequestoptions-mediation">#dom-credentialrequestoptions-mediation</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-credentialrequestoptions-mediation-1">2.3.1. The CredentialRequestOptions Dictionary</a> <a href="#ref-for-dom-credentialrequestoptions-mediation-2">(2)</a> <a href="#ref-for-dom-credentialrequestoptions-mediation-3">(3)</a> <a href="#ref-for-dom-credentialrequestoptions-mediation-4">(4)</a>
-    <li><a href="#ref-for-dom-credentialrequestoptions-mediation-5">2.3.2.1. Examples</a> <a href="#ref-for-dom-credentialrequestoptions-mediation-6">(2)</a> <a href="#ref-for-dom-credentialrequestoptions-mediation-7">(3)</a> <a href="#ref-for-dom-credentialrequestoptions-mediation-8">(4)</a> <a href="#ref-for-dom-credentialrequestoptions-mediation-9">(5)</a> <a href="#ref-for-dom-credentialrequestoptions-mediation-10">(6)</a> <a href="#ref-for-dom-credentialrequestoptions-mediation-11">(7)</a> <a href="#ref-for-dom-credentialrequestoptions-mediation-12">(8)</a>
-    <li><a href="#ref-for-dom-credentialrequestoptions-mediation-13">2.5.1. Request a Credential</a> <a href="#ref-for-dom-credentialrequestoptions-mediation-14">(2)</a>
-    <li><a href="#ref-for-dom-credentialrequestoptions-mediation-15">7.1. Website Authors</a>
+    <li><a href="#ref-for-dom-credentialrequestoptions-mediation">2.3.1. The CredentialRequestOptions Dictionary</a> <a href="#ref-for-dom-credentialrequestoptions-mediation①">(2)</a> <a href="#ref-for-dom-credentialrequestoptions-mediation②">(3)</a> <a href="#ref-for-dom-credentialrequestoptions-mediation③">(4)</a>
+    <li><a href="#ref-for-dom-credentialrequestoptions-mediation④">2.3.2.1. Examples</a> <a href="#ref-for-dom-credentialrequestoptions-mediation⑤">(2)</a> <a href="#ref-for-dom-credentialrequestoptions-mediation⑥">(3)</a> <a href="#ref-for-dom-credentialrequestoptions-mediation⑦">(4)</a> <a href="#ref-for-dom-credentialrequestoptions-mediation⑧">(5)</a> <a href="#ref-for-dom-credentialrequestoptions-mediation⑨">(6)</a> <a href="#ref-for-dom-credentialrequestoptions-mediation①⓪">(7)</a> <a href="#ref-for-dom-credentialrequestoptions-mediation①①">(8)</a>
+    <li><a href="#ref-for-dom-credentialrequestoptions-mediation①②">2.5.1. Request a Credential</a> <a href="#ref-for-dom-credentialrequestoptions-mediation①③">(2)</a>
+    <li><a href="#ref-for-dom-credentialrequestoptions-mediation①④">7.1. Website Authors</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="credentialrequestoptions-relevant-credential-interface-objects">
    <b><a href="#credentialrequestoptions-relevant-credential-interface-objects">#credentialrequestoptions-relevant-credential-interface-objects</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-credentialrequestoptions-relevant-credential-interface-objects-1">2.3.1. The CredentialRequestOptions Dictionary</a>
-    <li><a href="#ref-for-credentialrequestoptions-relevant-credential-interface-objects-2">2.5.2. Collect Credentials from the credential store</a>
-    <li><a href="#ref-for-credentialrequestoptions-relevant-credential-interface-objects-3">2.5.4. Create a Credential</a>
-    <li><a href="#ref-for-credentialrequestoptions-relevant-credential-interface-objects-4">5.3. Credential Selection</a> <a href="#ref-for-credentialrequestoptions-relevant-credential-interface-objects-5">(2)</a>
+    <li><a href="#ref-for-credentialrequestoptions-relevant-credential-interface-objects">2.3.1. The CredentialRequestOptions Dictionary</a>
+    <li><a href="#ref-for-credentialrequestoptions-relevant-credential-interface-objects①">2.5.2. Collect Credentials from the credential store</a>
+    <li><a href="#ref-for-credentialrequestoptions-relevant-credential-interface-objects②">2.5.4. Create a Credential</a>
+    <li><a href="#ref-for-credentialrequestoptions-relevant-credential-interface-objects③">5.3. Credential Selection</a> <a href="#ref-for-credentialrequestoptions-relevant-credential-interface-objects④">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="credentialrequestoptions-matchable-a-priori">
    <b><a href="#credentialrequestoptions-matchable-a-priori">#credentialrequestoptions-matchable-a-priori</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-credentialrequestoptions-matchable-a-priori-1">2.3.1. The CredentialRequestOptions Dictionary</a>
-    <li><a href="#ref-for-credentialrequestoptions-matchable-a-priori-2">2.5.1. Request a Credential</a>
-    <li><a href="#ref-for-credentialrequestoptions-matchable-a-priori-3">5.3. Credential Selection</a>
+    <li><a href="#ref-for-credentialrequestoptions-matchable-a-priori">2.3.1. The CredentialRequestOptions Dictionary</a>
+    <li><a href="#ref-for-credentialrequestoptions-matchable-a-priori①">2.5.1. Request a Credential</a>
+    <li><a href="#ref-for-credentialrequestoptions-matchable-a-priori②">5.3. Credential Selection</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="enumdef-credentialmediationrequirement">
    <b><a href="#enumdef-credentialmediationrequirement">#enumdef-credentialmediationrequirement</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-enumdef-credentialmediationrequirement-1">2.3.1. The CredentialRequestOptions Dictionary</a> <a href="#ref-for-enumdef-credentialmediationrequirement-2">(2)</a> <a href="#ref-for-enumdef-credentialmediationrequirement-3">(3)</a>
-    <li><a href="#ref-for-enumdef-credentialmediationrequirement-4">2.3.2. Mediation Requirements</a>
+    <li><a href="#ref-for-enumdef-credentialmediationrequirement">2.3.1. The CredentialRequestOptions Dictionary</a> <a href="#ref-for-enumdef-credentialmediationrequirement①">(2)</a> <a href="#ref-for-enumdef-credentialmediationrequirement②">(3)</a>
+    <li><a href="#ref-for-enumdef-credentialmediationrequirement③">2.3.2. Mediation Requirements</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-credentialmediationrequirement-silent">
    <b><a href="#dom-credentialmediationrequirement-silent">#dom-credentialmediationrequirement-silent</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-credentialmediationrequirement-silent-1">2.3.1. The CredentialRequestOptions Dictionary</a>
-    <li><a href="#ref-for-dom-credentialmediationrequirement-silent-2">2.3.2. Mediation Requirements</a>
-    <li><a href="#ref-for-dom-credentialmediationrequirement-silent-3">2.3.2.1. Examples</a> <a href="#ref-for-dom-credentialmediationrequirement-silent-4">(2)</a>
-    <li><a href="#ref-for-dom-credentialmediationrequirement-silent-5">2.5.1. Request a Credential</a>
+    <li><a href="#ref-for-dom-credentialmediationrequirement-silent">2.3.1. The CredentialRequestOptions Dictionary</a>
+    <li><a href="#ref-for-dom-credentialmediationrequirement-silent①">2.3.2. Mediation Requirements</a>
+    <li><a href="#ref-for-dom-credentialmediationrequirement-silent②">2.3.2.1. Examples</a> <a href="#ref-for-dom-credentialmediationrequirement-silent③">(2)</a>
+    <li><a href="#ref-for-dom-credentialmediationrequirement-silent④">2.5.1. Request a Credential</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-credentialmediationrequirement-optional">
    <b><a href="#dom-credentialmediationrequirement-optional">#dom-credentialmediationrequirement-optional</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-credentialmediationrequirement-optional-1">2.3.1. The CredentialRequestOptions Dictionary</a>
-    <li><a href="#ref-for-dom-credentialmediationrequirement-optional-2">2.3.2. Mediation Requirements</a>
-    <li><a href="#ref-for-dom-credentialmediationrequirement-optional-3">2.3.2.1. Examples</a> <a href="#ref-for-dom-credentialmediationrequirement-optional-4">(2)</a>
+    <li><a href="#ref-for-dom-credentialmediationrequirement-optional">2.3.1. The CredentialRequestOptions Dictionary</a>
+    <li><a href="#ref-for-dom-credentialmediationrequirement-optional①">2.3.2. Mediation Requirements</a>
+    <li><a href="#ref-for-dom-credentialmediationrequirement-optional②">2.3.2.1. Examples</a> <a href="#ref-for-dom-credentialmediationrequirement-optional③">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-credentialmediationrequirement-required">
    <b><a href="#dom-credentialmediationrequirement-required">#dom-credentialmediationrequirement-required</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-credentialmediationrequirement-required-1">2.3.2. Mediation Requirements</a>
-    <li><a href="#ref-for-dom-credentialmediationrequirement-required-2">2.3.2.1. Examples</a> <a href="#ref-for-dom-credentialmediationrequirement-required-3">(2)</a> <a href="#ref-for-dom-credentialmediationrequirement-required-4">(3)</a> <a href="#ref-for-dom-credentialmediationrequirement-required-5">(4)</a>
-    <li><a href="#ref-for-dom-credentialmediationrequirement-required-6">2.5.1. Request a Credential</a>
+    <li><a href="#ref-for-dom-credentialmediationrequirement-required">2.3.2. Mediation Requirements</a>
+    <li><a href="#ref-for-dom-credentialmediationrequirement-required①">2.3.2.1. Examples</a> <a href="#ref-for-dom-credentialmediationrequirement-required②">(2)</a> <a href="#ref-for-dom-credentialmediationrequirement-required③">(3)</a> <a href="#ref-for-dom-credentialmediationrequirement-required④">(4)</a>
+    <li><a href="#ref-for-dom-credentialmediationrequirement-required⑤">2.5.1. Request a Credential</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dictdef-credentialcreationoptions">
    <b><a href="#dictdef-credentialcreationoptions">#dictdef-credentialcreationoptions</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dictdef-credentialcreationoptions-1">2.2.1. Credential Internal Methods</a>
-    <li><a href="#ref-for-dictdef-credentialcreationoptions-2">2.3. navigator.credentials</a>
-    <li><a href="#ref-for-dictdef-credentialcreationoptions-3">2.4. The CredentialCreationOptions Dictionary</a> <a href="#ref-for-dictdef-credentialcreationoptions-4">(2)</a>
-    <li><a href="#ref-for-dictdef-credentialcreationoptions-5">2.5.4. Create a Credential</a>
-    <li><a href="#ref-for-dictdef-credentialcreationoptions-6">3.2. The PasswordCredential Interface</a>
-    <li><a href="#ref-for-dictdef-credentialcreationoptions-7">3.3.2. 
-    PasswordCredential's [[Create]](options) </a> <a href="#ref-for-dictdef-credentialcreationoptions-8">(2)</a>
-    <li><a href="#ref-for-dictdef-credentialcreationoptions-9">4.1. The FederatedCredential Interface</a>
-    <li><a href="#ref-for-dictdef-credentialcreationoptions-10">4.2.2. 
+    <li><a href="#ref-for-dictdef-credentialcreationoptions">2.2.1. Credential Internal Methods</a>
+    <li><a href="#ref-for-dictdef-credentialcreationoptions①">2.3. navigator.credentials</a>
+    <li><a href="#ref-for-dictdef-credentialcreationoptions②">2.4. The CredentialCreationOptions Dictionary</a> <a href="#ref-for-dictdef-credentialcreationoptions③">(2)</a>
+    <li><a href="#ref-for-dictdef-credentialcreationoptions④">2.5.4. Create a Credential</a>
+    <li><a href="#ref-for-dictdef-credentialcreationoptions⑤">3.2. The PasswordCredential Interface</a>
+    <li><a href="#ref-for-dictdef-credentialcreationoptions⑥">3.3.2. 
+    PasswordCredential's [[Create]](options) </a> <a href="#ref-for-dictdef-credentialcreationoptions⑦">(2)</a>
+    <li><a href="#ref-for-dictdef-credentialcreationoptions⑧">4.1. The FederatedCredential Interface</a>
+    <li><a href="#ref-for-dictdef-credentialcreationoptions⑨">4.2.2. 
     FederatedCredential's [[Create]](options) </a>
-    <li><a href="#ref-for-dictdef-credentialcreationoptions-11">7.2. Extension Points</a>
+    <li><a href="#ref-for-dictdef-credentialcreationoptions①⓪">7.2. Extension Points</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="abstract-opdef-request-a-credential">
    <b><a href="#abstract-opdef-request-a-credential">#abstract-opdef-request-a-credential</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-abstract-opdef-request-a-credential-1">2.3. navigator.credentials</a>
+    <li><a href="#ref-for-abstract-opdef-request-a-credential">2.3. navigator.credentials</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="abstract-opdef-collect-credentials-from-the-credential-store">
    <b><a href="#abstract-opdef-collect-credentials-from-the-credential-store">#abstract-opdef-collect-credentials-from-the-credential-store</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-abstract-opdef-collect-credentials-from-the-credential-store-1">2.5.1. Request a Credential</a>
+    <li><a href="#ref-for-abstract-opdef-collect-credentials-from-the-credential-store">2.5.1. Request a Credential</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="abstract-opdef-store-a-credential">
    <b><a href="#abstract-opdef-store-a-credential">#abstract-opdef-store-a-credential</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-abstract-opdef-store-a-credential-1">2.3. navigator.credentials</a>
+    <li><a href="#ref-for-abstract-opdef-store-a-credential">2.3. navigator.credentials</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="abstract-opdef-create-a-credential">
    <b><a href="#abstract-opdef-create-a-credential">#abstract-opdef-create-a-credential</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-abstract-opdef-create-a-credential-1">2.3. navigator.credentials</a>
+    <li><a href="#ref-for-abstract-opdef-create-a-credential">2.3. navigator.credentials</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="abstract-opdef-prevent-silent-access">
    <b><a href="#abstract-opdef-prevent-silent-access">#abstract-opdef-prevent-silent-access</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-abstract-opdef-prevent-silent-access-1">2.3. navigator.credentials</a>
+    <li><a href="#ref-for-abstract-opdef-prevent-silent-access">2.3. navigator.credentials</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="passwordcredential">
    <b><a href="#passwordcredential">#passwordcredential</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-passwordcredential-1">2. Core API</a>
-    <li><a href="#ref-for-passwordcredential-2">3. Password Credentials</a>
-    <li><a href="#ref-for-passwordcredential-3">3.1.2. Post-sign-in Confirmation</a>
-    <li><a href="#ref-for-passwordcredential-4">3.1.3. Change Password</a>
-    <li><a href="#ref-for-passwordcredential-5">3.2. The PasswordCredential Interface</a> <a href="#ref-for-passwordcredential-6">(2)</a> <a href="#ref-for-passwordcredential-7">(3)</a> <a href="#ref-for-passwordcredential-8">(4)</a> <a href="#ref-for-passwordcredential-9">(5)</a> <a href="#ref-for-passwordcredential-10">(6)</a>
-    <li><a href="#ref-for-passwordcredential-11">3.3.1. 
+    <li><a href="#ref-for-passwordcredential">2. Core API</a>
+    <li><a href="#ref-for-passwordcredential①">3. Password Credentials</a>
+    <li><a href="#ref-for-passwordcredential②">3.1.2. Post-sign-in Confirmation</a>
+    <li><a href="#ref-for-passwordcredential③">3.1.3. Change Password</a>
+    <li><a href="#ref-for-passwordcredential④">3.2. The PasswordCredential Interface</a> <a href="#ref-for-passwordcredential⑤">(2)</a> <a href="#ref-for-passwordcredential⑥">(3)</a> <a href="#ref-for-passwordcredential⑦">(4)</a> <a href="#ref-for-passwordcredential⑧">(5)</a> <a href="#ref-for-passwordcredential⑨">(6)</a>
+    <li><a href="#ref-for-passwordcredential①⓪">3.3.1. 
     PasswordCredential's [[CollectFromCredentialStore]](options) </a>
-    <li><a href="#ref-for-passwordcredential-12">3.3.2. 
-    PasswordCredential's [[Create]](options) </a> <a href="#ref-for-passwordcredential-13">(2)</a>
-    <li><a href="#ref-for-passwordcredential-14">3.3.3. 
-    PasswordCredential's [[Store]](credential) </a> <a href="#ref-for-passwordcredential-15">(2)</a> <a href="#ref-for-passwordcredential-16">(3)</a>
-    <li><a href="#ref-for-passwordcredential-17">3.3.4. 
+    <li><a href="#ref-for-passwordcredential①①">3.3.2. 
+    PasswordCredential's [[Create]](options) </a> <a href="#ref-for-passwordcredential①②">(2)</a>
+    <li><a href="#ref-for-passwordcredential①③">3.3.3. 
+    PasswordCredential's [[Store]](credential) </a> <a href="#ref-for-passwordcredential①④">(2)</a> <a href="#ref-for-passwordcredential①⑤">(3)</a>
+    <li><a href="#ref-for-passwordcredential①⑥">3.3.4. 
     Create a PasswordCredential from an HTMLFormElement </a>
-    <li><a href="#ref-for-passwordcredential-18">3.3.5. 
+    <li><a href="#ref-for-passwordcredential①⑦">3.3.5. 
     Create a PasswordCredential from PasswordCredentialData </a>
-    <li><a href="#ref-for-passwordcredential-19">3.3.6. 
+    <li><a href="#ref-for-passwordcredential①⑧">3.3.6. 
     CredentialRequestOptions Matching for PasswordCredential </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-credentialrequestoptions-password">
    <b><a href="#dom-credentialrequestoptions-password">#dom-credentialrequestoptions-password</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-credentialrequestoptions-password-1">3.1.1. Password-based Sign-in</a> <a href="#ref-for-dom-credentialrequestoptions-password-2">(2)</a>
-    <li><a href="#ref-for-dom-credentialrequestoptions-password-3">3.3.1. 
-    PasswordCredential's [[CollectFromCredentialStore]](options) </a> <a href="#ref-for-dom-credentialrequestoptions-password-4">(2)</a>
-    <li><a href="#ref-for-dom-credentialrequestoptions-password-5">3.3.6. 
+    <li><a href="#ref-for-dom-credentialrequestoptions-password">3.1.1. Password-based Sign-in</a> <a href="#ref-for-dom-credentialrequestoptions-password①">(2)</a>
+    <li><a href="#ref-for-dom-credentialrequestoptions-password②">3.3.1. 
+    PasswordCredential's [[CollectFromCredentialStore]](options) </a> <a href="#ref-for-dom-credentialrequestoptions-password③">(2)</a>
+    <li><a href="#ref-for-dom-credentialrequestoptions-password④">3.3.6. 
     CredentialRequestOptions Matching for PasswordCredential </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-passwordcredential-password">
    <b><a href="#dom-passwordcredential-password">#dom-passwordcredential-password</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-passwordcredential-password-1">3.2. The PasswordCredential Interface</a>
-    <li><a href="#ref-for-dom-passwordcredential-password-2">3.3.3. 
-    PasswordCredential's [[Store]](credential) </a> <a href="#ref-for-dom-passwordcredential-password-3">(2)</a> <a href="#ref-for-dom-passwordcredential-password-4">(3)</a> <a href="#ref-for-dom-passwordcredential-password-5">(4)</a>
-    <li><a href="#ref-for-dom-passwordcredential-password-6">3.3.5. 
+    <li><a href="#ref-for-dom-passwordcredential-password">3.2. The PasswordCredential Interface</a>
+    <li><a href="#ref-for-dom-passwordcredential-password①">3.3.3. 
+    PasswordCredential's [[Store]](credential) </a> <a href="#ref-for-dom-passwordcredential-password②">(2)</a> <a href="#ref-for-dom-passwordcredential-password③">(3)</a> <a href="#ref-for-dom-passwordcredential-password④">(4)</a>
+    <li><a href="#ref-for-dom-passwordcredential-password⑤">3.3.5. 
     Create a PasswordCredential from PasswordCredentialData </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-credential-type-password">
    <b><a href="#dom-credential-type-password">#dom-credential-type-password</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-credential-type-password-1">3.1.1. Password-based Sign-in</a>
+    <li><a href="#ref-for-dom-credential-type-password">3.1.1. Password-based Sign-in</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-passwordcredential-passwordcredential">
    <b><a href="#dom-passwordcredential-passwordcredential">#dom-passwordcredential-passwordcredential</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-passwordcredential-passwordcredential-1">3.1.2. Post-sign-in Confirmation</a>
-    <li><a href="#ref-for-dom-passwordcredential-passwordcredential-2">3.1.3. Change Password</a>
-    <li><a href="#ref-for-dom-passwordcredential-passwordcredential-3">3.2. The PasswordCredential Interface</a>
+    <li><a href="#ref-for-dom-passwordcredential-passwordcredential">3.1.2. Post-sign-in Confirmation</a>
+    <li><a href="#ref-for-dom-passwordcredential-passwordcredential①">3.1.3. Change Password</a>
+    <li><a href="#ref-for-dom-passwordcredential-passwordcredential②">3.2. The PasswordCredential Interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-passwordcredential-passwordcredential-data">
    <b><a href="#dom-passwordcredential-passwordcredential-data">#dom-passwordcredential-passwordcredential-data</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-passwordcredential-passwordcredential-data-1">3.2. The PasswordCredential Interface</a>
+    <li><a href="#ref-for-dom-passwordcredential-passwordcredential-data">3.2. The PasswordCredential Interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dictdef-passwordcredentialdata">
    <b><a href="#dictdef-passwordcredentialdata">#dictdef-passwordcredentialdata</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dictdef-passwordcredentialdata-1">3.2. The PasswordCredential Interface</a> <a href="#ref-for-dictdef-passwordcredentialdata-2">(2)</a> <a href="#ref-for-dictdef-passwordcredentialdata-3">(3)</a> <a href="#ref-for-dictdef-passwordcredentialdata-4">(4)</a>
-    <li><a href="#ref-for-dictdef-passwordcredentialdata-5">3.3.2. 
-    PasswordCredential's [[Create]](options) </a> <a href="#ref-for-dictdef-passwordcredentialdata-6">(2)</a>
-    <li><a href="#ref-for-dictdef-passwordcredentialdata-7">3.3.4. 
+    <li><a href="#ref-for-dictdef-passwordcredentialdata">3.2. The PasswordCredential Interface</a> <a href="#ref-for-dictdef-passwordcredentialdata①">(2)</a> <a href="#ref-for-dictdef-passwordcredentialdata②">(3)</a> <a href="#ref-for-dictdef-passwordcredentialdata③">(4)</a>
+    <li><a href="#ref-for-dictdef-passwordcredentialdata④">3.3.2. 
+    PasswordCredential's [[Create]](options) </a> <a href="#ref-for-dictdef-passwordcredentialdata⑤">(2)</a>
+    <li><a href="#ref-for-dictdef-passwordcredentialdata⑥">3.3.4. 
     Create a PasswordCredential from an HTMLFormElement </a>
-    <li><a href="#ref-for-dictdef-passwordcredentialdata-8">3.3.5. 
+    <li><a href="#ref-for-dictdef-passwordcredentialdata⑦">3.3.5. 
     Create a PasswordCredential from PasswordCredentialData </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-passwordcredentialdata-name">
    <b><a href="#dom-passwordcredentialdata-name">#dom-passwordcredentialdata-name</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-passwordcredentialdata-name-1">3.3.5. 
+    <li><a href="#ref-for-dom-passwordcredentialdata-name">3.3.5. 
     Create a PasswordCredential from PasswordCredentialData </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-passwordcredentialdata-iconurl">
    <b><a href="#dom-passwordcredentialdata-iconurl">#dom-passwordcredentialdata-iconurl</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-passwordcredentialdata-iconurl-1">3.3.5. 
+    <li><a href="#ref-for-dom-passwordcredentialdata-iconurl">3.3.5. 
     Create a PasswordCredential from PasswordCredentialData </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-passwordcredentialdata-password">
    <b><a href="#dom-passwordcredentialdata-password">#dom-passwordcredentialdata-password</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-passwordcredentialdata-password-1">3.3.4. 
-    Create a PasswordCredential from an HTMLFormElement </a> <a href="#ref-for-dom-passwordcredentialdata-password-2">(2)</a>
-    <li><a href="#ref-for-dom-passwordcredentialdata-password-3">3.3.5. 
-    Create a PasswordCredential from PasswordCredentialData </a> <a href="#ref-for-dom-passwordcredentialdata-password-4">(2)</a>
+    <li><a href="#ref-for-dom-passwordcredentialdata-password">3.3.4. 
+    Create a PasswordCredential from an HTMLFormElement </a> <a href="#ref-for-dom-passwordcredentialdata-password①">(2)</a>
+    <li><a href="#ref-for-dom-passwordcredentialdata-password②">3.3.5. 
+    Create a PasswordCredential from PasswordCredentialData </a> <a href="#ref-for-dom-passwordcredentialdata-password③">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="typedefdef-passwordcredentialinit">
    <b><a href="#typedefdef-passwordcredentialinit">#typedefdef-passwordcredentialinit</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-typedefdef-passwordcredentialinit-1">3.2. The PasswordCredential Interface</a>
+    <li><a href="#ref-for-typedefdef-passwordcredentialinit">3.2. The PasswordCredential Interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-credentialcreationoptions-password">
    <b><a href="#dom-credentialcreationoptions-password">#dom-credentialcreationoptions-password</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-credentialcreationoptions-password-1">3.3.2. 
-    PasswordCredential's [[Create]](options) </a> <a href="#ref-for-dom-credentialcreationoptions-password-2">(2)</a> <a href="#ref-for-dom-credentialcreationoptions-password-3">(3)</a> <a href="#ref-for-dom-credentialcreationoptions-password-4">(4)</a> <a href="#ref-for-dom-credentialcreationoptions-password-5">(5)</a>
+    <li><a href="#ref-for-dom-credentialcreationoptions-password">3.3.2. 
+    PasswordCredential's [[Create]](options) </a> <a href="#ref-for-dom-credentialcreationoptions-password①">(2)</a> <a href="#ref-for-dom-credentialcreationoptions-password②">(3)</a> <a href="#ref-for-dom-credentialcreationoptions-password③">(4)</a> <a href="#ref-for-dom-credentialcreationoptions-password④">(5)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-passwordcredential-collectfromcredentialstore-slot">
    <b><a href="#dom-passwordcredential-collectfromcredentialstore-slot">#dom-passwordcredential-collectfromcredentialstore-slot</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-passwordcredential-collectfromcredentialstore-slot-1">3.2. The PasswordCredential Interface</a>
+    <li><a href="#ref-for-dom-passwordcredential-collectfromcredentialstore-slot">3.2. The PasswordCredential Interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-passwordcredential-create-slot">
    <b><a href="#dom-passwordcredential-create-slot">#dom-passwordcredential-create-slot</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-passwordcredential-create-slot-1">3.2. The PasswordCredential Interface</a>
+    <li><a href="#ref-for-dom-passwordcredential-create-slot">2.2. The Credential Interface</a>
+    <li><a href="#ref-for-dom-passwordcredential-create-slot①">3.2. The PasswordCredential Interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-passwordcredential-store-slot">
    <b><a href="#dom-passwordcredential-store-slot">#dom-passwordcredential-store-slot</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-passwordcredential-store-slot-1">3.2. The PasswordCredential Interface</a>
+    <li><a href="#ref-for-dom-passwordcredential-store-slot">3.2. The PasswordCredential Interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="abstract-opdef-create-a-passwordcredential-from-an-htmlformelement">
    <b><a href="#abstract-opdef-create-a-passwordcredential-from-an-htmlformelement">#abstract-opdef-create-a-passwordcredential-from-an-htmlformelement</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-abstract-opdef-create-a-passwordcredential-from-an-htmlformelement-1">3.2. The PasswordCredential Interface</a>
-    <li><a href="#ref-for-abstract-opdef-create-a-passwordcredential-from-an-htmlformelement-2">3.3.2. 
+    <li><a href="#ref-for-abstract-opdef-create-a-passwordcredential-from-an-htmlformelement">3.2. The PasswordCredential Interface</a>
+    <li><a href="#ref-for-abstract-opdef-create-a-passwordcredential-from-an-htmlformelement①">3.3.2. 
     PasswordCredential's [[Create]](options) </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="abstract-opdef-create-a-passwordcredential-from-passwordcredentialdata">
    <b><a href="#abstract-opdef-create-a-passwordcredential-from-passwordcredentialdata">#abstract-opdef-create-a-passwordcredential-from-passwordcredentialdata</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-abstract-opdef-create-a-passwordcredential-from-passwordcredentialdata-1">3.2. The PasswordCredential Interface</a>
-    <li><a href="#ref-for-abstract-opdef-create-a-passwordcredential-from-passwordcredentialdata-2">3.3.2. 
+    <li><a href="#ref-for-abstract-opdef-create-a-passwordcredential-from-passwordcredentialdata">3.2. The PasswordCredential Interface</a>
+    <li><a href="#ref-for-abstract-opdef-create-a-passwordcredential-from-passwordcredentialdata①">3.3.2. 
     PasswordCredential's [[Create]](options) </a>
-    <li><a href="#ref-for-abstract-opdef-create-a-passwordcredential-from-passwordcredentialdata-3">3.3.4. 
+    <li><a href="#ref-for-abstract-opdef-create-a-passwordcredential-from-passwordcredentialdata②">3.3.4. 
     Create a PasswordCredential from an HTMLFormElement </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="federatedcredential">
    <b><a href="#federatedcredential">#federatedcredential</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-federatedcredential-1">2. Core API</a>
-    <li><a href="#ref-for-federatedcredential-2">4.1. The FederatedCredential Interface</a> <a href="#ref-for-federatedcredential-3">(2)</a> <a href="#ref-for-federatedcredential-4">(3)</a> <a href="#ref-for-federatedcredential-5">(4)</a> <a href="#ref-for-federatedcredential-6">(5)</a> <a href="#ref-for-federatedcredential-7">(6)</a>
-    <li><a href="#ref-for-federatedcredential-8">4.1.1. Identifying Providers</a>
-    <li><a href="#ref-for-federatedcredential-9">4.2.1. 
+    <li><a href="#ref-for-federatedcredential">2. Core API</a>
+    <li><a href="#ref-for-federatedcredential①">4.1. The FederatedCredential Interface</a> <a href="#ref-for-federatedcredential②">(2)</a> <a href="#ref-for-federatedcredential③">(3)</a> <a href="#ref-for-federatedcredential④">(4)</a> <a href="#ref-for-federatedcredential⑤">(5)</a> <a href="#ref-for-federatedcredential⑥">(6)</a>
+    <li><a href="#ref-for-federatedcredential⑦">4.1.1. Identifying Providers</a>
+    <li><a href="#ref-for-federatedcredential⑧">4.2.1. 
     FederatedCredential's [[CollectFromCredentialStore]](options) </a>
-    <li><a href="#ref-for-federatedcredential-10">4.2.2. 
+    <li><a href="#ref-for-federatedcredential⑨">4.2.2. 
     FederatedCredential's [[Create]](options) </a>
-    <li><a href="#ref-for-federatedcredential-11">4.2.3. 
-    FederatedCredential's [[Store]](credential) </a> <a href="#ref-for-federatedcredential-12">(2)</a> <a href="#ref-for-federatedcredential-13">(3)</a>
-    <li><a href="#ref-for-federatedcredential-14">4.2.4. 
+    <li><a href="#ref-for-federatedcredential①⓪">4.2.3. 
+    FederatedCredential's [[Store]](credential) </a> <a href="#ref-for-federatedcredential①①">(2)</a> <a href="#ref-for-federatedcredential①②">(3)</a>
+    <li><a href="#ref-for-federatedcredential①③">4.2.4. 
     Create a FederatedCredential from FederatedCredentialInit </a>
-    <li><a href="#ref-for-federatedcredential-15">8. Future Work</a>
+    <li><a href="#ref-for-federatedcredential①④">8. Future Work</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dictdef-federatedcredentialrequestoptions">
    <b><a href="#dictdef-federatedcredentialrequestoptions">#dictdef-federatedcredentialrequestoptions</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dictdef-federatedcredentialrequestoptions-1">4.1. The FederatedCredential Interface</a>
-    <li><a href="#ref-for-dictdef-federatedcredentialrequestoptions-2">4.1.1. Identifying Providers</a>
+    <li><a href="#ref-for-dictdef-federatedcredentialrequestoptions">4.1. The FederatedCredential Interface</a>
+    <li><a href="#ref-for-dictdef-federatedcredentialrequestoptions①">4.1.1. Identifying Providers</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-federatedcredentialrequestoptions-providers">
    <b><a href="#dom-federatedcredentialrequestoptions-providers">#dom-federatedcredentialrequestoptions-providers</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-federatedcredentialrequestoptions-providers-1">4.1.1. Identifying Providers</a>
-    <li><a href="#ref-for-dom-federatedcredentialrequestoptions-providers-2">4.2.1. 
+    <li><a href="#ref-for-dom-federatedcredentialrequestoptions-providers">4.1.1. Identifying Providers</a>
+    <li><a href="#ref-for-dom-federatedcredentialrequestoptions-providers①">4.2.1. 
     FederatedCredential's [[CollectFromCredentialStore]](options) </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-federatedcredentialrequestoptions-protocols">
    <b><a href="#dom-federatedcredentialrequestoptions-protocols">#dom-federatedcredentialrequestoptions-protocols</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-federatedcredentialrequestoptions-protocols-1">4.2.1. 
+    <li><a href="#ref-for-dom-federatedcredentialrequestoptions-protocols">4.2.1. 
     FederatedCredential's [[CollectFromCredentialStore]](options) </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-credentialrequestoptions-federated">
    <b><a href="#dom-credentialrequestoptions-federated">#dom-credentialrequestoptions-federated</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-credentialrequestoptions-federated-1">4.2.1. 
-    FederatedCredential's [[CollectFromCredentialStore]](options) </a> <a href="#ref-for-dom-credentialrequestoptions-federated-2">(2)</a> <a href="#ref-for-dom-credentialrequestoptions-federated-3">(3)</a>
+    <li><a href="#ref-for-dom-credentialrequestoptions-federated">4.2.1. 
+    FederatedCredential's [[CollectFromCredentialStore]](options) </a> <a href="#ref-for-dom-credentialrequestoptions-federated①">(2)</a> <a href="#ref-for-dom-credentialrequestoptions-federated②">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-federatedcredential-provider">
    <b><a href="#dom-federatedcredential-provider">#dom-federatedcredential-provider</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-federatedcredential-provider-1">4.1. The FederatedCredential Interface</a> <a href="#ref-for-dom-federatedcredential-provider-2">(2)</a>
-    <li><a href="#ref-for-dom-federatedcredential-provider-3">4.1.1. Identifying Providers</a>
-    <li><a href="#ref-for-dom-federatedcredential-provider-4">4.2.1. 
+    <li><a href="#ref-for-dom-federatedcredential-provider">4.1. The FederatedCredential Interface</a> <a href="#ref-for-dom-federatedcredential-provider①">(2)</a>
+    <li><a href="#ref-for-dom-federatedcredential-provider②">4.1.1. Identifying Providers</a>
+    <li><a href="#ref-for-dom-federatedcredential-provider③">4.2.1. 
     FederatedCredential's [[CollectFromCredentialStore]](options) </a>
-    <li><a href="#ref-for-dom-federatedcredential-provider-5">4.2.3. 
-    FederatedCredential's [[Store]](credential) </a> <a href="#ref-for-dom-federatedcredential-provider-6">(2)</a> <a href="#ref-for-dom-federatedcredential-provider-7">(3)</a> <a href="#ref-for-dom-federatedcredential-provider-8">(4)</a>
-    <li><a href="#ref-for-dom-federatedcredential-provider-9">4.2.4. 
+    <li><a href="#ref-for-dom-federatedcredential-provider④">4.2.3. 
+    FederatedCredential's [[Store]](credential) </a> <a href="#ref-for-dom-federatedcredential-provider⑤">(2)</a> <a href="#ref-for-dom-federatedcredential-provider⑥">(3)</a> <a href="#ref-for-dom-federatedcredential-provider⑦">(4)</a>
+    <li><a href="#ref-for-dom-federatedcredential-provider⑧">4.2.4. 
     Create a FederatedCredential from FederatedCredentialInit </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-federatedcredential-protocol">
    <b><a href="#dom-federatedcredential-protocol">#dom-federatedcredential-protocol</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-federatedcredential-protocol-1">4.1. The FederatedCredential Interface</a>
-    <li><a href="#ref-for-dom-federatedcredential-protocol-2">4.2.1. 
+    <li><a href="#ref-for-dom-federatedcredential-protocol">4.1. The FederatedCredential Interface</a>
+    <li><a href="#ref-for-dom-federatedcredential-protocol①">4.2.1. 
     FederatedCredential's [[CollectFromCredentialStore]](options) </a>
-    <li><a href="#ref-for-dom-federatedcredential-protocol-3">4.2.3. 
-    FederatedCredential's [[Store]](credential) </a> <a href="#ref-for-dom-federatedcredential-protocol-4">(2)</a>
+    <li><a href="#ref-for-dom-federatedcredential-protocol②">4.2.3. 
+    FederatedCredential's [[Store]](credential) </a> <a href="#ref-for-dom-federatedcredential-protocol③">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-federatedcredential-federatedcredential">
    <b><a href="#dom-federatedcredential-federatedcredential">#dom-federatedcredential-federatedcredential</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-federatedcredential-federatedcredential-1">4.1. The FederatedCredential Interface</a>
+    <li><a href="#ref-for-dom-federatedcredential-federatedcredential">4.1. The FederatedCredential Interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dictdef-federatedcredentialinit">
    <b><a href="#dictdef-federatedcredentialinit">#dictdef-federatedcredentialinit</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dictdef-federatedcredentialinit-1">4.1. The FederatedCredential Interface</a> <a href="#ref-for-dictdef-federatedcredentialinit-2">(2)</a> <a href="#ref-for-dictdef-federatedcredentialinit-3">(3)</a> <a href="#ref-for-dictdef-federatedcredentialinit-4">(4)</a>
-    <li><a href="#ref-for-dictdef-federatedcredentialinit-5">4.2.4. 
+    <li><a href="#ref-for-dictdef-federatedcredentialinit">4.1. The FederatedCredential Interface</a> <a href="#ref-for-dictdef-federatedcredentialinit①">(2)</a> <a href="#ref-for-dictdef-federatedcredentialinit②">(3)</a> <a href="#ref-for-dictdef-federatedcredentialinit③">(4)</a>
+    <li><a href="#ref-for-dictdef-federatedcredentialinit④">4.2.4. 
     Create a FederatedCredential from FederatedCredentialInit </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-federatedcredentialinit-provider">
    <b><a href="#dom-federatedcredentialinit-provider">#dom-federatedcredentialinit-provider</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-federatedcredentialinit-provider-1">4.2.4. 
-    Create a FederatedCredential from FederatedCredentialInit </a> <a href="#ref-for-dom-federatedcredentialinit-provider-2">(2)</a>
+    <li><a href="#ref-for-dom-federatedcredentialinit-provider">4.2.4. 
+    Create a FederatedCredential from FederatedCredentialInit </a> <a href="#ref-for-dom-federatedcredentialinit-provider①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-credentialcreationoptions-federated">
    <b><a href="#dom-credentialcreationoptions-federated">#dom-credentialcreationoptions-federated</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-credentialcreationoptions-federated-1">4.2.2. 
-    FederatedCredential's [[Create]](options) </a> <a href="#ref-for-dom-credentialcreationoptions-federated-2">(2)</a>
+    <li><a href="#ref-for-dom-credentialcreationoptions-federated">4.2.2. 
+    FederatedCredential's [[Create]](options) </a> <a href="#ref-for-dom-credentialcreationoptions-federated①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-federatedcredential-collectfromcredentialstore-slot">
    <b><a href="#dom-federatedcredential-collectfromcredentialstore-slot">#dom-federatedcredential-collectfromcredentialstore-slot</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-federatedcredential-collectfromcredentialstore-slot-1">4.1. The FederatedCredential Interface</a>
+    <li><a href="#ref-for-dom-federatedcredential-collectfromcredentialstore-slot">4.1. The FederatedCredential Interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-federatedcredential-create-slot">
    <b><a href="#dom-federatedcredential-create-slot">#dom-federatedcredential-create-slot</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-federatedcredential-create-slot-1">4.1. The FederatedCredential Interface</a>
+    <li><a href="#ref-for-dom-federatedcredential-create-slot">4.1. The FederatedCredential Interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-federatedcredential-store-slot">
    <b><a href="#dom-federatedcredential-store-slot">#dom-federatedcredential-store-slot</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-federatedcredential-store-slot-1">4.1. The FederatedCredential Interface</a>
+    <li><a href="#ref-for-dom-federatedcredential-store-slot">4.1. The FederatedCredential Interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="abstract-opdef-create-a-federatedcredential-from-federatedcredentialinit">
    <b><a href="#abstract-opdef-create-a-federatedcredential-from-federatedcredentialinit">#abstract-opdef-create-a-federatedcredential-from-federatedcredentialinit</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-abstract-opdef-create-a-federatedcredential-from-federatedcredentialinit-1">4.1. The FederatedCredential Interface</a>
-    <li><a href="#ref-for-abstract-opdef-create-a-federatedcredential-from-federatedcredentialinit-2">4.2.2. 
+    <li><a href="#ref-for-abstract-opdef-create-a-federatedcredential-from-federatedcredentialinit">4.1. The FederatedCredential Interface</a>
+    <li><a href="#ref-for-abstract-opdef-create-a-federatedcredential-from-federatedcredentialinit①">4.2.2. 
     FederatedCredential's [[Create]](options) </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="user-mediated">
    <b><a href="#user-mediated">#user-mediated</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-user-mediated-1">2.3.1. The CredentialRequestOptions Dictionary</a> <a href="#ref-for-user-mediated-2">(2)</a>
-    <li><a href="#ref-for-user-mediated-3">2.3.2. Mediation Requirements</a> <a href="#ref-for-user-mediated-4">(2)</a>
-    <li><a href="#ref-for-user-mediated-5">2.3.2.1. Examples</a> <a href="#ref-for-user-mediated-6">(2)</a>
-    <li><a href="#ref-for-user-mediated-7">3.3.3. 
-    PasswordCredential's [[Store]](credential) </a> <a href="#ref-for-user-mediated-8">(2)</a>
-    <li><a href="#ref-for-user-mediated-9">5. User Mediation</a>
-    <li><a href="#ref-for-user-mediated-10">5.1. Storing and Updating Credentials</a>
-    <li><a href="#ref-for-user-mediated-11">5.2. Requiring User Mediation</a> <a href="#ref-for-user-mediated-12">(2)</a> <a href="#ref-for-user-mediated-13">(3)</a>
-    <li><a href="#ref-for-user-mediated-14">5.3. Credential Selection</a>
-    <li><a href="#ref-for-user-mediated-15">6.1. Cross-domain credential access</a>
+    <li><a href="#ref-for-user-mediated">2.3.1. The CredentialRequestOptions Dictionary</a> <a href="#ref-for-user-mediated①">(2)</a>
+    <li><a href="#ref-for-user-mediated②">2.3.2. Mediation Requirements</a> <a href="#ref-for-user-mediated③">(2)</a>
+    <li><a href="#ref-for-user-mediated④">2.3.2.1. Examples</a> <a href="#ref-for-user-mediated⑤">(2)</a>
+    <li><a href="#ref-for-user-mediated⑥">3.3.3. 
+    PasswordCredential's [[Store]](credential) </a> <a href="#ref-for-user-mediated⑦">(2)</a>
+    <li><a href="#ref-for-user-mediated⑧">5. User Mediation</a>
+    <li><a href="#ref-for-user-mediated⑨">5.1. Storing and Updating Credentials</a>
+    <li><a href="#ref-for-user-mediated①⓪">5.2. Requiring User Mediation</a> <a href="#ref-for-user-mediated①①">(2)</a> <a href="#ref-for-user-mediated①②">(3)</a>
+    <li><a href="#ref-for-user-mediated①③">5.3. Credential Selection</a>
+    <li><a href="#ref-for-user-mediated①④">6.1. Cross-domain credential access</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="credential-chooser">
    <b><a href="#credential-chooser">#credential-chooser</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-credential-chooser-1">2.2.2. CredentialUserData Mixin</a> <a href="#ref-for-credential-chooser-2">(2)</a> <a href="#ref-for-credential-chooser-3">(3)</a>
-    <li><a href="#ref-for-credential-chooser-4">2.3.2. Mediation Requirements</a>
-    <li><a href="#ref-for-credential-chooser-5">2.3.2.1. Examples</a> <a href="#ref-for-credential-chooser-6">(2)</a>
-    <li><a href="#ref-for-credential-chooser-7">3. Password Credentials</a>
-    <li><a href="#ref-for-credential-chooser-8">3.1.1. Password-based Sign-in</a>
-    <li><a href="#ref-for-credential-chooser-9">5. User Mediation</a>
-    <li><a href="#ref-for-credential-chooser-10">5.2. Requiring User Mediation</a>
-    <li><a href="#ref-for-credential-chooser-11">6.7. Chooser Leakage</a>
+    <li><a href="#ref-for-credential-chooser">2.2.2. CredentialUserData Mixin</a> <a href="#ref-for-credential-chooser①">(2)</a> <a href="#ref-for-credential-chooser②">(3)</a>
+    <li><a href="#ref-for-credential-chooser③">2.3.2. Mediation Requirements</a>
+    <li><a href="#ref-for-credential-chooser④">2.3.2.1. Examples</a> <a href="#ref-for-credential-chooser⑤">(2)</a>
+    <li><a href="#ref-for-credential-chooser⑥">3. Password Credentials</a>
+    <li><a href="#ref-for-credential-chooser⑦">3.1.1. Password-based Sign-in</a>
+    <li><a href="#ref-for-credential-chooser⑧">5. User Mediation</a>
+    <li><a href="#ref-for-credential-chooser⑨">5.2. Requiring User Mediation</a>
+    <li><a href="#ref-for-credential-chooser①⓪">6.7. Chooser Leakage</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="abstract-opdef-ask-the-user-to-choose-a-credential">
    <b><a href="#abstract-opdef-ask-the-user-to-choose-a-credential">#abstract-opdef-ask-the-user-to-choose-a-credential</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-abstract-opdef-ask-the-user-to-choose-a-credential-1">2.5.1. Request a Credential</a>
+    <li><a href="#ref-for-abstract-opdef-ask-the-user-to-choose-a-credential">2.5.1. Request a Credential</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */

--- a/index.src.html
+++ b/index.src.html
@@ -52,9 +52,6 @@ spec: PSL; urlPrefix: https://publicsuffix.org/list/
 spec: FETCH; urlPrefix: https://fetch.spec.whatwg.org/
   type: dfn
     text: http-network-or-cache fetch; url: http-network-or-cache-fetch 
-spec: DOM; urlPrefix: https://dom.spec.whatwg.org/
-  type: interface
-    text: AbortSignal url: https://dom.spec.whatwg.org/#abortsignal
 </pre>
 <pre class="link-defaults">
 spec:html; type:dfn; for:/; text:origin
@@ -242,7 +239,6 @@ spec:url; type:dfn; text:urlencoded byte serializer
     interface Credential {
       readonly attribute USVString id;
       readonly attribute DOMString type;
-      readonly attribute AbortSignal signal;
     };
   </pre>
   <div dfn-for="Credential">
@@ -253,12 +249,6 @@ spec:url; type:dfn; text:urlencoded byte serializer
     :   <dfn attribute>type</dfn>
     ::  This attribute's getter returns the value of the object's [=interface object=]'s
         {{[[type]]}} slot, which specifies the kind of credential represented by this object.
-
-    :   <dfn attribute>signal</dfn>
-    ::  The credential object has an associated signal (an {{AbortSignal}} object), initially 
-        a new {{AbortSignal}} object. Developers can use AbortSignal to [=terminated|terminate=] an 
-        ongoing {{PasswordCredential/[[Create]](options)}} operation or 
-        {{Credential/[[DiscoverFromExternalSource]](options)}} operation. 
 
     :   <dfn attribute>\[[type]]</dfn>
     ::  The {{Credential}} [=interface object=] has an internal slot named `[[type]]`, which

--- a/index.src.html
+++ b/index.src.html
@@ -302,7 +302,7 @@ spec:url; type:dfn; text:urlencoded byte serializer
     <dfn for="Credential" method export>\[[CollectFromCredentialStore]](options)</dfn> is called
     with a {{CredentialRequestOptions}}, and returns a set of {{Credential}} objects from the user
     agent's [=credential store=] that match the options provided. If no matching {{Credential}}
-    objects are available, the returned set will be empty. 
+    objects are available, the returned set will be empty.
 
     <ol class="algorithm">
       1.  Return an empty set.
@@ -335,7 +335,7 @@ spec:url; type:dfn; text:urlencoded byte serializer
     <dfn for="Credential" method export>\[[Create]](options)</dfn> is called with a
     {{CredentialCreationOptions}}, and returns either a {{Credential}}, if one can be created, 
     `null` if no credential was created, or an error if creation fails due to exceptional situations
-    (for example, incorrect options could produce a {{TypeError}}). 
+    (for example, incorrect options could produce a {{TypeError}}):
 
     <ol class="algorithm">
       1.  Return `null`.

--- a/index.src.html
+++ b/index.src.html
@@ -452,6 +452,7 @@ spec:url; type:dfn; text:urlencoded byte serializer
   <pre class="idl">
     dictionary CredentialRequestOptions {
       CredentialMediationRequirement mediation = "optional";
+      AbortSignal signal;
     };
   </pre>
   <div dfn-for="CredentialRequestOptions" dfn-type="dict-member">
@@ -671,6 +672,7 @@ spec:url; type:dfn; text:urlencoded byte serializer
 
   <pre class="idl">
     dictionary CredentialCreationOptions {
+      AbortSignal signal;
     };
   </pre>
 

--- a/index.src.html
+++ b/index.src.html
@@ -282,10 +282,7 @@ spec:url; type:dfn; text:urlencoded byte serializer
   ### `Credential` Internal Methods ### {#credential-internal-methods}
 
   Each [=interface object=] created for interfaces which [=interface/inherit=] from {{Credential}}
-  defines several internal methods that allow retrieval and storage of {{Credential}} objects. The
-  methods taking an `options` argument receive an {{AbortSignal}}, with which they
-  can [respond](https://dom.spec.whatwg.org/#abortcontroller-api-integration) to a caller attempting
-  to abort them.
+  defines several internal methods that allow retrieval and storage of {{Credential}} objects:
 
   <section algorithm="'collect credentials' internal method">
     <dfn for="Credential" method export>\[[CollectFromCredentialStore]](options)</dfn> is called
@@ -1923,6 +1920,11 @@ spec:url; type:dfn; text:urlencoded byte serializer
       can therefore simply be copied out of the [=credential store=], while
       {{Credential/[[DiscoverFromExternalSource]](options)}} is appropriate for
       [=credentials=] that need to be re-generated from a [=credential source=].
+
+      Long-running operations, like those in {{PublicKeyCredential}}'s
+      {{PublicKeyCredential/[[Create]](options)}} and {{PublicKeyCredential/[[DiscoverFromExternalSource]](options)}}
+      operations are encouraged to use <code>options.signal</code> to allow developers to abort
+      the operation. See [[dom#abortcontroller-api-integration]] for detailed instructions.
 
       <div class="example">
         `ExampleCredential`'s `[[CollectFromCredentialStore]](options)` internal method is called

--- a/index.src.html
+++ b/index.src.html
@@ -58,6 +58,7 @@ spec:html; type:dfn; for:/; text:origin
 spec:fetch; type:dfn; for:/; text:request
 spec:fetch; type:dictionary; for:/; text:RequestInit
 spec:webidl; type:interface; text:Promise
+spec:dom; type:dfn; text:aborted flag
 
 <!-- These need to be exported -->
 spec:html; type:dfn; text:submittable element
@@ -430,7 +431,7 @@ spec:url; type:dfn; text:urlencoded byte serializer
 
         Note: This function was previously called `requireUserMediation()` which should be considered
         deprecated.
-      </div>
+  </div>
 
   <div algorithm="create credentialscontainer">
     When a {{Navigator}} object (|navigator|) is created, the user agent MUST create a
@@ -460,7 +461,7 @@ spec:url; type:dfn; text:urlencoded byte serializer
         Processing details are defined in [[#algorithm-request]].
     :   <dfn>signal</dfn>
     ::  This property lets the developer abort an ongoing 
-        {{[[DiscoverFromExternalSource]](options)}} operation and subequently all related 
+        {{[[DiscoverFromExternalSource]](options)}} operation and subsequently all related 
         [=authenticatorGetAssertion=] operations. Aborted promise would 
         be rejected with an "AbortError" DOMException. 
   </div>
@@ -680,9 +681,10 @@ spec:url; type:dfn; text:urlencoded byte serializer
   </pre>
    <div dfn-for="CredentialCreationOptions" dfn-type="dict-member">
     :   <dfn>signal</dfn>
-    ::  This property lets the developer to abort an ongoing {{Credential/[[Create]](options)}} operation
-        and susquently all related [=authenticatorMakeCredential=] operations. Aborted romise would 
-        be rejected with an "AbortError" DOMException. 
+    ::  This property lets the developer abort an ongoing {{Credential/[[Create]](options)}} operation
+        and susquently all related [=authenticatorMakeCredential=] operations. An aborted operation 
+        may complete successfully (if the [=aborted flag=] was set after the operation completed) 
+        or be rejected with an "{{AbortError}}" {{DOMException}}. 
   </div>
 
   

--- a/index.src.html
+++ b/index.src.html
@@ -52,6 +52,9 @@ spec: PSL; urlPrefix: https://publicsuffix.org/list/
 spec: FETCH; urlPrefix: https://fetch.spec.whatwg.org/
   type: dfn
     text: http-network-or-cache fetch; url: http-network-or-cache-fetch 
+spec: DOM; urlPrefix: https://dom.spec.whatwg.org/
+  type: interface
+    text: AbortSignal url: https://dom.spec.whatwg.org/#abortsignal
 </pre>
 <pre class="link-defaults">
 spec:html; type:dfn; for:/; text:origin
@@ -239,6 +242,7 @@ spec:url; type:dfn; text:urlencoded byte serializer
     interface Credential {
       readonly attribute USVString id;
       readonly attribute DOMString type;
+      readonly attribute AbortSignal signal;
     };
   </pre>
   <div dfn-for="Credential">
@@ -249,6 +253,12 @@ spec:url; type:dfn; text:urlencoded byte serializer
     :   <dfn attribute>type</dfn>
     ::  This attribute's getter returns the value of the object's [=interface object=]'s
         {{[[type]]}} slot, which specifies the kind of credential represented by this object.
+
+    :   <dfn attribute>signal</dfn>
+    ::  The credential object has an associated signal (an {{AbortSignal}} object), initially 
+        a new {{AbortSignal}} object. Developers can use AbortSignal to [=terminated|terminate=] an 
+        ongoing {{PasswordCredential/[[Create]](options)}} operation or 
+        {{Credential/[[DiscoverFromExternalSource]](options)}} operation. 
 
     :   <dfn attribute>\[[type]]</dfn>
     ::  The {{Credential}} [=interface object=] has an internal slot named `[[type]]`, which
@@ -282,13 +292,17 @@ spec:url; type:dfn; text:urlencoded byte serializer
   ### `Credential` Internal Methods ### {#credential-internal-methods}
 
   Each [=interface object=] created for interfaces which [=interface/inherit=] from {{Credential}}
-  defines several internal methods that allow retrieval and storage of {{Credential}} objects:
+  defines several internal methods that allow retrieval and storage of {{Credential}} objects. The 
+  {{Credential/[[Create]](options)}} method and {{Credential/[[DiscoverFromExternalSource]](options)}}
+  method can be <dfn id="concept-credman-terminated">terminated</dfn> with flag
+  [=AbortSignal/aborted flag=], which is unset unless otherwise specificed. When methods are 
+  [=terminated=], the promise MUST be rejected with an {{AbortError}} {{DOMException}}.  
 
   <section algorithm="'collect credentials' internal method">
     <dfn for="Credential" method export>\[[CollectFromCredentialStore]](options)</dfn> is called
     with a {{CredentialRequestOptions}}, and returns a set of {{Credential}} objects from the user
     agent's [=credential store=] that match the options provided. If no matching {{Credential}}
-    objects are available, the returned set will be empty.
+    objects are available, the returned set will be empty. 
 
     <ol class="algorithm">
       1.  Return an empty set.
@@ -321,7 +335,7 @@ spec:url; type:dfn; text:urlencoded byte serializer
     <dfn for="Credential" method export>\[[Create]](options)</dfn> is called with a
     {{CredentialCreationOptions}}, and returns either a {{Credential}}, if one can be created, 
     `null` if no credential was created, or an error if creation fails due to exceptional situations
-    (for example, incorrect options could produce a {{TypeError}}):
+    (for example, incorrect options could produce a {{TypeError}}). 
 
     <ol class="algorithm">
       1.  Return `null`.
@@ -828,7 +842,7 @@ spec:url; type:dfn; text:urlencoded byte serializer
 
     5.  Let |p| be [=a new promise=].
 
-    6.  Run the following steps [=in parallel=]:
+    6.  Run the following steps [=in parallel=] but abort if the execution is [=terminated=]:
 
         1.  Let |r| be the result of executing |interfaces|[0] {{Credential/[[Create]](options)}}
             internal method on |options|.

--- a/index.src.html
+++ b/index.src.html
@@ -1880,7 +1880,7 @@ spec:url; type:dfn; text:urlencoded byte serializer
  ██  ██     ██ ██        ██       ██       ██     ██ ██       ██   ███    ██    ██     ██    ██     ██  ██     ██ ██   ███
 ████ ██     ██ ██        ████████ ████████ ██     ██ ████████ ██    ██    ██    ██     ██    ██    ████  ███████  ██    ██
 -->
-<section>
+<section class="non-normative">
   # Implementation Considerations # {#implementation}
 
   <em>This section is non-normative.</em>

--- a/index.src.html
+++ b/index.src.html
@@ -284,9 +284,7 @@ spec:url; type:dfn; text:urlencoded byte serializer
   Each [=interface object=] created for interfaces which [=interface/inherit=] from {{Credential}}
   defines several internal methods that allow retrieval and storage of {{Credential}} objects. The 
   {{Credential/[[Create]](options)}} method and {{Credential/[[DiscoverFromExternalSource]](options)}}
-  method can be <dfn id="concept-credman-terminated">terminated</dfn> with flag
-  [=AbortSignal/aborted flag=], which is unset unless otherwise specificed. When methods are 
-  [=terminated=], the promise MUST be rejected with an {{AbortError}} {{DOMException}}.  
+  method can be aborted. 
 
   <section algorithm="'collect credentials' internal method">
     <dfn for="Credential" method export>\[[CollectFromCredentialStore]](options)</dfn> is called
@@ -432,7 +430,7 @@ spec:url; type:dfn; text:urlencoded byte serializer
 
         Note: This function was previously called `requireUserMediation()` which should be considered
         deprecated.
-  </div>
+      </div>
 
   <div algorithm="create credentialscontainer">
     When a {{Navigator}} object (|navigator|) is created, the user agent MUST create a
@@ -460,6 +458,11 @@ spec:url; type:dfn; text:urlencoded byte serializer
     ::  This property specifies the mediation requirements for a given credential request. The
         meaning of each enum value is described below in {{CredentialMediationRequirement}}.
         Processing details are defined in [[#algorithm-request]].
+    :   <dfn>signal</dfn>
+    ::  This property allow the developer to abort an ongoing 
+        {{[[DiscoverFromExternalSource]](options)}} operation and subequently all related 
+        [=authenticatorGetAssertion=] operations. Aborted romise would 
+        be rejected with an "AbortError" DOMException. 
   </div>
 
   <div class="note">
@@ -675,7 +678,14 @@ spec:url; type:dfn; text:urlencoded byte serializer
       AbortSignal signal;
     };
   </pre>
+   <div dfn-for="CredentialCreationOptions" dfn-type="dict-member">
+    :   <dfn>signal</dfn>
+    ::  This property allow the developer to abort an ongoing {{Credential/[[Create]](options)}} operation
+        and susquently all related [=authenticatorMakeCredential=] operations. Aborted romise would 
+        be rejected with an "AbortError" DOMException. 
+  </div>
 
+  
   ## Algorithms ## {#algorithms}
 
   <h4 id="algorithm-request" algorithm>Request a `Credential`</h4>
@@ -813,37 +823,37 @@ spec:url; type:dfn; text:urlencoded byte serializer
   <ol class="algorithm">
     1.  Let |settings| be the <a>current settings object</a>
 
-    2.  Assert: |settings| is a [=secure context=].
+    1.  Assert: |settings| is a [=secure context=].
 
-    3.  Let |interfaces| be the set of |options|' <a>relevant credential interface objects</a>.
+    1.  Let |interfaces| be the set of |options|' <a>relevant credential interface objects</a>.
 
-    4.  Return [=a promise rejected with=] `NotSupportedError` if any of the following statements
+    1.  Return [=a promise rejected with=] `NotSupportedError` if any of the following statements
         are true:
 
         1.  |settings| does not have a [=environment settings object/responsible document=].
 
-        2.  |settings|' [=environment settings object/responsible document=] is not the
+        1.  |settings|' [=environment settings object/responsible document=] is not the
             [=active document=] in a [=top-level browsing context=].
 
-        3.  |interfaces|' [=list/size=] is greater than 1.
+        1.  |interfaces|' [=list/size=] is greater than 1.
 
             Note: It may be reasonable at some point in the future to loosen this restriction, and
             allow the user agent to help the user choose among one of many potential credential
             types in order to support a "sign-up" use case. For the moment, though, we're punting
             on that by restricting the dictionary to a single entry.
 
-    5.  Let |p| be [=a new promise=].
+    1.  Let |p| be [=a new promise=].
 
-    6.  Run the following steps [=in parallel=] but abort if the execution is [=terminated=]:
+    1.  Run the following steps [=in parallel=]:
 
         1.  Let |r| be the result of executing |interfaces|[0] {{Credential/[[Create]](options)}}
             internal method on |options|.
 
-        2.  If |r| is an [=exception=], [=reject=] |p| with |r|.
+        1.  If |r| is an [=exception=], [=reject=] |p| with |r|.
 
             Otherwise, [=resolve=] |p| with |r|.
 
-    7.  Return |p|.
+    1.  Return |p|.
   </ol>
 
   <h4 id="algorithm-prevent-silent-access" algorithm>Prevent Silent Access</h4>

--- a/index.src.html
+++ b/index.src.html
@@ -58,7 +58,6 @@ spec:html; type:dfn; for:/; text:origin
 spec:fetch; type:dfn; for:/; text:request
 spec:fetch; type:dictionary; for:/; text:RequestInit
 spec:webidl; type:interface; text:Promise
-spec:dom; type:dfn; text:aborted flag
 
 <!-- These need to be exported -->
 spec:html; type:dfn; text:submittable element
@@ -283,9 +282,10 @@ spec:url; type:dfn; text:urlencoded byte serializer
   ### `Credential` Internal Methods ### {#credential-internal-methods}
 
   Each [=interface object=] created for interfaces which [=interface/inherit=] from {{Credential}}
-  defines several internal methods that allow retrieval and storage of {{Credential}} objects. The 
-  {{Credential/[[Create]](options)}} method and {{Credential/[[DiscoverFromExternalSource]](options)}}
-  method can be aborted. 
+  defines several internal methods that allow retrieval and storage of {{Credential}} objects. The
+  methods taking an `options` argument receive an {{AbortSignal}}, with which they
+  can [respond](https://dom.spec.whatwg.org/#abortcontroller-api-integration) to a caller attempting
+  to abort them.
 
   <section algorithm="'collect credentials' internal method">
     <dfn for="Credential" method export>\[[CollectFromCredentialStore]](options)</dfn> is called
@@ -460,10 +460,9 @@ spec:url; type:dfn; text:urlencoded byte serializer
         meaning of each enum value is described below in {{CredentialMediationRequirement}}.
         Processing details are defined in [[#algorithm-request]].
     :   <dfn>signal</dfn>
-    ::  This property lets the developer abort an ongoing 
-        {{[[DiscoverFromExternalSource]](options)}} operation and subsequently all related 
-        [=authenticatorGetAssertion=] operations. Aborted promise would 
-        be rejected with an "AbortError" DOMException. 
+    ::  This property lets the developer abort an ongoing {{CredentialsContainer/get()}} operation.
+        An aborted operation may complete normally (generally if the abort was received after the
+        operation finished) or reject with an "{{AbortError}}" {{DOMException}}."
   </div>
 
   <div class="note">
@@ -679,15 +678,13 @@ spec:url; type:dfn; text:urlencoded byte serializer
       AbortSignal signal;
     };
   </pre>
-   <div dfn-for="CredentialCreationOptions" dfn-type="dict-member">
+  <div dfn-for="CredentialCreationOptions" dfn-type="dict-member">
     :   <dfn>signal</dfn>
-    ::  This property lets the developer abort an ongoing {{Credential/[[Create]](options)}} operation
-        and susquently all related [=authenticatorMakeCredential=] operations. An aborted operation 
-        may complete successfully (if the [=aborted flag=] was set after the operation completed) 
-        or be rejected with an "{{AbortError}}" {{DOMException}}. 
+    ::  This property lets the developer abort an ongoing {{CredentialsContainer/create()}}
+        operation. An aborted operation may complete normally (generally if the abort was received
+        after the operation finished) or reject with an "{{AbortError}}" {{DOMException}}."
   </div>
 
-  
   ## Algorithms ## {#algorithms}
 
   <h4 id="algorithm-request" algorithm>Request a `Credential`</h4>
@@ -708,6 +705,9 @@ spec:url; type:dfn; text:urlencoded byte serializer
 
         2.  |settings|' [=environment settings object/responsible document=] is not the
             [=active document=] in a [=top-level browsing context=].
+
+    1.  If <code>|options|.{{CredentialRequestOptions/signal}}</code>'s [=AbortSignal/aborted flag=]
+        is set, then return [=a promise rejected with=] an "{{AbortError}}" {{DOMException}}.
 
     4.  Let |p| be [=a new promise=].
    
@@ -843,6 +843,9 @@ spec:url; type:dfn; text:urlencoded byte serializer
             allow the user agent to help the user choose among one of many potential credential
             types in order to support a "sign-up" use case. For the moment, though, we're punting
             on that by restricting the dictionary to a single entry.
+
+    1.  If <code>|options|.{{CredentialCreationOptions/signal}}</code>'s [=AbortSignal/aborted
+        flag=] is set, then return [=a promise rejected with=] an "{{AbortError}}" {{DOMException}}.
 
     5.  Let |p| be [=a new promise=].
 

--- a/index.src.html
+++ b/index.src.html
@@ -459,9 +459,9 @@ spec:url; type:dfn; text:urlencoded byte serializer
         meaning of each enum value is described below in {{CredentialMediationRequirement}}.
         Processing details are defined in [[#algorithm-request]].
     :   <dfn>signal</dfn>
-    ::  This property allow the developer to abort an ongoing 
+    ::  This property lets the developer abort an ongoing 
         {{[[DiscoverFromExternalSource]](options)}} operation and subequently all related 
-        [=authenticatorGetAssertion=] operations. Aborted romise would 
+        [=authenticatorGetAssertion=] operations. Aborted promise would 
         be rejected with an "AbortError" DOMException. 
   </div>
 
@@ -680,7 +680,7 @@ spec:url; type:dfn; text:urlencoded byte serializer
   </pre>
    <div dfn-for="CredentialCreationOptions" dfn-type="dict-member">
     :   <dfn>signal</dfn>
-    ::  This property allow the developer to abort an ongoing {{Credential/[[Create]](options)}} operation
+    ::  This property lets the developer to abort an ongoing {{Credential/[[Create]](options)}} operation
         and susquently all related [=authenticatorMakeCredential=] operations. Aborted romise would 
         be rejected with an "AbortError" DOMException. 
   </div>
@@ -823,37 +823,37 @@ spec:url; type:dfn; text:urlencoded byte serializer
   <ol class="algorithm">
     1.  Let |settings| be the <a>current settings object</a>
 
-    1.  Assert: |settings| is a [=secure context=].
+    2.  Assert: |settings| is a [=secure context=].
 
-    1.  Let |interfaces| be the set of |options|' <a>relevant credential interface objects</a>.
+    3.  Let |interfaces| be the set of |options|' <a>relevant credential interface objects</a>.
 
-    1.  Return [=a promise rejected with=] `NotSupportedError` if any of the following statements
+    4.  Return [=a promise rejected with=] `NotSupportedError` if any of the following statements
         are true:
 
         1.  |settings| does not have a [=environment settings object/responsible document=].
 
-        1.  |settings|' [=environment settings object/responsible document=] is not the
+        2.  |settings|' [=environment settings object/responsible document=] is not the
             [=active document=] in a [=top-level browsing context=].
 
-        1.  |interfaces|' [=list/size=] is greater than 1.
+        3.  |interfaces|' [=list/size=] is greater than 1.
 
             Note: It may be reasonable at some point in the future to loosen this restriction, and
             allow the user agent to help the user choose among one of many potential credential
             types in order to support a "sign-up" use case. For the moment, though, we're punting
             on that by restricting the dictionary to a single entry.
 
-    1.  Let |p| be [=a new promise=].
+    5.  Let |p| be [=a new promise=].
 
-    1.  Run the following steps [=in parallel=]:
+    6.  Run the following steps [=in parallel=]:
 
         1.  Let |r| be the result of executing |interfaces|[0] {{Credential/[[Create]](options)}}
             internal method on |options|.
 
-        1.  If |r| is an [=exception=], [=reject=] |p| with |r|.
+        2.  If |r| is an [=exception=], [=reject=] |p| with |r|.
 
             Otherwise, [=resolve=] |p| with |r|.
 
-    1.  Return |p|.
+    7.  Return |p|.
   </ol>
 
   <h4 id="algorithm-prevent-silent-access" algorithm>Prevent Silent Access</h4>


### PR DESCRIPTION
This builds on #104 (Thanks @angelokai!) and now follows the instructions in https://dom.spec.whatwg.org/#abortcontroller-api-integration to bail out early if the caller has already aborted before the operation starts.

8c46783 shows two approaches to explaining how the internal methods use the AbortSignal. Let me know which you prefer.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/jyasskin/webappsec-credential-management/integrate-abort.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webappsec-credential-management/6e831a6...jyasskin:b26c4d1.html)