### PR TITLE
Fix several build errors and warnings

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -39,6 +39,15 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
         text: name; url: attr-fe-autocomplete-name
         text: photo; url: attr-fe-autocomplete-photo
         text: username; url: attr-fe-autocomplete-username
+  urlPrefix: origin.html
+    type: dfn
+      text: origin; for: html-origin-def; url: concept-origin
+  urlPrefix: browsers.html
+    type: dfn
+      text: browsing context; for: document; url: concept-document-bc
+  urlPrefix: webappapis.html
+    type: dfn
+      text: DOM manipulation task source; url: dom-manipulation-task-source
 spec: XHR; urlPrefix: https://xhr.spec.whatwg.org/
   type: dfn
     text: entry; url: concept-formdata-entry
@@ -55,10 +64,13 @@ spec: PSL; urlPrefix: https://publicsuffix.org/list/
 spec: FETCH; urlPrefix: https://fetch.spec.whatwg.org/
   type: dfn
     text: http-network-or-cache fetch; url: http-network-or-cache-fetch
+spec: promises-guide-1; urlPrefix: https://www.w3.org/2001/tag/doc/promises-guide
+  type: dfn
+    text: promise-calling; url: should-promise-call
 </pre>
 
 <pre class="link-defaults">
-spec:html; type:dfn; for:/; text:origin
+spec:html; type:dfn; for:html-origin-def; text:origin
 spec:html; type:dfn; for:environment settings object; text:global object
 spec:fetch; type:dfn; for:/; text:request
 spec:fetch; type:dictionary; for:/; text:RequestInit
@@ -66,7 +78,7 @@ spec:infra; type:dfn; for:/; text:set
 spec:infra; type:dfn; for:struct; text:item
 spec:webidl; type:idl; for:/; text:Function
 spec:webidl; type:interface; text:Promise
-spec:promises-guide-1; type:dfn; text:resolve
+spec:webidl; type:dfn; text:resolve
 
 <!-- These need to be exported -->
 spec:html; type:dfn; text:submittable element
@@ -247,21 +259,25 @@ spec:css-syntax-3;
   An [=environment settings object=] (|settings|) is <dfn noexport>same-origin with its
   ancestors</dfn> if the following algorithm returns `true`:
 
-  1.  If |settings| has no [=environment settings object/responsible browsing context=],
+  1.  If |settings| has no [=environment settings object/responsible document=],
       return `false`.
 
-  2.  Let |origin| be |settings|' [=environment settings object/origin=].
+  2.  Let |document| be |settings|' [=environment settings object/responsible document=].
 
-  3.  Let |current| be |settings|' [=environment settings object/responsible browsing context=].
+  3.  If |document| has no [=document/browsing context=], return `false`.
 
-  4.  While |current| has a [=parent browsing context=]:
+  4.  Let |origin| be |settings|' [=environment settings object/origin=].
+
+  5.  Let |current| be |document|'s [=document/browsing context=].
+
+  6.  While |current| has a [=parent browsing context=]:
 
       1.  Set |current| to |current|'s [=parent browsing context=].
 
       2.  If |current|'s [=active document=]'s [=origin=] is not [=same origin=] with |origin|,
           return `false`.
 
-  5.  Return `true`.
+  7.  Return `true`.
 
   ## The `Credential` Interface ## {#the-credential-interface}
 
@@ -428,7 +444,7 @@ spec:css-syntax-3;
   </pre>
 
   The <dfn for="Navigator" attribute>`credentials`</dfn> attribute MUST return the
-  {{CredentialsContainer}} associated with the [=context object=].
+  {{CredentialsContainer}} associated with the [=active document=]'s [=document/browsing context=].
 
   Note: As discussed in [[#insecure-sites]], the credential management API is exposed only in
   [=Secure Contexts=].
@@ -1250,7 +1266,7 @@ spec:css-syntax-3;
   <ol class="algorithm">
     1.  Assert: |options|["{{CredentialRequestOptions/password}}"] [=map/exists=].
 
-    2.  If |sameOriginWithAncestors is `false`, return a "{{NotAllowedError}}" {{DOMException}}.
+    2.  If |sameOriginWithAncestors| is `false`, return a "{{NotAllowedError}}" {{DOMException}}.
 
         Note: This restriction aims to address the concern raised in [[#security-origin-confusion]].
 
@@ -1602,7 +1618,7 @@ spec:css-syntax-3;
   <ol class="algorithm">
     1.  Assert: |options|["{{CredentialRequestOptions/federated}}"] [=map/exists=].
 
-    2.  If <var ignore>sameOriginWithAncestors</var> is `false`, return a "{{NotAllowedError}}" {{DOMException}}.
+    2.  If |sameOriginWithAncestors| is `false`, return a "{{NotAllowedError}}" {{DOMException}}.
 
         Note: This restriction aims to address the concern raised in [[#security-origin-confusion]].
 
@@ -1632,7 +1648,7 @@ spec:css-syntax-3;
 
   <ol class="algorithm">
     1.  Assert: |options|["{{CredentialCreationOptions/federated}}"] [=map/exists=], and
-        <var ignore>sameOriginWithAncestors</var> is unused.
+        |sameOriginWithAncestors| is unused.
 
     2.  Set |options|["{{CredentialCreationOptions/federated}}"]'s {{FederatedCredentialInit/origin}}
         member's value to |origin|'s value.


### PR DESCRIPTION
* Refactor the definition of `same-origin with its ancestors`

  It was originally mentioning an environment settings object's
  responsible browsing context, but that is not a term defined in the
  HTML spec. Instead, refer to the responsible document (which may be
  null) and crawl through it to its browsing context. This should have
  no impact on the intended implementation for the algorithm.

* Disambiguate the definition for `origin`.

* Fix default definition for `resolve`.

* Manually add definitions for:
  * DOM manipulation task source.
  * promise-call.

* Do not ignore |sameOriginWithAncestors| for algorithms where it's used
  more than once.

Fixes #171