### PR TITLE
Add default dictionary value

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -435,9 +435,9 @@ spec:css-syntax-3;
   <pre class="idl">
     [Exposed=Window, SecureContext]
     interface CredentialsContainer {
-      Promise&lt;Credential?&gt; get(optional CredentialRequestOptions options);
+      Promise&lt;Credential?&gt; get(optional CredentialRequestOptions options = {});
       Promise&lt;Credential&gt; store(Credential credential);
-      Promise&lt;Credential?&gt; create(optional CredentialCreationOptions options);
+      Promise&lt;Credential?&gt; create(optional CredentialCreationOptions options = {});
       Promise&lt;void&gt; preventSilentAccess();
     };
 


### PR DESCRIPTION
Required after heycam/webidl#750. (Found from web-platform-tests/wpt#18382)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/saschanaz/webappsec-credential-management/pull/139.html" title="Last updated on Feb 16, 2021, 11:21 PM UTC (b9265e8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-credential-management/139/99332be...saschanaz:b9265e8.html" title="Last updated on Feb 16, 2021, 11:21 PM UTC (b9265e8)">Diff</a>