### PR TITLE
Editorial: use associated Document in place of responsible document

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1078,7 +1078,7 @@ spec:css-syntax-3;
     6.  Return [=a promise rejected with=] `NotSupportedError` if any of the following statements
         are true:
 
-        1.  |settings| does not have a [=environment settings object/responsible document=].
+        1.  |global| does not have an [=associated Document=].
 
         2.  |interfaces|' [=list/size=] is greater than 1.
 

--- a/index.bs
+++ b/index.bs
@@ -277,10 +277,10 @@ spec:css-syntax-3;
   ancestors</dfn> if the following algorithm returns `true`:
 
   <ol class="algorithm">
-    1.  If |settings| has no [=environment settings object/responsible document=],
+    1.  If |settings|'s [=relevant global object=] has no [=associated Document=],
         return `false`.
 
-    2.  Let |document| be |settings|' [=environment settings object/responsible document=].
+    2.  Let |document| be |settings|' [=relevant global object=]'s [=associated Document=].
 
     3.  If |document| has no [=document/browsing context=], return `false`.
 
@@ -932,12 +932,14 @@ spec:css-syntax-3;
         ancestors=], and `false` otherwise.
 
     1.  If |options|[{{CredentialRequestOptions/publicKey}}] [=map/exists=] then
-        if |settings|' [=responsible document=] is **not** [=allowed to use=] the
-        [=publickey-credentials-get-feature|publickey-credentials-get=]
-        [=policy-controlled feature=] return [=a promise rejected with=] a "{{NotAllowedError}}" {{DOMException}}.
+        if |settings|' [=relevant global object=]'s [=associated Document=] is **not**
+        [=allowed to use=] the [=publickey-credentials-get-feature|publickey-credentials-get=]
+        [=policy-controlled feature=] return [=a promise rejected with=] a "{{NotAllowedError}}"
+        {{DOMException}}.
 
-        Note: <a const>`password`</a> and <a const>`federated`</a> [=credential type registry/credential types=] are not presently
-        treated as [=policy-controlled features=], although this may change in the future.
+        Note: <a const>`password`</a> and <a const>`federated`</a>
+        [=credential type registry/credential types=] are not presently treated as
+        [=policy-controlled features=], although this may change in the future.
 
     1.  Run the following steps [=in parallel=]:
 


### PR DESCRIPTION
cf. https://github.com/whatwg/html/pull/7694


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/miketaylr/webappsec-credential-management/pull/193.html" title="Last updated on Mar 31, 2022, 7:32 PM UTC (52feb5b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-credential-management/193/466e853...miketaylr:52feb5b.html" title="Last updated on Mar 31, 2022, 7:32 PM UTC (52feb5b)">Diff</a>