### PR TITLE
Make order of checking abort signal in "create algorithm" match "request algorithm"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -569,7 +569,7 @@ spec:css-syntax-3;
     The algorithm either:
 
     * creates a {{Credential}}, or
-    * does not algorithmsedential and returns `null`, or
+    * does not create a credential and returns `null`, or
     * throws an error if creation fails due to exceptional situations
         (for example, incorrect options could produce a {{TypeError}}).
 

--- a/index.bs
+++ b/index.bs
@@ -569,7 +569,7 @@ spec:css-syntax-3;
     The algorithm either:
 
     * creates a {{Credential}}, or
-    * does not create a credential and returns `null`, or
+    * does not algorithmsedential and returns `null`, or
     * throws an error if creation fails due to exceptional situations
         (for example, incorrect options could produce a {{TypeError}}).
 
@@ -1189,6 +1189,10 @@ spec:css-syntax-3;
     1.  If |document| is not [=Document/fully active=], then return
         [=a promise rejected with=] an "{{InvalidStateError}}" {{DOMException}}.
 
+    1.  If <code>|options|.{{CredentialRequestOptions/signal}}</code> is [=AbortSignal/aborted=],
+        then return [=a promise rejected with=]
+        <code>|options|.{{CredentialRequestOptions/signal}}</code>'s [=AbortSignal/abort reason=].
+
     1.  Let |sameOriginWithAncestors| be `true` if the [=current settings object=] is [=same-origin
         with its ancestors=], and `false` otherwise.
 
@@ -1214,10 +1218,6 @@ spec:css-syntax-3;
 
         1. If |document| is **not** [=allowed to use=] |permission|, return
            [=a promise rejected with=] a "{{NotAllowedError}}" {{DOMException}}.
-
-    1.  If <code>|options|.{{CredentialRequestOptions/signal}}</code> is [=AbortSignal/aborted=],
-        then return [=a promise rejected with=]
-        <code>|options|.{{CredentialRequestOptions/signal}}</code>'s [=AbortSignal/abort reason=].
 
     1. Let |type| be |interfaces|[0]'s {{Credential/[[type]]}}.
 


### PR DESCRIPTION
Make order of checking abort signal in "create algorithm" match "request algorithm"


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/pkotwicz/webappsec-credential-management/pull/264.html" title="Last updated on Oct 8, 2024, 4:12 PM UTC (007769f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-credential-management/264/d1e655f...pkotwicz:007769f.html" title="Last updated on Oct 8, 2024, 4:12 PM UTC (007769f)">Diff</a>