### PR TITLE
Throw exceptions instead of returning them

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -988,6 +988,8 @@ spec:css-syntax-3;
 
                     1. [=Reject=] |p| with |e|.
 
+		1. Terminate these substeps.
+
         1.  Assert: |result| is `null`, or a {{Credential}}.
 
         1.  If |result| is a {{Credential}}, [=resolve=] |p| with |result|.
@@ -1018,7 +1020,7 @@ spec:css-syntax-3;
 
         1.  Let |r| be the result of executing |interface|'s
             {{Credential/[[CollectFromCredentialStore]](origin, options, sameOriginWithAncestors)}} internal method on
-            |origin|, |options|, and |sameOriginWithAncestors|. If that threw an [=exception], rethrow that exception.
+            |origin|, |options|, and |sameOriginWithAncestors|. If that threw an [=exception=], rethrow that exception.
 
         2.  Assert: |r| is a list of [=interface objects=].
 
@@ -1119,6 +1121,8 @@ spec:css-syntax-3;
                following substeps:
 
                1. [=Reject=] |p| with |e|.
+
+	    3. Terminate these substeps.
 
         2.  If |r| is a {{Credential}} or `null`, [=resolve=] |p| with |r|, and terminate these substeps.
 

--- a/index.bs
+++ b/index.bs
@@ -978,7 +978,7 @@ spec:css-syntax-3;
             1.  Set |result| to the result of executing |result|'s
                 {{[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}},
                 given |origin|, |options|, and |sameOriginWithAncestors|. If that threw an
-		exception, then [=reject=] |p| with that exception, and terminate these substeps.
+                exception, then [=reject=] |p| with that exception, and terminate these substeps.
 
         1.  Assert: |result| is `null`, or a {{Credential}}.
 
@@ -1097,7 +1097,7 @@ spec:css-syntax-3;
         1.  Let |r| be the result of executing |interfaces|[0]'s
             {{Credential/[[Create]](origin, options, sameOriginWithAncestors)}} internal method on
             |origin|, |options|, and |sameOriginWithAncestors|. If that threw an exception, then
-	    [=reject=] |p| with that exception, and terminate these substeps.
+            [=reject=] |p| with that exception, and terminate these substeps.
 
         2.  If |r| is a {{Credential}} or `null`, [=resolve=] |p| with |r|, and terminate these substeps.
 
@@ -1601,7 +1601,7 @@ spec:css-syntax-3;
 
     7.  Let |c| be the result of executing <a abstract-op>Create a `PasswordCredential` from
         `PasswordCredentialData`</a> on |data|. If that threw an exception, re-throw that
-	exception.
+        exception.
      
     8.  Assert: |c| is a {{PasswordCredential}}.
 
@@ -1711,7 +1711,7 @@ spec:css-syntax-3;
 
         1.  Let |r| be the result of executing <a abstract-op>Create a `FederatedCredential` from
             `FederatedCredentialInit`</a> on |data|. If that threw an exception, re-throw that
-	    exception.
+            exception.
 
         2.  Return |r|.
   </div>

--- a/index.bs
+++ b/index.bs
@@ -1052,7 +1052,14 @@ spec:css-syntax-3;
             {{Credential/[[Store]](credential, sameOriginWithAncestors)}} internal method on
             |credential| and |sameOriginWithAncestors|.
 
-        2.  If |r| is an [=exception=], [=reject=] |p| with |r|.
+            If that threw an [=exception=]:
+
+            1.  Let |e| be the thrown [=exception=].
+
+            2.  [=Queue a task=] on |global|'s [=DOM manipulation task source=] to run the
+                following substeps:
+
+                1. [=Reject=] |p| with |e|.
 
             Otherwise, [=resolve=] |p| with |r|.
 
@@ -1501,7 +1508,7 @@ spec:css-syntax-3;
   The algorithm will return a `NotAllowedError` if |sameOriginWithAncestors| is not `true`.
 
   <ol class="algorithm">
-    1.  Return a "{{NotAllowedError}}" {{DOMException}} without altering the user agent's
+    1.  Throw a "{{NotAllowedError}}" {{DOMException}} without altering the user agent's
         [=credential store=] if |sameOriginWithAncestors| is `false`.
 
         Note: This restriction aims to address the concern raised in [[#security-origin-confusion]].
@@ -1850,7 +1857,7 @@ spec:css-syntax-3;
   The algorithm will return a `NotAllowedError` if |sameOriginWithAncestors| is not `true`.
 
   <ol class="algorithm">
-    1.  Return a "{{NotAllowedError}}" {{DOMException}} without altering the user agent's
+    1.  Throw a "{{NotAllowedError}}" {{DOMException}} without altering the user agent's
         [=credential store=] if <var ignore>sameOriginWithAncestors</var> is `false`.
 
         Note: This restriction aims to address the concern raised in [[#security-origin-confusion]].

--- a/index.bs
+++ b/index.bs
@@ -480,10 +480,10 @@ spec:css-syntax-3;
     and a boolean which is true iff the caller's [=environment settings object=] is
     [=same-origin with its ancestors=].
     It returns a {{Credential}} if one can be
-    returned given the options provided, `null` if no credential is available, or an error if
-    discovery fails (for example, incorrect options could produce a {{TypeError}}). If this
-    kind of {{Credential}} is only [=effective=] for a single use or a limited time, this
-    method is responsible for generating new [=credentials=] using a [=credential source=].
+    returned given the options provided, `null` if no credential is available, or throws an
+    error if discovery fails (for example, incorrect options could produce a {{TypeError}}).
+    If this kind of {{Credential}} is only [=effective=] for a single use or a limited time,
+    this method is responsible for generating new [=credentials=] using a [=credential source=].
 
     {{Credential}}'s default implementation of
     {{Credential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}}:
@@ -513,7 +513,7 @@ spec:css-syntax-3;
 
     * creates a {{Credential}}, or
     * does not create a credential and returns `null`, or
-    * returns an error if creation fails due to exceptional situations
+    * throws an error if creation fails due to exceptional situations
         (for example, incorrect options could produce a {{TypeError}}).
 
     When creating a {{Credential}}, it will return an algorithm that takes a [=global object=]
@@ -977,13 +977,12 @@ spec:css-syntax-3;
 
             1.  Set |result| to the result of executing |result|'s
                 {{[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}},
-                given |origin|, |options|, and |sameOriginWithAncestors|.
+                given |origin|, |options|, and |sameOriginWithAncestors|. If that threw an
+		exception, then [=reject=] |p| with that exception, and terminate these substeps.
 
-        1.  Assert: |result| is `null`, a {{Credential}}, or an [=exception=].
+        1.  Assert: |result| is `null`, or a {{Credential}}.
 
         1.  If |result| is a {{Credential}}, [=resolve=] |p| with |result|.
-
-        1.  If |result| is an [=exception=], [=reject=] |p| with |result|.
 
         1.  If |result| is `null` and |options|.{{CredentialRequestOptions/mediation}} is not
             {{CredentialMediationRequirement/conditional}}, [=resolve=] |p| with |result|.
@@ -1097,15 +1096,14 @@ spec:css-syntax-3;
 
         1.  Let |r| be the result of executing |interfaces|[0]'s
             {{Credential/[[Create]](origin, options, sameOriginWithAncestors)}} internal method on
-            |origin|, |options|, and |sameOriginWithAncestors|.
+            |origin|, |options|, and |sameOriginWithAncestors|. If that threw an exception, then
+	    [=reject=] |p| with that exception, and terminate these substeps.
 
-        2.  If |r| is an [=exception=], [=reject=] |p| with |r|, and terminate these substeps.
+        2.  If |r| is a {{Credential}} or `null`, [=resolve=] |p| with |r|, and terminate these substeps.
 
-        3.  If |r| is a {{Credential}} or `null`, [=resolve=] |p| with |r|, and terminate these substeps.
+        3.  Assert: |r| is a algorithm (as defined in [[#algorithm-create-cred]]).
 
-        4.  Assert: |r| is a algorithm (as defined in [[#algorithm-create-cred]]).
-
-        5.  [=Queue a task=] on |global|'s [=DOM manipulation task source=] to run the following substeps:
+        4.  [=Queue a task=] on |global|'s [=DOM manipulation task source=] to run the following substeps:
 
             1. [=Resolve=] |p| with the result of [=promise-calling=] |r| given |global|.
 
@@ -1458,7 +1456,7 @@ spec:css-syntax-3;
   The algorithm returns a {{PasswordCredential}} if one can be created,
   `null` otherwise. The {{CredentialCreationOptions}} dictionary must have a `password` member which
   holds either an {{HTMLFormElement}} or a {{PasswordCredentialData}}. If that member's value cannot be
-  used to create a {{PasswordCredential}}, this algorithm will return a {{TypeError}} [=exception=].
+  used to create a {{PasswordCredential}}, this algorithm will throw a {{TypeError}} [=exception=].
 
   <ol class="algorithm">
     1.  Assert: |options|["{{CredentialCreationOptions/password}}"] [=map/exists=], and
@@ -1472,7 +1470,7 @@ spec:css-syntax-3;
         the result of executing <a abstract-op>Create a `PasswordCredential` from
         `PasswordCredentialData`</a> given |options|["{{CredentialCreationOptions/password}}"].
 
-    4.  Return a {{TypeError}} [=exception=].
+    4.  Throw a {{TypeError}} [=exception=].
   </ol>
 
   <h4 algorithm id="store-passwordcredential">
@@ -1602,13 +1600,12 @@ spec:css-syntax-3;
                         on |name|.
 
     7.  Let |c| be the result of executing <a abstract-op>Create a `PasswordCredential` from
-        `PasswordCredentialData`</a> on |data|.
+        `PasswordCredentialData`</a> on |data|. If that threw an exception, re-throw that
+	exception.
      
-    8.  If |c| is an [=exception=], return |c|.
+    8.  Assert: |c| is a {{PasswordCredential}}.
 
-    9.  Assert: |c| is a {{PasswordCredential}}.
-
-    10.  Return |c|.
+    9.  Return |c|.
   </ol>
 
   <h4 algorithm id="construct-passwordcredential-data">
@@ -1621,7 +1618,7 @@ spec:css-syntax-3;
   <ol class="algorithm">
     1.  Let |c| be a new {{PasswordCredential}} object.
     
-    2.  If any of the following are the empty string, return a {{TypeError}} [=exception=]:
+    2.  If any of the following are the empty string, throw a {{TypeError}} [=exception=]:
 
         *   |data|'s {{CredentialData/id}} member's value
         *   |data|'s {{PasswordCredentialData/origin}} member's value
@@ -1713,11 +1710,10 @@ spec:css-syntax-3;
     ::  This constructor accepts a {{FederatedCredentialInit}} (|data|), and runs the following steps:
 
         1.  Let |r| be the result of executing <a abstract-op>Create a `FederatedCredential` from
-            `FederatedCredentialInit`</a> on |data|.
+            `FederatedCredentialInit`</a> on |data|. If that threw an exception, re-throw that
+	    exception.
 
-        2.  If |r| is an [=exception=], [=throw=] |r|.
-
-            Otherwise, return |r|.
+        2.  Return |r|.
   </div>
 
   {{FederatedCredential}} objects can be created by passing a {{FederatedCredentialInit}} dictionary
@@ -1812,7 +1808,7 @@ spec:css-syntax-3;
   {{CredentialCreationOptions}} (|options|), and a boolean which is `true` iff the
   calling context is [=same-origin with its ancestors=] (|sameOriginWithAncestors|).
   The algorithm returns a {{FederatedCredential}} if one can be created,
-  `null` otherwise, or an [=exception=] in exceptional circumstances:
+  `null` otherwise, or throws an [=exception=] in exceptional circumstances:
 
   <ol class="algorithm">
     1.  Assert: |options|["{{CredentialCreationOptions/federated}}"] [=map/exists=], and
@@ -1822,7 +1818,7 @@ spec:css-syntax-3;
         member's value to |origin|'s value.
 
     3.  Return the result of executing <a abstract-op>Create a `FederatedCredential` from
-        `FederatedCredentialInit`</a> given |options|["{{CredentialCreationOptions/federated}}"].
+        `FederatedCredentialInit`</a> given |options|["{{CredentialCreationOptions/federated}}"]. If that threw an exception, then re-throw that exception.
   </ol>
 
   <h4 algorithm id="store-federatedcredential">
@@ -1879,7 +1875,7 @@ spec:css-syntax-3;
   <ol class="algorithm">
     1.  Let |c| be a new {{FederatedCredential}} object.
     
-    2.  If any of the following are the empty string, return a {{TypeError}} [=exception=]:
+    2.  If any of the following are the empty string, throw a {{TypeError}} [=exception=]:
 
         *   |init|.{{CredentialData/id}}'s value
         *   |init|.{{FederatedCredentialInit/provider}}'s value

--- a/index.bs
+++ b/index.bs
@@ -978,7 +978,7 @@ spec:css-syntax-3;
             1.  Set |result| to the result of executing |result|'s
                 {{[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}},
                 given |origin|, |options|, and |sameOriginWithAncestors|. If that threw an
-                exception, then [=reject=] |p| with that exception, and terminate these substeps.
+                [=exception=], then [=reject=] |p| with that exception, and terminate these substeps.
 
         1.  Assert: |result| is `null`, or a {{Credential}}.
 
@@ -1096,7 +1096,7 @@ spec:css-syntax-3;
 
         1.  Let |r| be the result of executing |interfaces|[0]'s
             {{Credential/[[Create]](origin, options, sameOriginWithAncestors)}} internal method on
-            |origin|, |options|, and |sameOriginWithAncestors|. If that threw an exception, then
+            |origin|, |options|, and |sameOriginWithAncestors|. If that threw an [=exception=], then
             [=reject=] |p| with that exception, and terminate these substeps.
 
         2.  If |r| is a {{Credential}} or `null`, [=resolve=] |p| with |r|, and terminate these substeps.
@@ -1600,7 +1600,7 @@ spec:css-syntax-3;
                         on |name|.
 
     7.  Let |c| be the result of executing <a abstract-op>Create a `PasswordCredential` from
-        `PasswordCredentialData`</a> on |data|. If that threw an exception, re-throw that
+        `PasswordCredentialData`</a> on |data|. If that threw an [=exception=], re-throw that
         exception.
      
     8.  Assert: |c| is a {{PasswordCredential}}.
@@ -1710,7 +1710,7 @@ spec:css-syntax-3;
     ::  This constructor accepts a {{FederatedCredentialInit}} (|data|), and runs the following steps:
 
         1.  Let |r| be the result of executing <a abstract-op>Create a `FederatedCredential` from
-            `FederatedCredentialInit`</a> on |data|. If that threw an exception, re-throw that
+            `FederatedCredentialInit`</a> on |data|. If that threw an [=exception=], re-throw that
             exception.
 
         2.  Return |r|.
@@ -1818,7 +1818,8 @@ spec:css-syntax-3;
         member's value to |origin|'s value.
 
     3.  Return the result of executing <a abstract-op>Create a `FederatedCredential` from
-        `FederatedCredentialInit`</a> given |options|["{{CredentialCreationOptions/federated}}"]. If that threw an exception, then re-throw that exception.
+        `FederatedCredentialInit`</a> given |options|["{{CredentialCreationOptions/federated}}"].
+        If that threw an [=exception=], then re-throw that exception.
   </ol>
 
   <h4 algorithm id="store-federatedcredential">

--- a/index.bs
+++ b/index.bs
@@ -983,8 +983,8 @@ spec:css-syntax-3;
 
                 1. Let |e| be the thrown [=exception=].
 
-                1. [=Queue a task=] on |global|'s [=DOM manipulation task source=] to run the
-                   following substeps:
+                1. [=Queue a task=] on <var ignore>global</var>'s [=DOM manipulation task source=]
+                   to run the following substeps:
 
                     1. [=Reject=] |p| with |e|.
 
@@ -1056,8 +1056,8 @@ spec:css-syntax-3;
 
             1.  Let |e| be the thrown [=exception=].
 
-            2.  [=Queue a task=] on |global|'s [=DOM manipulation task source=] to run the
-                following substeps:
+            2.  [=Queue a task=] on <var ignore>global</var>'s [=DOM manipulation task source=] to
+                run the following substeps:
 
                 1. [=Reject=] |p| with |e|.
 

--- a/index.bs
+++ b/index.bs
@@ -977,8 +977,16 @@ spec:css-syntax-3;
 
             1.  Set |result| to the result of executing |result|'s
                 {{[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}},
-                given |origin|, |options|, and |sameOriginWithAncestors|. If that threw an
-                [=exception=], then [=reject=] |p| with that exception, and terminate these substeps.
+                given |origin|, |options|, and |sameOriginWithAncestors|.
+
+                If that threw an [=exception=]:
+
+                1. Let |e| be the thrown [=exception=].
+
+                1. [=Queue a task=] on |global|'s [=DOM manipulation task source=] to run the
+                   following substeps:
+
+                    1. [=Reject=] |p| with |e|.
 
         1.  Assert: |result| is `null`, or a {{Credential}}.
 
@@ -1010,13 +1018,11 @@ spec:css-syntax-3;
 
         1.  Let |r| be the result of executing |interface|'s
             {{Credential/[[CollectFromCredentialStore]](origin, options, sameOriginWithAncestors)}} internal method on
-            |origin|, |options|, and |sameOriginWithAncestors|.
+            |origin|, |options|, and |sameOriginWithAncestors|. If that threw an [=exception], rethrow that exception.
 
-        2.  If |r| is an [=exception=], return |r|.
+        2.  Assert: |r| is a list of [=interface objects=].
 
-        3.  Assert: |r| is a list of [=interface objects=].
-
-        4.  For each |c| in |r|:
+        3.  For each |c| in |r|:
 
             1.  <a for="set">Append</a> |c| to |possible matches|.
 
@@ -1096,12 +1102,20 @@ spec:css-syntax-3;
 
         1.  Let |r| be the result of executing |interfaces|[0]'s
             {{Credential/[[Create]](origin, options, sameOriginWithAncestors)}} internal method on
-            |origin|, |options|, and |sameOriginWithAncestors|. If that threw an [=exception=], then
-            [=reject=] |p| with that exception, and terminate these substeps.
+            |origin|, |options|, and |sameOriginWithAncestors|.
+
+            If that threw an [=exception=]:
+
+            1. Let |e| be the thrown [=exception=].
+
+            2. [=Queue a task=] on |global|'s [=DOM manipulation task source=] to run the
+               following substeps:
+
+               1. [=Reject=] |p| with |e|.
 
         2.  If |r| is a {{Credential}} or `null`, [=resolve=] |p| with |r|, and terminate these substeps.
 
-        3.  Assert: |r| is a algorithm (as defined in [[#algorithm-create-cred]]).
+        3.  Assert: |r| is an algorithm (as defined in [[#algorithm-create-cred]]).
 
         4.  [=Queue a task=] on |global|'s [=DOM manipulation task source=] to run the following substeps:
 
@@ -1427,12 +1441,12 @@ spec:css-syntax-3;
   the [=credential store=]. If no matching {{Credential}} objects are available, the returned set
   will be empty.
 
-  The algorithm will return a `NotAllowedError` if |sameOriginWithAncestors| is not `true`.
+  The algorithm will throw a `NotAllowedError` if |sameOriginWithAncestors| is not `true`.
 
   <ol class="algorithm">
     1.  Assert: |options|["{{CredentialRequestOptions/password}}"] [=map/exists=].
 
-    2.  If |sameOriginWithAncestors| is `false`, return a "{{NotAllowedError}}" {{DOMException}}.
+    2.  If |sameOriginWithAncestors| is `false`, throw a "{{NotAllowedError}}" {{DOMException}}.
 
         Note: This restriction aims to address the concern raised in [[#security-origin-confusion]].
 
@@ -1465,10 +1479,12 @@ spec:css-syntax-3;
     2.  If |options|["{{CredentialCreationOptions/password}}"] is an {{HTMLFormElement}}, return the
         result of executing <a abstract-op>Create a `PasswordCredential` from an
         `HTMLFormElement`</a> given |options|["{{CredentialCreationOptions/password}}"] and |origin|.
+        Rethrow any exceptions.
 
     3.  If |options|["{{CredentialCreationOptions/password}}"] is a {{PasswordCredentialData}}, return
         the result of executing <a abstract-op>Create a `PasswordCredential` from
         `PasswordCredentialData`</a> given |options|["{{CredentialCreationOptions/password}}"].
+        Rethrow any exceptions.
 
     4.  Throw a {{TypeError}} [=exception=].
   </ol>
@@ -1600,7 +1616,7 @@ spec:css-syntax-3;
                         on |name|.
 
     7.  Let |c| be the result of executing <a abstract-op>Create a `PasswordCredential` from
-        `PasswordCredentialData`</a> on |data|. If that threw an [=exception=], re-throw that
+        `PasswordCredentialData`</a> on |data|. If that threw an [=exception=], rethrow that
         exception.
      
     8.  Assert: |c| is a {{PasswordCredential}}.
@@ -1710,7 +1726,7 @@ spec:css-syntax-3;
     ::  This constructor accepts a {{FederatedCredentialInit}} (|data|), and runs the following steps:
 
         1.  Let |r| be the result of executing <a abstract-op>Create a `FederatedCredential` from
-            `FederatedCredentialInit`</a> on |data|. If that threw an [=exception=], re-throw that
+            `FederatedCredentialInit`</a> on |data|. If that threw an [=exception=], rethrow that
             exception.
 
         2.  Return |r|.
@@ -1782,7 +1798,7 @@ spec:css-syntax-3;
   <ol class="algorithm">
     1.  Assert: |options|["{{CredentialRequestOptions/federated}}"] [=map/exists=].
 
-    2.  If |sameOriginWithAncestors| is `false`, return a "{{NotAllowedError}}" {{DOMException}}.
+    2.  If |sameOriginWithAncestors| is `false`, throw a "{{NotAllowedError}}" {{DOMException}}.
 
         Note: This restriction aims to address the concern raised in [[#security-origin-confusion]].
 
@@ -1819,7 +1835,7 @@ spec:css-syntax-3;
 
     3.  Return the result of executing <a abstract-op>Create a `FederatedCredential` from
         `FederatedCredentialInit`</a> given |options|["{{CredentialCreationOptions/federated}}"].
-        If that threw an [=exception=], then re-throw that exception.
+        If that threw an [=exception=], then rethrow that exception.
   </ol>
 
   <h4 algorithm id="store-federatedcredential">


### PR DESCRIPTION
As a follow up to https://github.com/w3c/webauthn/pull/1706#discussion_r828811241, this PR aims to address the necessary changes on the Credential Management side to throw exceptions in all of the Credential internal methods: [`[[CollectFromCredentialStore]]`](https://w3c.github.io/webappsec-credential-management/#algorithm-collect-creds), [`[[DiscoverFromExternalSource]]`](https://w3c.github.io/webappsec-credential-management/#algorithm-discover-creds), [`[[Create]]`](https://w3c.github.io/webappsec-credential-management/#algorithm-create-cred), and [`[[Store]]`](https://w3c.github.io/webappsec-credential-management/#algorithm-store-cred). 

All of the credential types have also been updated in the places:
- Web Authentication: https://github.com/w3c/webauthn/pull/1706
- WebOTP: https://github.com/WICG/web-otp/pull/57
- Password Credentials: this PR
- Federated Credentials: this PR

@nsatragno: Would you be able to take a look at this? Thank you!

Fixes https://github.com/w3c/webappsec-credential-management/issues/197


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nidhijaju/webappsec-credential-management/pull/196.html" title="Last updated on Apr 1, 2022, 12:16 AM UTC (1441cab)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-credential-management/196/dbabb7b...nidhijaju:1441cab.html" title="Last updated on Apr 1, 2022, 12:16 AM UTC (1441cab)">Diff</a>