### PR TITLE
Fail the CI on bikeshed warnings

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -13,6 +13,6 @@ jobs:
       - uses: w3c/spec-prod@v2
         with:
           GH_PAGES_BRANCH: gh-pages
-          BUILD_FAIL_ON: nothing
+          BUILD_FAIL_ON: warning
           VALIDATE_LINKS: false
           VALIDATE_MARKUP: true


### PR DESCRIPTION
https://github.com/w3c/webappsec-credential-management/runs/4107086975?check_suite_focus=true found a problem with a version of the PR, but then didn't fail the check, so the author didn't see it.

Failing on `link-error` would be fine too, but @nsatragno just made the spec warning-clean, so it'd be good to help keep it that way.