### PR TITLE
Update requestor contact for digital-credential

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -341,7 +341,7 @@ spec:css-syntax-3;
         <td>digital-credentials-create</td>
         <td>[=set/empty=]</td>
         <td>[[DIGITAL-CREDENTIALS]]</td>
-        <td><a href="https://wicg.io/">WICG</a></td>
+        <td><a href="https://www.w3.org/community/fed-id/">W3C</a></td>
     </tr>
     <tr>
         <td>federated</td>


### PR DESCRIPTION
Update the requestor contact for digital-credential to point to W3C FedID CG, similar to identity credential, as it is no longer in WICG.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-credential-management/pull/303.html" title="Last updated on Jul 2, 2026, 9:29 AM UTC (37abc99)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-credential-management/303/f37aeb2...37abc99.html" title="Last updated on Jul 2, 2026, 9:29 AM UTC (37abc99)">Diff</a>