### PR TITLE
fix .pr-preview.json to use index.bs, not index.src.html

### DIFF
--- a/.pr-preview.json
+++ b/.pr-preview.json
@@ -1,5 +1,5 @@
 {
-    "src_file": "index.src.html",
+    "src_file": "index.bs",
     "type": "bikeshed",
     "params": {
         "force": 1


### PR DESCRIPTION
We did not update the `.pr-preview.json` config file when we changed the spec source file from `index.src.html` to `index.bs`.