### PR TITLE
Fix TypeError exception type in Request a Credential

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1055,13 +1055,13 @@ spec:css-syntax-3;
             {{CredentialMediationRequirement/conditional}} and |interface| does
             not support {{CredentialMediationRequirement/conditional}}
             [=user mediation=], return [=a promise rejected with=]
-            a "{{TypeError}}" {{DOMException}}.
+            a {{TypeError}}.
 
         1.  If |options|.{{CredentialRequestOptions/uiMode}} is
             {{CredentialUiMode/immediate}} and |interface| does
             not support {{CredentialUiMode/immediate}}
             [=user mediation=], return [=a promise rejected with=]
-            a "{{TypeError}}" {{DOMException}}.
+            a {{TypeError}}.
 
         1. If |settings|' [=active credential types=] [=set/contains=] |interface|'s
             {{Credential/[[type]]}}, return [=a promise rejected with=] a "{{NotAllowedError}}"


### PR DESCRIPTION
Closes #293

`TypeError` is a [simple exception](https://webidl.spec.whatwg.org/#dfn-simple-exception) (native ECMAScript TypeError), not a `DOMException` name. The Bikeshed markup `"{{TypeError}}" {{DOMException}}` incorrectly implies it's a DOMException — should be just `{{TypeError}}`.

Affects two steps in §2.5.1 "Request a Credential": the mediation conditional check and the uiMode immediate check.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-credential-management/pull/294.html" title="Last updated on Apr 10, 2026, 2:28 AM UTC (18b168a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-credential-management/294/6215107...18b168a.html" title="Last updated on Apr 10, 2026, 2:28 AM UTC (18b168a)">Diff</a>