### PR TITLE
Use the registry to find interface objects for a CredentalOptions.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -673,31 +673,22 @@ spec:css-syntax-3;
     <ol class="algorithm">
         1.  Let |settings| be the <a>current settings object</a>
 
-        1.  Let |interface objects| be the set of [=interface objects=] on |settings|'
-            [=environment settings object/global object=].
-
         1.  Let |relevant interface objects| be an [=set/empty=] [=set=].
 
-        1.  For each |object| in |interface objects|:
+        1.  [=map/For each=] |optionKey| → <var ignore>optionValue</var> of |options|:
 
-            1.  If |object|'s [=inherited interfaces=] do not <a for="set">contain</a> {{Credential}},
-                <a for="iteration">continue</a>.
+            1.  Let |credentialInterfaceObject| be the [=credential type registry/Appropriate Interface Object=]
+                (on |settings|' [=environment settings object/global object=]) whose [=credential
+                type registry/Options Member Identifier=] is |optionKey|.
 
-            1.  Let |credentialType| be |object|'s {{Credential/[[type]]}} slot's value.
+            1.  Assert: |credentialInterfaceObject|'s {{[[type]]}} slot equals the [=credential type
+                registry/Credential Type=] whose [=credential type registry/Options Member
+                Identifier=] is |optionKey|.
 
-            1.  Let |key| be the [=credential type registry/Options Member Identifier=] whose [=credential type registry/Credential Type=] is |credentialType|.
-
-            1.  If |options|[|key|] <a for="map">exists</a>, <a for="set">append</a> |object| to
-                |relevant interface objects|.
+            1.  Append |credentialInterfaceObject| to |relevant interface objects|.
 
         1.  Return |relevant interface objects|.
     </ol>
-
-    ISSUE: jyasskin@ suggests replacing the iteration through the interface objects with a registry.
-    I'm not sure which is less clear, honestly. I'll leave it like this for the moment, and we can
-    argue about whether this is too much of a `COMEFROM` interface. (The addition of the
-    [[#sctn-cred-type-registry|Credential Type Registry]]
-    does not obviate this issue.)
   </div>
 
   <div algorithm="can collect locally">


### PR DESCRIPTION
This the core of @jyasskin's answer to [my questions here](https://github.com/w3c/webappsec-credential-management/pull/181#discussion_r781658592) wrt how to re-write the relevant credential interface objects alg to use the new registry.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/webappsec-credential-management/pull/185.html" title="Last updated on Jan 12, 2022, 10:31 PM UTC (da4772a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-credential-management/185/37a3cb2...jyasskin:da4772a.html" title="Last updated on Jan 12, 2022, 10:31 PM UTC (da4772a)">Diff</a>