### PR TITLE
fix: getQuerySelector/querySelector in examples

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -974,12 +974,12 @@ spec:url; type:dfn; text:urlencoded byte serializer
           if (!credential) {
             return; // as above...
           }
-          if (credential.<a attribute for="Credential">type</a> == '<a const href="#password-literal">password</a>') {
-            document.getQuerySelector('input[name=username_field]').value =
-                credential.id;
-            document.getQuerySelector('input[name=password_field]').value =
-                credential.password;
-            document.getQuerySelector('#myform').submit();
+          if (credential.<a attribute for="Credential">type</a> === '<a const href="#password-literal">password</a>') {
+            document.querySelector('input[name=username_field]').value =
+              credential.id;
+            document.querySelector('input[name=password_field]').value =
+              credential.password;
+            document.getElementById('myform').submit();
           }
         });
     </pre>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/marcoscaceres/webappsec-credential-management/pull/125.html" title="Last updated on Jul 18, 2018, 11:36 PM GMT (d182f77)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-credential-management/125/e62cb76...marcoscaceres:d182f77.html" title="Last updated on Jul 18, 2018, 11:36 PM GMT (d182f77)">Diff</a>