### PR TITLE
Use credential type registry for permissions + digital credentials

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1186,7 +1186,7 @@ spec:css-syntax-3;
     1.  Let |sameOriginWithAncestors| be `true` if the [=current settings object=] is [=same-origin
         with its ancestors=], and `false` otherwise.
 
-    1. Let |permission| be |options| [=credential type registry/Create Permissions Policy=].
+    1. Let |permission| be |options|'s [=credential type registry/Create Permissions Policy=].
 
     1. If |permission| is not null, and |document| is **not** [=allowed to use=]
        the |permission| [=policy-controlled feature=], return [=a promise rejected with=]

--- a/index.bs
+++ b/index.bs
@@ -397,12 +397,13 @@ spec:css-syntax-3;
   * Each registry entry must state the [=credential type registry/Appropriate Interface Object=] [=identifier=] for the
     [=credential type registry/credential type=].
 
-  * Each registry entry must state the [=credential type registry/Get Permissions Policy=] [=permission=] used when executing <a abstract-op>Request a `Credential`</a>
-    for a [=credential type registry/credential type=], or null if no [=Document/permissions policy=] is specified.
+  * Each registry entry must state the [=credential type registry/Get Permissions Policy=] [=permission=]
+     used when executing <a abstract-op>Request a `Credential`</a> for 
+     a [=credential type registry/credential type=], or null if no [=Document/permissions policy=] is specified.
 
-  * Each registry entry must state the [=credential type registry/Create Permissions Policy=] [=permission=] used when executing <a abstract-op>Create a `Credential`</a>
-    for a [=credential type registry/credential type=], or null if no [=Document/permissions policy=] is specified.
-
+  * Each registry entry must state the [=credential type registry/Create Permissions Policy=] [=permission=]
+     used when executing <a abstract-op>Create a `Credential`</a> for 
+     a [=credential type registry/credential type=], or null if no [=Document/permissions policy=] is specified.
   * Each registry entry must include a link that references a publicly available specification
     defining the [=credential type registry/credential type=] and the [=dictionary member=] [=identifier=].
 

--- a/index.bs
+++ b/index.bs
@@ -320,7 +320,8 @@ spec:css-syntax-3;
         <small>(in alphabetical order)</small></th>
         <th><dfn for="credential type registry">Options Member Identifier</dfn></th>
         <th><dfn for="credential type registry">Appropriate Interface Object</dfn></th>
-        <th><dfn for="credential type registry">Corresponding Permissions Policy</dfn></th>
+        <th><dfn for="credential type registry">Get Permissions Policy</dfn></th>
+        <th><dfn for="credential type registry">Create Permissions Policy</dfn></th>
         <th>Specification</th>
         <th>Requestor Contact</th>
       </tr>
@@ -330,6 +331,7 @@ spec:css-syntax-3;
         <td>digital</td>
         <td>{{DigitalCredential}}</td>
         <td>digital-credentials-get</td>
+        <td>null</td>
         <td>[[DIGITAL-CREDENTIALS]]</td>
         <td><a href="https://wicg.io/">WICG</a></td>
     </tr>
@@ -337,6 +339,7 @@ spec:css-syntax-3;
         <td>federated</td>
         <td>federated</td>
         <td>{{FederatedCredential}}</td>
