### PR TITLE
Remove typedef CredentialBodyType

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -1107,8 +1107,6 @@ spec:url; type:dfn; text:urlencoded byte serializer
   ## The `PasswordCredential` Interface ## {#passwordcredential-interface}
 
   <pre class="idl">
-    typedef (FormData or URLSearchParams) CredentialBodyType;
-
     [Constructor(HTMLFormElement form),
      Constructor(PasswordCredentialData data),
      Exposed=Window,


### PR DESCRIPTION
closes #122
It was defined but never used.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/marcoscaceres/webappsec-credential-management/pull/123.html" title="Last updated on Jul 18, 2018, 10:16 PM GMT (971f7a8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-credential-management/123/e62cb76...marcoscaceres:971f7a8.html" title="Last updated on Jul 18, 2018, 10:16 PM GMT (971f7a8)">Diff</a>