### PR TITLE
Chore: export "origin-bound" definition

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -475,7 +475,7 @@ spec:css-syntax-3;
   [[#algorithm-request]], etc. I'm not sure I've gotten the terminology right. [=interface prototype
   object=], maybe?
 
-  Some {{Credential}} objects are <dfn for="Credential">origin bound</dfn>: these contain an
+  Some {{Credential}} objects are <dfn for="Credential" export>origin bound</dfn>: these contain an
   internal slot named <dfn for="Credential" attribute>\[[origin]]</dfn>, which stores the [=origin=]
   for which the {{Credential}} may be [=effective=].
 


### PR DESCRIPTION
Need this for Digital Credential spec, so we can say that DigitalCredential is origin-bound.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-credential-management/pull/240.html" title="Last updated on Jun 7, 2024, 7:08 AM UTC (7d95c24)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-credential-management/240/4fa577c...7d95c24.html" title="Last updated on Jun 7, 2024, 7:08 AM UTC (7d95c24)">Diff</a>