### PR TITLE
Reject aborted operations with the abort reason

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -535,7 +535,7 @@ spec:css-syntax-3;
     :   <dfn>signal</dfn>
     ::  This property lets the developer abort an ongoing {{CredentialsContainer/get()}} operation.
         An aborted operation may complete normally (generally if the abort was received after the
-        operation finished) or reject with an "{{AbortError}}" {{DOMException}}."
+        operation finished) or reject with an [=AbortSignal/abort reason=].
   </div>
 
   <div class="note">
@@ -755,7 +755,7 @@ spec:css-syntax-3;
     :   <dfn>signal</dfn>
     ::  This property lets the developer abort an ongoing {{CredentialsContainer/create()}}
         operation. An aborted operation may complete normally (generally if the abort was received
-        after the operation finished) or reject with an "{{AbortError}}" {{DOMException}}."
+        after the operation finished) or reject with an [=AbortSignal/abort reason=].
   </div>
 
   ## Algorithms ## {#algorithms}
@@ -771,8 +771,9 @@ spec:css-syntax-3;
 
     2.  Assert: |settings| is a [=secure context=].
 
-    3.  If <code>|options|.{{CredentialRequestOptions/signal}}</code>'s [=AbortSignal/aborted flag=]
-        is set, then return [=a promise rejected with=] an "{{AbortError}}" {{DOMException}}.
+    3.  If <code>|options|.{{CredentialRequestOptions/signal}}</code> is [=AbortSignal/aborted=],
+        then return [=a promise rejected with=]
+        <code>|options|.{{CredentialRequestOptions/signal}}</code>'s [=AbortSignal/abort reason=].
 
     4.  Let |p| be [=a new promise=].
 
@@ -918,8 +919,9 @@ spec:css-syntax-3;
             types in order to support a "sign-up" use case. For the moment, though, we're punting
             on that by restricting the dictionary to a single entry.
 
-    7.  If <code>|options|.{{CredentialCreationOptions/signal}}</code>'s [=AbortSignal/aborted
-        flag=] is set, then return [=a promise rejected with=] an "{{AbortError}}" {{DOMException}}.
+    3.  If <code>|options|.{{CredentialRequestOptions/signal}}</code> is [=AbortSignal/aborted=],
+        then return [=a promise rejected with=]
+        <code>|options|.{{CredentialRequestOptions/signal}}</code>'s [=AbortSignal/abort reason=].
 
     8.  Let |p| be [=a new promise=].
 


### PR DESCRIPTION
Reject aborted operations with the "abort reason" instead of AbortError.

Fixes #175.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nsatragno/webappsec-credential-management/pull/176.html" title="Last updated on Nov 10, 2021, 3:56 PM UTC (18a0146)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-credential-management/176/9617033...nsatragno:18a0146.html" title="Last updated on Nov 10, 2021, 3:56 PM UTC (18a0146)">Diff</a>