### PR TITLE
Change default store algorithm to throw (#218)

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -517,7 +517,7 @@ spec:css-syntax-3;
     {{Credential}}'s default implementation of {{Credential/[[Store]](credential, sameOriginWithAncestors)}}:
 
     <ol class="algorithm">
-      1.  Return `undefined`.
+      1.  Throw a `NotSupportedError`.
     </ol>
 
   <h5 id="algorithm-create-cred" algorithm>`[[Create]]` internal method</h5>


### PR DESCRIPTION
Throw a NotSupportedError by default for store rather than return undefined.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lukewarlow/webappsec-credential-management/pull/219.html" title="Last updated on Jul 5, 2023, 5:54 PM UTC (38e5755)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-credential-management/219/c009d69...lukewarlow:38e5755.html" title="Last updated on Jul 5, 2023, 5:54 PM UTC (38e5755)">Diff</a>