### PR TITLE
Cite HTML for postMessage(), not WEBMESSAGING fork

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -1912,7 +1912,7 @@ spec:css-syntax-3;
       mitigates the risk that credentials could be exfiltrated to `evil.com`.
 
   *   <a>`child-src`</a> restricts the nested browsing contexts which may be embedded in a page,
-      making it more difficult to inject a malicious `postMessage()` target. [[WEBMESSAGING]]
+      making it more difficult to inject a malicious `postMessage()` target. [[HTML]]
 
   Developers should, of course, also properly escape input and output, and consider using other
   layers of defense, such as Subresource Integrity [[SRI]] to further reduce risk.


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-credential-management/pull/159.html" title="Last updated on Feb 20, 2021, 5:39 AM UTC (2dd407c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-credential-management/159/0a402ff...2dd407c.html" title="Last updated on Feb 20, 2021, 5:39 AM UTC (2dd407c)">Diff</a>