### PR TITLE
Use 'InvalidStateError' for fully active check

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1186,7 +1186,7 @@ spec:css-syntax-3;
     1.  Let |document| be the [=relevant global object=]'s [=associated Document=].
 
     1.  If |document| is not [=Document/fully active=], then return
-        [=a promise rejected with=] "{{InvalidState}}" {{DOMException}}.
+        [=a promise rejected with=] an "{{InvalidStateError}}" {{DOMException}}.
 
     1.  Let |sameOriginWithAncestors| be `true` if the [=current settings object=] is [=same-origin
         with its ancestors=], and `false` otherwise.

--- a/index.bs
+++ b/index.bs
@@ -951,7 +951,7 @@ spec:css-syntax-3;
     1.  Assert: |settings| is a [=secure context=].
 
     1.  If |settings|'s [=relevant global object=]'s [=associated Document=] is not [=Document/fully active=],
-        then return [=a promise rejected with=] "{{NotAllowedError}}" {{DOMException}}.
+        then return [=a promise rejected with=] "{{InvalidStateError}}" {{DOMException}}.
 
     1.  If <code>|options|.{{CredentialRequestOptions/signal}}</code> is [=AbortSignal/aborted=],
         then return [=a promise rejected with=]


### PR DESCRIPTION
In order to make errors more distinguishable, it would be good if we could use "InvalidStateError" instead for fully active checks.  

The following tasks have been completed:

 * [x] [Modified Web platform tests](https://github.com/web-platform-tests/wpt/pull/47306)

Implementation commitment:

 * [ ] [WebKit](https://bugs.webkit.org/show_bug.cgi?id=277125)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-credential-management/pull/245.html" title="Last updated on Jul 26, 2024, 7:22 AM UTC (26de7f1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-credential-management/245/7fb261a...26de7f1.html" title="Last updated on Jul 26, 2024, 7:22 AM UTC (26de7f1)">Diff</a>