### PR TITLE
Editorial: unlink digital wallets

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -243,7 +243,7 @@ spec:css-syntax-3;
   A <dfn export>credential manager</dfn> is an application, hardware device, or service
   that [=credential store|stores=], organizes, manages,
   and allows [=credential chooser|choosing=] credentials.
-  Example credential managers include [=digital wallets=], password managers,
+  Example credential managers include digital wallets, password managers,
   and [=passkey=] managers.
 
   User agents MUST internally provide a <dfn export id="concept-credential-store">credential


### PR DESCRIPTION
Temporarily unlink "digital wallets" as https://github.com/w3c-fedid/digital-credentials/pull/386 hasn't been merged yet.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-credential-management/pull/277.html" title="Last updated on Oct 28, 2025, 4:42 AM UTC (011ae26)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-credential-management/277/ac1d176...011ae26.html" title="Last updated on Oct 28, 2025, 4:42 AM UTC (011ae26)">Diff</a>