+        <td>null</td>
         <td>null</td>
         <td>This specification: [[#federated]]</td>
         <td><a href="https://www.w3.org/2011/webappsec/">W3C</a></td>
@@ -346,6 +349,7 @@ spec:css-syntax-3;
         <td>identity</td>
         <td>{{IdentityCredential}}</td>
         <td>[=identity-credentials-get=]</td>
+        <td>null</td>
         <td>[[FEDCM]]</td>
         <td><a href="https://www.w3.org/community/fed-id/">W3C</a></td>
     </tr>
@@ -362,6 +366,7 @@ spec:css-syntax-3;
         <td>password</td>
         <td>{{PasswordCredential}}</td>
         <td>null</td>
+        <td>null</td>
         <td>This specification: [[#passwords]]</td>
         <td><a href="https://www.w3.org/2011/webappsec/">W3C</a></td>
     </tr>
@@ -370,6 +375,7 @@ spec:css-syntax-3;
         <td>publicKey</td>
         <td>{{PublicKeyCredential}}</td>
         <td>[=publickey-credentials-get-feature|publickey-credentials-get=]</td>
+        <td>[=publickey-credentials-create-feature|publickey-credentials-create=]</td>
         <td>[[WEBAUTHN]]</td>
         <td><a href="https://www.w3.org/blog/webauthn/">W3C</a></td>
     </tr>
@@ -391,8 +397,11 @@ spec:css-syntax-3;
   * Each registry entry must state the [=credential type registry/Appropriate Interface Object=] [=identifier=] for the
     [=credential type registry/credential type=].
 
-  * Each registry entry may state the [=credential type registry/Corresponding Permissions Policy=] [=permission=] for the
-    [=credential type registry/credential type=].
+  * Each registry entry may state the [=credential type registry/Get Permissions Policy=] [=permission=] used when executing <a abstract-op>Request a `Credential`</a>
+    for a [=credential type registry/credential type=].
+
+  * Each registry entry may state the [=credential type registry/Create Permissions Policy=] [=permission=] used when executing <a abstract-op>Create a `Credential`</a>
+    for a [=credential type registry/credential type=].
 
   * Each registry entry must include a link that references a publicly available specification
     defining the [=credential type registry/credential type=] and the [=dictionary member=] [=identifier=].
@@ -995,7 +1004,7 @@ spec:css-syntax-3;
     1.  Let |sameOriginWithAncestors| be `true` if |settings| is [=same-origin with its
         ancestors=], and `false` otherwise.
 
-    1. For each |permission| in |options|' [=credential type registry/Corresponding Permissions Policy=]:
+    1. For each |permission| in |options|' [=credential type registry/Get Permissions Policy=]:
 
         1. If |permission| is null, continue.
 
@@ -1169,11 +1178,19 @@ spec:css-syntax-3;
 
     1.  Let |global| be |settings|' [=environment settings object/global object=].
 
-    1.  If |settings|'s [=relevant global object=]'s [=associated Document=] is not [=Document/fully active=],
-        then return [=a promise rejected with=] "{{NotAllowedError}}" {{DOMException}}.
+    1.  Let |document| be the [=relevant global object=]'s [=associated Document=].
+
+    1.  If |document| is not [=Document/fully active=], then return
+        [=a promise rejected with=] "{{NotAllowedError}}" {{DOMException}}.
 
     1.  Let |sameOriginWithAncestors| be `true` if the [=current settings object=] is [=same-origin
         with its ancestors=], and `false` otherwise.
+
+    1. Let |permission| be |options| [=credential type registry/Create Permissions Policy=]:
+
+    1. If |permission| is not null, and |document| is **not** [=allowed to use=]
+       the |permission| [=policy-controlled feature=], return [=a promise rejected with=]
+       a "{{NotAllowedError}}" {{DOMException}}.
 
     1.  If |options|[{{CredentialCreationOptions/publicKey}}] [=map/exists=] and
         if |settings|' [=relevant global object=]'s [=associated Document=] is **not**

--- a/index.bs
+++ b/index.bs
@@ -1186,7 +1186,7 @@ spec:css-syntax-3;
     1.  Let |sameOriginWithAncestors| be `true` if the [=current settings object=] is [=same-origin
         with its ancestors=], and `false` otherwise.
 
-    1. Let |permission| be |options| [=credential type registry/Create Permissions Policy=]:
+    1. Let |permission| be |options| [=credential type registry/Create Permissions Policy=].
 
     1. If |permission| is not null, and |document| is **not** [=allowed to use=]
        the |permission| [=policy-controlled feature=], return [=a promise rejected with=]

--- a/index.bs
+++ b/index.bs
@@ -1009,11 +1009,11 @@ spec:css-syntax-3;
 
     1. For each |interface| in |options|' [=relevant credential interface objects=]:
 
-        1.  Let |permission| be the |interface|'s {{Credential/[[type]]}} [=credential type registry/Get Permissions Policy=].
+        1. Let |permission| be the |interface|'s {{Credential/[[type]]}} [=credential type registry/Get Permissions Policy=].
 
         1. If |permission| is null, continue.
 
-        1. If |document| is **not** [=allowed to use=] |permission|, return 
+        1. If |document| is **not** [=allowed to use=] |permission|, return
            [=a promise rejected with=] a "{{NotAllowedError}}" {{DOMException}}.
 
     1.  Let |p| be [=a new promise=].
@@ -1191,11 +1191,6 @@ spec:css-syntax-3;
     1.  Let |sameOriginWithAncestors| be `true` if the [=current settings object=] is [=same-origin
         with its ancestors=], and `false` otherwise.
 
-    1. Let |permission| be |options|'s [=credential type registry/Create Permissions Policy=].
-
-    1. If |permission| is not null, and |document| is **not** [=allowed to use=] |permission|,
-       return [=a promise rejected with=] a "{{NotAllowedError}}" {{DOMException}}.
-
     1.  Let |interfaces| be the [=set=] of |options|' <a>relevant credential interface objects</a>.
 
     1.  Return [=a promise rejected with=] `NotSupportedError` if any of the following statements
@@ -1209,6 +1204,15 @@ spec:css-syntax-3;
             allow the user agent to help the user choose among one of many potential credential
             types in order to support a "sign-up" use case. For the moment, though, we're punting
             on that by restricting the dictionary to a single entry.
+
+    1. For each |interface| in |interfaces|:
+
+        1. Let |permission| be the |interface|'s {{Credential/[[type]]}} [=credential type registry/Create Permissions Policy=].
+
+        1. If |permission| is null, continue.
+
+        1. If |document| is **not** [=allowed to use=] |permission|, return
+           [=a promise rejected with=] a "{{NotAllowedError}}" {{DOMException}}.
 
     1.  If <code>|options|.{{CredentialRequestOptions/signal}}</code> is [=AbortSignal/aborted=],
         then return [=a promise rejected with=]

--- a/index.bs
+++ b/index.bs
@@ -357,7 +357,7 @@ spec:css-syntax-3;
         <td>otp</td>
         <td>otp</td>
         <td>{{OTPCredential}}</td>
-        <td>otp-credentials</td>
+        <td>[=otp-credentials|otp-credentials-feature=]</td>
         <td>null</td>
         <td>[[WEB-OTP]]</td>
         <td><a href="https://wicg.io/">WICG</a></td>

--- a/index.bs
+++ b/index.bs
@@ -1192,16 +1192,6 @@ spec:css-syntax-3;
        the |permission| [=policy-controlled feature=], return [=a promise rejected with=]
        a "{{NotAllowedError}}" {{DOMException}}.
 
-    1.  If |options|[{{CredentialCreationOptions/publicKey}}] [=map/exists=] and
-        if |settings|' [=relevant global object=]'s [=associated Document=] is **not**
-        [=allowed to use=] the [=publickey-credentials-create-feature|publickey-credentials-create=]
-        [=policy-controlled feature=] return [=a promise rejected with=] a "{{NotAllowedError}}"
-        {{DOMException}}.
-
-        Note: <a const>`password`</a> and <a const>`federated`</a>
-        [=credential type registry/credential types=] are not presently treated as
-        [=policy-controlled features=], although this may change in the future.
-
     1.  Let |interfaces| be the [=set=] of |options|' <a>relevant credential interface objects</a>.
 
     1.  Return [=a promise rejected with=] `NotSupportedError` if any of the following statements

--- a/index.bs
+++ b/index.bs
@@ -358,6 +358,7 @@ spec:css-syntax-3;
         <td>otp</td>
         <td>{{OTPCredential}}</td>
         <td>otp-credentials</td>
+        <td>null</td>
         <td>[[WEB-OTP]]</td>
         <td><a href="https://wicg.io/">WICG</a></td>
     </tr>

--- a/index.bs
+++ b/index.bs
@@ -397,11 +397,11 @@ spec:css-syntax-3;
   * Each registry entry must state the [=credential type registry/Appropriate Interface Object=] [=identifier=] for the
     [=credential type registry/credential type=].
 
-  * Each registry entry may state the [=credential type registry/Get Permissions Policy=] [=permission=] used when executing <a abstract-op>Request a `Credential`</a>
-    for a [=credential type registry/credential type=].
+  * Each registry entry must state the [=credential type registry/Get Permissions Policy=] [=permission=] used when executing <a abstract-op>Request a `Credential`</a>
+    for a [=credential type registry/credential type=], or null if one is not specified.
 
-  * Each registry entry may state the [=credential type registry/Create Permissions Policy=] [=permission=] used when executing <a abstract-op>Create a `Credential`</a>
-    for a [=credential type registry/credential type=].
+  * Each registry entry must state the [=credential type registry/Create Permissions Policy=] [=permission=] used when executing <a abstract-op>Create a `Credential`</a>
+    for a [=credential type registry/credential type=], or null if one is not specified.
 
   * Each registry entry must include a link that references a publicly available specification
     defining the [=credential type registry/credential type=] and the [=dictionary member=] [=identifier=].

--- a/index.bs
+++ b/index.bs
@@ -1189,7 +1189,7 @@ spec:css-syntax-3;
     1. Let |permission| be |options|'s [=credential type registry/Create Permissions Policy=].
 
     1. If |permission| is not null, and |document| is **not** [=allowed to use=] |permission|,
-        return [=a promise rejected with=] a "{{NotAllowedError}}" {{DOMException}}.
+       return [=a promise rejected with=] a "{{NotAllowedError}}" {{DOMException}}.
 
     1.  Let |interfaces| be the [=set=] of |options|' <a>relevant credential interface objects</a>.
 

--- a/index.bs
+++ b/index.bs
@@ -1008,8 +1008,8 @@ spec:css-syntax-3;
 
         1. If |permission| is null, continue.
 
-        1. If |document| is **not** [=allowed to use=] |permission|, return [=a promise rejected with=] 
-            a "{{NotAllowedError}}" {{DOMException}}.
+        1. If |document| is **not** [=allowed to use=] |permission|, return 
+            [=a promise rejected with=] a "{{NotAllowedError}}" {{DOMException}}.
 
     1.  Let |p| be [=a new promise=].
 

--- a/index.bs
+++ b/index.bs
@@ -1007,7 +1007,9 @@ spec:css-syntax-3;
     1.  Let |sameOriginWithAncestors| be `true` if |settings| is [=same-origin with its
         ancestors=], and `false` otherwise.
 
-    1. For each |permission| in |options|' [=credential type registry/Get Permissions Policy=]:
+    1. For each |interface| in |options|' [=relevant credential interface objects=]:
+
+        1.  Let |permission| be the |interface|'s {{Credential/[[type]]}} [=credential type registry/Get Permissions Policy=].
 
         1. If |permission| is null, continue.
 

--- a/index.bs
+++ b/index.bs
@@ -398,12 +398,13 @@ spec:css-syntax-3;
     [=credential type registry/credential type=].
 
   * Each registry entry must state the [=credential type registry/Get Permissions Policy=] [=permission=]
-     used when executing <a abstract-op>Request a `Credential`</a> for 
-     a [=credential type registry/credential type=], or null if no [=Document/permissions policy=] is specified.
+    used when executing <a abstract-op>Request a `Credential`</a> for a
+    [=credential type registry/credential type=], or null if no [=Document/permissions policy=] is specified.
 
   * Each registry entry must state the [=credential type registry/Create Permissions Policy=] [=permission=]
-     used when executing <a abstract-op>Create a `Credential`</a> for 
-     a [=credential type registry/credential type=], or null if no [=Document/permissions policy=] is specified.
+    used when executing <a abstract-op>Create a `Credential`</a> for a
+    [=credential type registry/credential type=], or null if no [=Document/permissions policy=] is specified.
+
   * Each registry entry must include a link that references a publicly available specification
     defining the [=credential type registry/credential type=] and the [=dictionary member=] [=identifier=].
 

--- a/index.bs
+++ b/index.bs
@@ -1011,7 +1011,7 @@ spec:css-syntax-3;
         1. If |permission| is null, continue.
 
         1. If |document| is **not** [=allowed to use=] |permission|, return 
-            [=a promise rejected with=] a "{{NotAllowedError}}" {{DOMException}}.
+           [=a promise rejected with=] a "{{NotAllowedError}}" {{DOMException}}.
 
     1.  Let |p| be [=a new promise=].
 

--- a/index.bs
+++ b/index.bs
@@ -1008,8 +1008,8 @@ spec:css-syntax-3;
 
         1. If |permission| is null, continue.
 
-        1. If |document| is **not** [=allowed to use=] the |permission| [=policy-controlled feature=],
-           return [=a promise rejected with=] a "{{NotAllowedError}}" {{DOMException}}.
+        1. If |document| is **not** [=allowed to use=] |permission|, return [=a promise rejected with=] 
+            a "{{NotAllowedError}}" {{DOMException}}.
 
     1.  Let |p| be [=a new promise=].
 

--- a/index.bs
+++ b/index.bs
@@ -357,7 +357,7 @@ spec:css-syntax-3;
         <td>otp</td>
         <td>otp</td>
         <td>{{OTPCredential}}</td>
-        <td>[=otp-credentials|otp-credentials-feature=]</td>
+        <td>[=otp-credentials-feature|otp-credentials=]</td>
         <td>null</td>
         <td>[[WEB-OTP]]</td>
         <td><a href="https://wicg.io/">WICG</a></td>

--- a/index.bs
+++ b/index.bs
@@ -398,10 +398,10 @@ spec:css-syntax-3;
     [=credential type registry/credential type=].
 
   * Each registry entry must state the [=credential type registry/Get Permissions Policy=] [=permission=] used when executing <a abstract-op>Request a `Credential`</a>
-    for a [=credential type registry/credential type=], or null if one is not specified.
+    for a [=credential type registry/credential type=], or null if no [=Document/permissions policy=] specified.
 
   * Each registry entry must state the [=credential type registry/Create Permissions Policy=] [=permission=] used when executing <a abstract-op>Create a `Credential`</a>
-    for a [=credential type registry/credential type=], or null if one is not specified.
+    for a [=credential type registry/credential type=], or null if no [=Document/permissions policy=] specified.
 
   * Each registry entry must include a link that references a publicly available specification
     defining the [=credential type registry/credential type=] and the [=dictionary member=] [=identifier=].

--- a/index.bs
+++ b/index.bs
@@ -98,20 +98,15 @@ spec:css-syntax-3;
 </pre>
 <pre class="biblio">
 {
-  "FEDCM": {
-    "authors": [ "Sam Goto" ],
-    "href": "https://fedidcg.github.io/FedCM/",
-    "title": "FedCM API"
-  },
   "WEB-LOGIN": {
     "authors": [ "Jason Denizac", "Robin Berjon", "Anne van Kesteren" ],
     "href": "https://github.com/jden/web-login",
     "title": "web-login"
   },
-  "WEB-OTP": {
-    "authors": [ "Sam Goto" ],
-    "href": "https://wicg.github.io/web-otp/",
-    "title": "WebOTP API"
+  "DIGITAL-CREDENTIALS": {
+    "authors": [ "Marcos Cáceres", "Sam Goto" ],
+    "href": "https://wicg.github.io/digital-credentials/",
+    "title": "Digital Credentials"
   }
 }
 </pre>
@@ -325,14 +320,24 @@ spec:css-syntax-3;
         <small>(in alphabetical order)</small></th>
         <th><dfn for="credential type registry">Options Member Identifier</dfn></th>
         <th><dfn for="credential type registry">Appropriate Interface Object</dfn></th>
+        <th><dfn for="credential type registry">Corresponding Permissions Policy</dfn></th>
         <th>Specification</th>
         <th>Requestor Contact</th>
       </tr>
     </thead>
     <tr>
+        <td>digital-credential</td>
+        <td>digital</td>
+        <td>{{DigitalCredential}}</td>
+        <td>digital-credentials-get</td>
+        <td>[[DIGITAL-CREDENTIALS]]</td>
+        <td><a href="https://wicg.io/">WICG</a></td>
+    </tr>
+    <tr>
         <td>federated</td>
         <td>federated</td>
         <td>{{FederatedCredential}}</td>
+        <td>null</td>
         <td>This specification: [[#federated]]</td>
         <td><a href="https://www.w3.org/2011/webappsec/">W3C</a></td>
     </tr>
@@ -340,6 +345,7 @@ spec:css-syntax-3;
         <td>identity</td>
         <td>identity</td>
         <td>{{IdentityCredential}}</td>
+        <td>[=identity-credentials-get=]</td>
         <td>[[FEDCM]]</td>
         <td><a href="https://www.w3.org/community/fed-id/">W3C</a></td>
     </tr>
@@ -347,6 +353,7 @@ spec:css-syntax-3;
         <td>otp</td>
         <td>otp</td>
         <td>{{OTPCredential}}</td>
+        <td>otp-credentials</td>
         <td>[[WEB-OTP]]</td>
         <td><a href="https://wicg.io/">WICG</a></td>
     </tr>
@@ -354,6 +361,7 @@ spec:css-syntax-3;
         <td>password</td>
         <td>password</td>
         <td>{{PasswordCredential}}</td>
+        <td>null</td>
         <td>This specification: [[#passwords]]</td>
         <td><a href="https://www.w3.org/2011/webappsec/">W3C</a></td>
     </tr>
@@ -361,6 +369,7 @@ spec:css-syntax-3;
         <td>public-key</td>
         <td>publicKey</td>
         <td>{{PublicKeyCredential}}</td>
+        <td>[=publickey-credentials-get-feature|publickey-credentials-get=]</td>
         <td>[[WEBAUTHN]]</td>
         <td><a href="https://www.w3.org/blog/webauthn/">W3C</a></td>
     </tr>
@@ -380,6 +389,9 @@ spec:css-syntax-3;
     {{CredentialRequestOptions}}.
 
   * Each registry entry must state the [=credential type registry/Appropriate Interface Object=] [=identifier=] for the
+    [=credential type registry/credential type=].
+
+  * Each registry entry may state the [=credential type registry/Corresponding Permissions Policy=] [=permission=] for the
     [=credential type registry/credential type=].
 
   * Each registry entry must include a link that references a publicly available specification
@@ -950,8 +962,10 @@ spec:css-syntax-3;
 
     1.  Assert: |settings| is a [=secure context=].
 
-    1.  If |settings|'s [=relevant global object=]'s [=associated Document=] is not [=Document/fully active=],
-        then return [=a promise rejected with=] "{{NotAllowedError}}" {{DOMException}}.
+    1.  Let |document| be |settings|'s [=relevant global object=]'s [=associated Document=].
+
+    1.  If |document| is not [=Document/fully active=], then return [=a promise rejected with=]
+        "{{NotAllowedError}}" {{DOMException}}.
 
     1.  If <code>|options|.{{CredentialRequestOptions/signal}}</code> is [=AbortSignal/aborted=],
         then return [=a promise rejected with=]
@@ -964,8 +978,6 @@ spec:css-syntax-3;
 
             1.  If |interface| does not support {{CredentialMediationRequirement/conditional}}
                 [=user mediation=], return [=a promise rejected with=] a "{{TypeError}}" {{DOMException}}.
-
-    1.  Let |p| be [=a new promise=].
 
     1. For each |interface| in |options|' <a>relevant credential interface objects</a>:
 
@@ -983,21 +995,14 @@ spec:css-syntax-3;
     1.  Let |sameOriginWithAncestors| be `true` if |settings| is [=same-origin with its
         ancestors=], and `false` otherwise.
 
-    1.  If |options|[{{CredentialRequestOptions/identity}}] [=map/exists=] and
-        if |settings|' [=relevant global object=]'s [=associated Document=] is **not**
-        [=allowed to use=] the [=identity-credentials-get=]
-        [=policy-controlled feature=] return [=a promise rejected with=] a "{{NotAllowedError}}"
-        {{DOMException}}.
+    1. For each |permission| in |options|' [=credential type registry/Corresponding Permissions Policy=]:
 
-    1.  If |options|[{{CredentialRequestOptions/publicKey}}] [=map/exists=] and
-        if |settings|' [=relevant global object=]'s [=associated Document=] is **not**
-        [=allowed to use=] the [=publickey-credentials-get-feature|publickey-credentials-get=]
-        [=policy-controlled feature=] return [=a promise rejected with=] a "{{NotAllowedError}}"
-        {{DOMException}}.
+        1. If |permission| is null, continue.
 
-        Note: <a const>`password`</a> and <a const>`federated`</a>
-        [=credential type registry/credential types=] are not presently treated as
-        [=policy-controlled features=], although this may change in the future.
+        1. If |document| is **not** [=allowed to use=] the |permission| [=policy-controlled feature=],
+           return [=a promise rejected with=] a "{{NotAllowedError}}" {{DOMException}}.
+
+    1.  Let |p| be [=a new promise=].
 
     1.  Run the following steps [=in parallel=]:
 

--- a/index.bs
+++ b/index.bs
@@ -398,10 +398,10 @@ spec:css-syntax-3;
     [=credential type registry/credential type=].
 
   * Each registry entry must state the [=credential type registry/Get Permissions Policy=] [=permission=] used when executing <a abstract-op>Request a `Credential`</a>
-    for a [=credential type registry/credential type=], or null if no [=Document/permissions policy=] specified.
+    for a [=credential type registry/credential type=], or null if no [=Document/permissions policy=] is specified.
 
   * Each registry entry must state the [=credential type registry/Create Permissions Policy=] [=permission=] used when executing <a abstract-op>Create a `Credential`</a>
-    for a [=credential type registry/credential type=], or null if no [=Document/permissions policy=] specified.
+    for a [=credential type registry/credential type=], or null if no [=Document/permissions policy=] is specified.
 
   * Each registry entry must include a link that references a publicly available specification
     defining the [=credential type registry/credential type=] and the [=dictionary member=] [=identifier=].

--- a/index.bs
+++ b/index.bs
@@ -1188,9 +1188,8 @@ spec:css-syntax-3;
 
     1. Let |permission| be |options|'s [=credential type registry/Create Permissions Policy=].
 
-    1. If |permission| is not null, and |document| is **not** [=allowed to use=]
-       the |permission| [=policy-controlled feature=], return [=a promise rejected with=]
-       a "{{NotAllowedError}}" {{DOMException}}.
+    1. If |permission| is not null, and |document| is **not** [=allowed to use=] |permission|,
+        return [=a promise rejected with=] a "{{NotAllowedError}}" {{DOMException}}.
 
     1.  Let |interfaces| be the [=set=] of |options|' <a>relevant credential interface objects</a>.
 


### PR DESCRIPTION
Now allows registration of Permission Policy, and added Digital Credentials. 

The following tasks have been completed:

 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-credential-management/pull/242.html" title="Last updated on Jul 22, 2024, 3:27 AM UTC (a4d1981)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-credential-management/242/75bcf50...a4d1981.html" title="Last updated on Jul 22, 2024, 3:27 AM UTC (a4d1981)">Diff</a>