### PR TITLE
create(): reject with NotSupportedError when no credential type is specified

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1266,7 +1266,9 @@ spec:css-syntax-3;
 
         1.  |global| does not have an [=associated Document=].
 
-        2.  |interfaces|' [=list/size=] is greater than 1.
+        2.  |interfaces|' [=list/size=] is 0.
+
+        3.  |interfaces|' [=list/size=] is greater than 1.
 
             Note: It may be reasonable at some point in the future to loosen this restriction, and
             allow the user agent to help the user choose among one of many potential credential


### PR DESCRIPTION
## Problem

When `navigator.credentials.create()` is called with no recognised credential type (no argument, or an empty/unrecognised options object), the [Create a Credential algorithm](https://www.w3.org/TR/credential-management-1/#algorithm-create) does not handle the case where `|interfaces|` is empty.

Step 8.2 rejects with `NotSupportedError` when `|interfaces|.size > 1`, but has no corresponding check for `size == 0`. Step 11 then does:

> Let |type| be |interfaces|[0]'s Credential.[[type]].

...which dereferences an empty set — undefined behaviour.

The existing [WPT tests](https://github.com/web-platform-tests/wpt/blob/master/credential-management/credentialscontainer-create-basics.https.html) have always expected `NotSupportedError` for `create()` with no argument or empty options, but the spec text doesn't explicitly support this.

## Fix

Add an explicit `|interfaces|.size == 0` condition to the `NotSupportedError` check in step 8, before the `> 1` check.

## Related

- Analogous to the empty-type check in `get()` added in #261.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-credential-management/pull/292.html" title="Last updated on Apr 7, 2026, 7:38 AM UTC (75350c3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-credential-management/292/6215107...75350c3.html" title="Last updated on Apr 7, 2026, 7:38 AM UTC (75350c3)">Diff</a>