### PR TITLE
Remove custom anchors for FedCM

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -71,14 +71,6 @@ spec: promises-guide-1; urlPrefix: https://www.w3.org/2001/tag/doc/promises-guid
 spec: web-otp; urlPrefix: https://wicg.github.io/web-otp
   type: interface
     text: OTPCredential; url: otpcredential
-spec: FEDCM; urlPrefix: https://fedidcg.github.io/FedCM
-  type: dfn
-    text: identity-credentials-get
-  type: interface
-    text: IdentityCredential; url: identitycredential
-  type: dict-member
-    for: CredentialRequestOptions
-      text: identity; url: dom-credentialrequestoptions-identity
 </pre>
 
 <pre class="link-defaults">


### PR DESCRIPTION
These are no longer necessary, see https://github.com/w3c/webappsec-credential-management/pull/204#discussion_r961758297


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/johannhof/webappsec-credential-management/pull/208.html" title="Last updated on Sep 7, 2022, 1:01 PM UTC (ce85c6a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-credential-management/208/05f4402...johannhof:ce85c6a.html" title="Last updated on Sep 7, 2022, 1:01 PM UTC (ce85c6a)">Diff</a>