### PR TITLE
Remove willRequestConditionalCreation method from Credential

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -436,7 +436,6 @@ spec:css-syntax-3;
       readonly attribute USVString id;
       readonly attribute DOMString type;
       static Promise&lt;boolean&gt; isConditionalMediationAvailable();
-      static Promise&lt;undefined&gt; willRequestConditionalCreation();
     };
   </pre>
   <div dfn-for="Credential">
@@ -466,20 +465,6 @@ spec:css-syntax-3;
 
         Note: If this function is not present, {{CredentialMediationRequirement/conditional}}
         mediation is not supported for the [=credential/credential type=].
-
-    :   <dfn method>willRequestConditionalCreation()</dfn>
-    ::  Returns a {{Promise}} that [=resolves=] after the user agent registers the relying party's intention
-        to create a credential using the {{CredentialMediationRequirement/conditional}} approach to
-        [[#mediation-requirements|mediation of credential creation]] for the [=credential/credential type=].
-
-        {{Credential}}'s default implementation of {{Credential/willRequestConditionalCreation()}}:
-
-        <ol class="algorithm">
-            1.  Return [=a promise resolved with=] `undefined`.
-        </ol>
-
-        Note: If this method is not present, {{CredentialMediationRequirement/conditional}}
-        mediation for credential creation is not supported for the [=credential/credential type=].
 
     :   <dfn attribute>\[[type]]</dfn>
     ::  The {{Credential}} [=interface object=] has an internal slot named `[[type]]`, which


### PR DESCRIPTION
Removed the willRequestConditionalCreation method and its documentation from the Credential interface.

Rationale for removal is that no one implements it and no one seems to have plans to implement it. 

Closes #279

(Remove the following for non-normative changes)

The following tasks have been completed:

 * [X] [Modified Web platform tests]((https://github.com/web-platform-tests/wpt/pull/58446)

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-credential-management/pull/282.html" title="Last updated on Dec 18, 2025, 8:02 AM UTC (e58abeb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-credential-management/282/037da69...e58abeb.html" title="Last updated on Dec 18, 2025, 8:02 AM UTC (e58abeb)">Diff</a>