### PR TITLE
Add digital-credentials-create permission policy

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -338,7 +338,7 @@ spec:css-syntax-3;
         <td>digital</td>
         <td>{{DigitalCredential}}</td>
         <td>digital-credentials-get</td>
-        <td>null</td>
+        <td>digital-credentials-create</td>
         <td>[=set/empty=]</td>
         <td>[[DIGITAL-CREDENTIALS]]</td>
         <td><a href="https://wicg.io/">WICG</a></td>


### PR DESCRIPTION
Document the digital-credentials-create permission policy for digital-credential, similar to digital-credentials-get.
The following tasks have been completed:

 * [x] Modified Web platform tests ([code](https://github.com/web-platform-tests/wpt/blob/master/digital-credentials/permissions-policy/create.html))

Implementation commitment:

 * [ ] WebKit 
 * [x] Chromium 
 * [ ] Gecko


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-credential-management/pull/302.html" title="Last updated on Jul 2, 2026, 9:18 AM UTC (ed610f8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-credential-management/302/90065ec...ed610f8.html" title="Last updated on Jul 2, 2026, 9:18 AM UTC (ed610f8)">Diff</a>