### PR TITLE
Meta: Build, validate, and publish spec automatically

### DIFF
--- a/.github/workflows/build-validate-publish.yml
+++ b/.github/workflows/build-validate-publish.yml
@@ -1,0 +1,18 @@
+name: CI
+on:
+  pull_request: {}
+  push:
+    branches: [main]
+
+jobs:
+  main:
+    name: Build, Validate, and Publish
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: w3c/spec-prod@v2
+        with:
+          SOURCE: index.src.html
+          TOOLCHAIN: bikeshed
+          GH_PAGES_BRANCH: gh-pages
+          BUILD_FAIL_ON: nothing


### PR DESCRIPTION
This change adds CI automation to build and validate spec output — both for PRs and pushes to main — and to deploy/publish the spec output to https://w3c.github.io/webappsec-credential-management/ on pushes to main.

https://github.com/w3c/spec-prod is what does the actual work.