### PR TITLE
Define and export 'credential manager'

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -141,7 +141,7 @@ spec:css-syntax-3;
   mechanisms (submitting credentials via {{XMLHttpRequest}} [[XMLHTTPREQUEST]], for instance) are
   difficult to reliably detect, as is the increasingly common case in which users wish to
   authenticate themselves using a federated identity provider. Allowing websites to more directly
-  interact with the user agent's credential manager would allow the credential manager to be more
+  interact with the user agent's [=credential manager=] would allow the [=credential manager=] to be more
   accurate on the one hand, and to assist users with federated sign-in on the other.
 
   These use cases are explored in more detail in [[#use-cases]] and in
@@ -153,7 +153,7 @@ spec:css-syntax-3;
 
   Note: The API defined here is intentionally small and simple: it does not intend to provide
   authentication in and of itself, but is limited to providing an interface to the existing
-  credential managers implemented by existing user agents. That functionality is valuable
+  [=credential managers=] implemented by existing user agents. That functionality is valuable
   <em>right now</em>, without significant effort on the part of either vendors or authors. There's
   certainly quite a bit more which could be done, of course. See [[#teh-futur]] for some thoughts
   we've punted for now, but which could be explored in future iterations of this API.
@@ -239,6 +239,12 @@ spec:css-syntax-3;
   sources to the user in the future.
 
   ## Infrastructure ## {#core-infrastructure}
+
+  A <dfn export>credential manager</dfn> is an application, hardware device, or service
+  that [=credential store|stores=], organizes, manages,
+  and allows [=credential chooser|choosing=] credentials.
+  Example credential managers include [=digital wallets=], password managers,
+  and [=passkey=] managers.
 
   User agents MUST internally provide a <dfn export id="concept-credential-store">credential
   store</dfn>, which is a vendor-specific, opaque storage mechanism to record which [=credentials=]
@@ -2125,7 +2131,7 @@ spec:css-syntax-3;
       `false` without [=user mediation=]. For example, the [=credential chooser=] described in
       [[#user-mediated-selection]] could have a checkbox which the user could toggle to mark a
       credential as available without mediation for the origin, or the user agent could have an
-      onboarding process for its credential manager which asked a user for a default setting.
+      onboarding process for its [=credential manager=] which asked a user for a default setting.
 
   3.  User agents MUST notify users when credentials are provided to an origin. This could take the
       form of an icon in the address bar, or some similar location.
@@ -2260,7 +2266,7 @@ spec:css-syntax-3;
   User agents MUST NOT expose the APIs defined here to environments which are not [=secure
   contexts=]. User agents might implement autofill mechanisms which store user credentials and fill
   sign-in forms on [=potentially trustworthy URL|non-potentially trustworthy URLs=], but those sites cannot
-  be trusted to interact directly with the credential manager in any meaningful way, and those sites
+  be trusted to interact directly with the [=credential manager=] in any meaningful way, and those sites
   MUST NOT have access to credentials saved in [=secure contexts=].
 
   ## Origin Confusion ## {#security-origin-confusion}
@@ -2524,8 +2530,8 @@ spec:css-syntax-3;
 
   <em>This section is non-normative.</em>
 
-  The API defined here does the bare minimum to expose user agent's credential managers to the web,
-  and allows the web to help those credential managers understand when federated identity providers
+  The API defined here does the bare minimum to expose user agent's [=credential managers=] to the web,
+  and allows the web to help those [=credential managers=] understand when federated identity providers
   are in use. The next logical step will be along the lines sketched in documents like [[WEB-LOGIN]]
   (and, to some extent, Mozilla's BrowserID [[BROWSERID]]).
 


### PR DESCRIPTION
This pull request improves the consistency and clarity of terminology related to credential management in the `index.bs` specification file. The main focus is on standardizing the use of the term "credential manager" by replacing plain text references with properly defined and linked terms, and by adding a clear definition of what a credential manager is.

Key terminology and documentation improvements:

* Standardized all references to "credential manager" and "credential managers" by replacing plain text mentions with the defined term `[=credential manager=]` throughout the specification. [[1]](diffhunk://#diff-5e793325cd2bfc452e268a4aa2f02b4024dd9584bd1db3c2595f61f1ecf7b985L144-R144) [[2]](diffhunk://#diff-5e793325cd2bfc452e268a4aa2f02b4024dd9584bd1db3c2595f61f1ecf7b985L156-R156) [[3]](diffhunk://#diff-5e793325cd2bfc452e268a4aa2f02b4024dd9584bd1db3c2595f61f1ecf7b985L2128-R2134) [[4]](diffhunk://#diff-5e793325cd2bfc452e268a4aa2f02b4024dd9584bd1db3c2595f61f1ecf7b985L2263-R2269) [[5]](diffhunk://#diff-5e793325cd2bfc452e268a4aa2f02b4024dd9584bd1db3c2595f61f1ecf7b985L2527-R2534)
* Added a formal definition for `credential manager`, clarifying that it can be an application, hardware device, or service that stores, organizes, manages, and allows choosing credentials (e.g., digital wallets, password managers, passkey managers).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-credential-management/pull/275.html" title="Last updated on Oct 14, 2025, 8:36 AM UTC (bf61714)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-credential-management/275/b8af53c...bf61714.html" title="Last updated on Oct 14, 2025, 8:36 AM UTC (bf61714)">Diff</a>