### PR TITLE
create separate security and privacy considerations sections

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2136,15 +2136,6 @@ spec:css-syntax-3;
   will immedietely return an empty set if called from inside a {{Worker}}, or a non-[=top-level
   browsing context=].
 
-  ## Timing Attacks ## {#security-timing}
-
-  If the user has no credentials for an origin, a call to {{CredentialsContainer/get()}} will
-  resolve very quickly indeed. A malicious website could distinguish between a user with no
-  credentials and a user with credentials who chooses not to share them.
-
-  User agents SHOULD also rate-limit credential requests. It's almost certainly abusive for a page
-  to request credentials more than a few times in a short period.
-
   ## Signing-Out ## {#security-signout}
 
   If a user has chosen to automatically sign-in to websites, as discussed in
@@ -2169,6 +2160,15 @@ spec:css-syntax-3;
 
 <section>
   # Privacy Considerations # {#privacy-considerations}
+
+  ## Timing Attacks ## {#security-timing}
+
+  If the user has no credentials for an origin, a call to {{CredentialsContainer/get()}} will
+  resolve very quickly indeed. A malicious website could distinguish between a user with no
+  credentials and a user with credentials who chooses not to share them.
+
+  User agents SHOULD also rate-limit credential requests. It's almost certainly abusive for a page
+  to request credentials more than a few times in a short period.
 
   ## Chooser Leakage ## {#security-chooser-leakage}
 

--- a/index.bs
+++ b/index.bs
@@ -2049,7 +2049,7 @@ spec:css-syntax-3;
  ██████  ████████  ██████   ███████  ██     ██ ████    ██       ██
 -->
 <section>
-  # Security and Privacy Considerations # {#security-and-privacy}
+  # Security Considerations # {#security-considerations}
 
   The following sections represent guidelines for various security and privacy considerations.
   Individual credential types may enforce stricter or more relaxed versions of these guidelines.
@@ -2164,6 +2164,11 @@ spec:css-syntax-3;
   the [=credential store=] to `true`. Additionally, the user agent SHOULD provide some UI affordance
   for disabling automatic sign-in for a particular origin. This could be tied to the notification
   that credentials have been provided to an origin, for example.
+</section>
+
+
+<section>
+  # Privacy Considerations # {#privacy-considerations}
 
   ## Chooser Leakage ## {#security-chooser-leakage}
 


### PR DESCRIPTION
This is a very quickly done separation of section [6. Security and Privacy Considerations](https://w3c.github.io/webappsec-credential-management/#security-and-privacy) into two separate "security cons" and "privacy cons" sections in order to get our editors' draft to be published.

upon a quick scan it seemed the last two subsections were the only privacy-oriented ones, so I carved them into the new "privacy cons" section.

This will need review and polishing no doubt, but hopefully will re-instate editors' draft auto-updating. 

fixes #186


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-credential-management/pull/187.html" title="Last updated on Jan 19, 2022, 8:56 PM UTC (c04caaf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-credential-management/187/2311d7b...c04caaf.html" title="Last updated on Jan 19, 2022, 8:56 PM UTC (c04caaf)">Diff</a>