### PR TITLE
Add [[implicitMediation]] internal slot to Credential

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -498,6 +498,17 @@ spec:css-syntax-3;
         while the latter means that the user agent can discover credentials outside of those
         explicitly represented in the [=credential store=] via interaction with some external device
         or service.
+
+    :   <dfn for="Credential" attribute>\[[implicitMediation]]</dfn>
+    ::  The {{Credential}} [=interface object=] has an internal slot named `[[implicitMediation]]`,
+        which specifies the {{CredentialMediationRequirement}} that is always enforced for this
+        [=credential/credential type=], regardless of what the developer passes. Its value is null
+        unless otherwise specified by a subtype.
+
+        When {{Credential/[[implicitMediation]]}} is not null, the credential type behaves as if
+        the developer had passed that {{CredentialMediationRequirement}} value, and the user agent
+        MUST NOT reject based on the actual value of
+        {{CredentialRequestOptions/mediation}} for that [=credential/credential type=].
   </div>
 
   ISSUE: Talk to Tobie/Dominic about the [=interface object=] bits, here and in
@@ -1050,6 +1061,8 @@ spec:css-syntax-3;
                 then return [=a promise rejected with=] a "{{NotSupportedError}}" {{DOMException}}. 
 
     1.  [=set/For each=] |interface| of |interfaces|:
+
+        1.  If |interface|'s {{Credential/[[implicitMediation]]}} is not null, [=iteration/continue=].
 
         1.  If |options|.{{CredentialRequestOptions/mediation}} is
             {{CredentialMediationRequirement/conditional}} and |interface| does


### PR DESCRIPTION
Closes #297

## Summary

- Adds `[[implicitMediation]]` to the `Credential` dfn list (default: null)
- Modifies step 9 of "Request a Credential" to skip conditional/immediate checks when `[[implicitMediation]]` is set
- Resolves the contradiction between this spec and Digital Credentials

## The problem

Step 9 throws TypeError when `mediation: "conditional"` is passed to a type that doesn't support it. But the DC spec says "MUST NOT throw an error if the mediation member has a value other than required." DC's instruction is unreachable because the TypeError fires in *this* algorithm before DC's `[[DiscoverFromExternalSource]]` is called.

WebKit's implementation already ignores mediation for digital credentials (no TypeError), matching DC's intent but not this spec's algorithm.

## The fix

Credential types can now declare `[[implicitMediation]]` = `"required"` (or another value). When set, step 9 skips that type and does not throw. The type always behaves as if that mediation value was passed.

## Landing order

1. **This PR** (Cred Man: adds the slot and modifies step 9)
2. **w3c-fedid/digital-credentials#511** (DC: declares `[[implicitMediation]]` = "required", removes "MUST NOT throw" prose)

## Related

- w3c-fedid/digital-credentials#510 (DC issue)
- web-platform-tests/wpt#59087 (WPT test asserting the TypeError — should be updated after both PRs land)
- #295, #296 (parallel `[[origin]]` refactoring)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-credential-management/pull/298.html" title="Last updated on May 7, 2026, 8:58 AM UTC (77b997c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-credential-management/298/90065ec...77b997c.html" title="Last updated on May 7, 2026, 8:58 AM UTC (77b997c)">Diff</a>