### PR TITLE
Move [[origin]] into Credential's dfn list

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -498,15 +498,20 @@ spec:css-syntax-3;
         while the latter means that the user agent can discover credentials outside of those
         explicitly represented in the [=credential store=] via interaction with some external device
         or service.
+
+    :   <dfn for="Credential" attribute>\[[origin]]</dfn>
+    ::  The {{Credential}} [=interface object=] has an internal slot named `[[origin]]`,
+        which stores the [=origin=] for which the {{Credential}} may be [=effective=], or
+        null if the credential is not [=Credential/origin bound=]. Its value is null unless
+        otherwise specified by a subtype.
+
+        A {{Credential}} is <dfn for="Credential" export>origin bound</dfn> if its
+        {{Credential/[[origin]]}} slot is not null.
   </div>
 
   ISSUE: Talk to Tobie/Dominic about the [=interface object=] bits, here and in
   [[#algorithm-request]], etc. I'm not sure I've gotten the terminology right. [=interface prototype
   object=], maybe?
-
-  Some {{Credential}} objects are <dfn for="Credential" export>origin bound</dfn>: these contain an
-  internal slot named <dfn for="Credential" attribute>\[[origin]]</dfn>, which stores the [=origin=]
-  for which the {{Credential}} may be [=effective=].
 
   ### `Credential` Internal Methods ### {#credential-internal-methods}
   
@@ -1626,7 +1631,8 @@ spec:css-syntax-3;
     };
   </pre>
 
-  {{PasswordCredential}} objects are [=Credential/origin bound=].
+  {{PasswordCredential}} objects are [=Credential/origin bound=]: their {{Credential/[[origin]]}}
+  slot is set to the caller's [=origin=] at creation time.
 
   {{PasswordCredential}}'s [=interface object=] inherits {{Credential}}'s implementation of
   {{Credential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}}, and defines
@@ -1955,7 +1961,8 @@ spec:css-syntax-3;
     };
   </pre>
 
-  {{FederatedCredential}} objects are [=Credential/origin bound=].
+  {{FederatedCredential}} objects are [=Credential/origin bound=]: their {{Credential/[[origin]]}}
+  slot is set to the caller's [=origin=] at creation time.
 
   {{FederatedCredential}}'s [=interface object=] inherits {{Credential}}'s implementation of
   {{Credential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}},


### PR DESCRIPTION
Closes #295

## Summary

- Moves the `[[origin]]` internal slot definition from a floating prose paragraph into the formal dfn list alongside `[[type]]` and `[[discovery]]`
- Makes `[[origin]]` universally present on all `Credential` objects (default: null)
- Redefines "origin bound" as: a credential whose `[[origin]]` slot is not null
- Clarifies that `PasswordCredential` and `FederatedCredential` set `[[origin]]` to the caller's origin at creation time
- Subtypes that don't use origin-binding (e.g., `PublicKeyCredential`) leave it as null

## Rationale

The previous pattern (conditionally present slot) was unusual and didn't match how `[[type]]` and `[[discovery]]` are specified. A universal slot with a null default:

- Makes the data model uniform
- Allows generic algorithms to check `credential.[[origin]]` without first checking if the credential type is "origin bound"
- Fits the dfn list pattern already established for other `Credential` internal slots

Related: w3c-fedid/digital-credentials#508 (removing the "origin bound" declaration from `DigitalCredential`, which declared it but never used it)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-credential-management/pull/296.html" title="Last updated on May 7, 2026, 8:38 AM UTC (8ae7137)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-credential-management/296/90065ec...8ae7137.html" title="Last updated on May 7, 2026, 8:38 AM UTC (8ae7137)">Diff</a>