### PR TITLE
Editorial: Replace "a priori authenticated URL" with "potentially trustworthy URL

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -564,8 +564,7 @@ spec:css-syntax-3;
         display in a [=credential chooser=].
     :   <dfn attribute>iconURL</dfn>
     ::  A URL pointing to an image for the credential, intended for display in a
-        [=credential chooser=]. This URL MUST be an <a><i lang="la">a priori</i> authenticated
-        URL</a>.
+        [=credential chooser=]. This URL MUST be an [=potentially trustworthy URL=].
   </div>
 
   ## `navigator.credentials` ## {#framework-credential-management}
@@ -2205,7 +2204,7 @@ spec:css-syntax-3;
 
   User agents MUST NOT expose the APIs defined here to environments which are not [=secure
   contexts=]. User agents might implement autofill mechanisms which store user credentials and fill
-  sign-in forms on non-<a><i lang="la">a priori</i> authenticated URLs</a>, but those sites cannot
+  sign-in forms on [=potentially trustworthy URL|non-potentially trustworthy URLs=], but those sites cannot
   be trusted to interact directly with the credential manager in any meaningful way, and those sites
   MUST NOT have access to credentials saved in [=secure contexts=].
 


### PR DESCRIPTION
Closes #166

cc @fred-wang


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-credential-management/pull/234.html" title="Last updated on May 22, 2024, 1:18 AM UTC (47b4cf7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-credential-management/234/123c9ea...47b4cf7.html" title="Last updated on May 22, 2024, 1:18 AM UTC (47b4cf7)">Diff</a>