### PR TITLE
Add support for publickey-credentials-create permission policy

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1139,7 +1139,7 @@ spec:css-syntax-3;
     1.  Let |sameOriginWithAncestors| be `true` if the [=current settings object=] is [=same-origin
         with its ancestors=], and `false` otherwise.
 
-    1.  If |options|[{{CredentialCreationOptions/publicKey}}] [=map/exists=] then
+    1.  If |options|[{{CredentialCreationOptions/publicKey}}] [=map/exists=] and
         if |settings|' [=relevant global object=]'s [=associated Document=] is **not**
         [=allowed to use=] the [=publickey-credentials-create-feature|publickey-credentials-create=]
         [=policy-controlled feature=] return [=a promise rejected with=] a "{{NotAllowedError}}"

--- a/index.bs
+++ b/index.bs
@@ -1139,6 +1139,16 @@ spec:css-syntax-3;
     1.  Let |sameOriginWithAncestors| be `true` if the [=current settings object=] is [=same-origin
         with its ancestors=], and `false` otherwise.
 
+    1.  If |options|[{{CredentialCreationOptions/publicKey}}] [=map/exists=] then
+        if |settings|' [=relevant global object=]'s [=associated Document=] is **not**
+        [=allowed to use=] the [=publickey-credentials-create-feature|publickey-credentials-create=]
+        [=policy-controlled feature=] return [=a promise rejected with=] a "{{NotAllowedError}}"
+        {{DOMException}}.
+
+        Note: <a const>`password`</a> and <a const>`federated`</a>
+        [=credential type registry/credential types=] are not presently treated as
+        [=policy-controlled features=], although this may change in the future.
+
     1.  Let |interfaces| be the [=set=] of |options|' <a>relevant credential interface objects</a>.
 
     1.  Return [=a promise rejected with=] `NotSupportedError` if any of the following statements


### PR DESCRIPTION
This PR adds support for `publickey-credentials-create` permission policy,
to support https://github.com/w3c/webauthn/pull/1801

See also https://github.com/w3c/webauthn/issues/1656


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/stephenmcgruer/webappsec-credential-management/pull/209.html" title="Last updated on Feb 27, 2023, 3:51 PM UTC (305097c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-credential-management/209/976f91b...stephenmcgruer:305097c.html" title="Last updated on Feb 27, 2023, 3:51 PM UTC (305097c)">Diff</a>