### PR TITLE
Full active check should happen before AbortSignal check

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -928,12 +928,12 @@ spec:css-syntax-3;
 
     1.  Assert: |settings| is a [=secure context=].
 
+    1.  If |settings|'s [=relevant global object=]'s [=associated Document=] is not [=Document/fully active=],
+        then return [=a promise rejected with=] "{{NotAllowedError}}" {{DOMException}}.
+
     1.  If <code>|options|.{{CredentialRequestOptions/signal}}</code> is [=AbortSignal/aborted=],
         then return [=a promise rejected with=]
         <code>|options|.{{CredentialRequestOptions/signal}}</code>'s [=AbortSignal/abort reason=].
-
-    1.  If |settings|'s [=relevant global object=]'s [=associated Document=] is not [=Document/fully active=],
-        then return [=a promise rejected with=] "{{NotAllowedError}}" {{DOMException}}.
 
     1.  If <code>|options|.{{CredentialRequestOptions/mediation}}</code> is
         "{{CredentialMediationRequirement/conditional}}":


### PR DESCRIPTION
The following tasks have been completed:

 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-credential-management/pull/236.html" title="Last updated on May 23, 2024, 1:26 AM UTC (736fcda)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-credential-management/236/674c63c...736fcda.html" title="Last updated on May 23, 2024, 1:26 AM UTC (736fcda)">Diff</a>