### PR TITLE
Add fully active checks

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -291,8 +291,7 @@ spec:css-syntax-3;
 
     2.  Let |document| be |settings|' [=relevant global object=]'s [=associated Document=].
 
-    1.  If |document| is not [=Document/fully active=], then return [=a promise rejected with=]
-        "{{NotAllowedError}}" {{DOMException}}.
+    1.  If |document| has no [=document/browsing context=], return `false`.
 
     4.  Let |origin| be |settings|' [=environment settings object/origin=].
 

--- a/index.bs
+++ b/index.bs
@@ -291,7 +291,8 @@ spec:css-syntax-3;
 
     2.  Let |document| be |settings|' [=relevant global object=]'s [=associated Document=].
 
-    3.  If |document| has no [=document/browsing context=], return `false`.
+    1.  If |document| is not [=Document/fully active=], then return [=a promise rejected with=]
+        "{{NotAllowedError}}" {{DOMException}}.
 
     4.  Let |origin| be |settings|' [=environment settings object/origin=].
 
@@ -933,6 +934,9 @@ spec:css-syntax-3;
         then return [=a promise rejected with=]
         <code>|options|.{{CredentialRequestOptions/signal}}</code>'s [=AbortSignal/abort reason=].
 
+    1.  If |settings|'s [=relevant global object=]'s [=associated Document=] is not [=Document/fully active=],
+        then return [=a promise rejected with=] "{{NotAllowedError}}" {{DOMException}}.
+
     1.  If <code>|options|.{{CredentialRequestOptions/mediation}}</code> is
         "{{CredentialMediationRequirement/conditional}}":
 
@@ -1086,6 +1090,9 @@ spec:css-syntax-3;
 
     1.  Assert: |settings| is a [=secure context=].
 
+    1.  If |settings|'s [=relevant global object=]'s [=associated Document=] is not [=Document/fully active=],
+        then return [=a promise rejected with=] "{{NotAllowedError}}" {{DOMException}}.
+
     1.  Let |sameOriginWithAncestors| be `true` if the [=current settings object=] is [=same-origin
         with its ancestors=], and `false` otherwise.
 
@@ -1136,6 +1143,9 @@ spec:css-syntax-3;
     1.  Assert: |settings| is a [=secure context=].
 
     1.  Let |global| be |settings|' [=environment settings object/global object=].
+
+    1.  If |settings|'s [=relevant global object=]'s [=associated Document=] is not [=Document/fully active=],
+        then return [=a promise rejected with=] "{{NotAllowedError}}" {{DOMException}}.
 
     1.  Let |sameOriginWithAncestors| be `true` if the [=current settings object=] is [=same-origin
         with its ancestors=], and `false` otherwise.

--- a/index.bs
+++ b/index.bs
@@ -291,7 +291,7 @@ spec:css-syntax-3;
 
     2.  Let |document| be |settings|' [=relevant global object=]'s [=associated Document=].
 
-    1.  If |document| has no [=document/browsing context=], return `false`.
+    3.  If |document| has no [=document/browsing context=], return `false`.
 
     4.  Let |origin| be |settings|' [=environment settings object/origin=].
 


### PR DESCRIPTION
closes #227 

Adds fully active checks for `CredentialsContainer`:

- .get()
- .store()
- .create()
- .preventSilentAccess()

The following tasks have been completed:

 * [ ] [Modified Web platform tests](https://github.com/web-platform-tests/wpt/pull/46422)

Implementation commitment:

 * [x] [WebKit](https://bugs.webkit.org/show_bug.cgi?id=274444)
 * [X] Chromium https://crbug.com/341986321
 * [ ] [Gecko](https://bugzilla.mozilla.org/show_bug.cgi?id=1898145)

